### PR TITLE
feat: security autocomplete, news filtering, and infinite scroll

### DIFF
--- a/internal/news/news.go
+++ b/internal/news/news.go
@@ -12,6 +12,96 @@ import (
 	"time"
 )
 
+// SearchResult represents a security from the FMP search API.
+type SearchResult struct {
+	Symbol   string `json:"symbol"`
+	Name     string `json:"name"`
+	Currency string `json:"currency"`
+	Exchange string `json:"exchange"`
+}
+
+// SearchSymbol searches for securities by ticker and company name in parallel,
+// merging and deduplicating the results.
+func (c *Client) SearchSymbol(ctx context.Context, query string, limit int) ([]SearchResult, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+
+	type result struct {
+		items []SearchResult
+		err   error
+	}
+
+	ch := make(chan result, 2)
+
+	// Search by ticker
+	go func() {
+		items, err := c.searchEndpoint(ctx, "/stable/search-symbol", query, limit)
+		ch <- result{items, err}
+	}()
+
+	// Search by name
+	go func() {
+		items, err := c.searchEndpoint(ctx, "/stable/search-name", query, limit)
+		ch <- result{items, err}
+	}()
+
+	seen := make(map[string]bool)
+	var merged []SearchResult
+
+	for i := 0; i < 2; i++ {
+		r := <-ch
+		if r.err != nil {
+			continue
+		}
+		for _, item := range r.items {
+			if !seen[item.Symbol] {
+				seen[item.Symbol] = true
+				merged = append(merged, item)
+			}
+		}
+	}
+
+	if len(merged) > limit {
+		merged = merged[:limit]
+	}
+	return merged, nil
+}
+
+func (c *Client) searchEndpoint(ctx context.Context, endpoint, query string, limit int) ([]SearchResult, error) {
+	params := url.Values{}
+	params.Set("query", query)
+	params.Set("limit", strconv.Itoa(limit))
+	params.Set("apikey", c.apiKey)
+
+	reqURL := c.baseURL + endpoint + "?" + params.Encode()
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("search API %d: %s", resp.StatusCode, string(body))
+	}
+
+	var results []SearchResult
+	if err := json.Unmarshal(body, &results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 // Category represents a news feed type.
 type Category string
 
@@ -57,13 +147,28 @@ func (c *Client) GetNews(ctx context.Context, cat Category, symbol string, page,
 
 	switch cat {
 	case Stock:
-		endpoint = "/stable/news/stock-latest"
+		if symbol != "" {
+			endpoint = "/stable/news/stock"
+			params.Set("symbols", symbol)
+		} else {
+			endpoint = "/stable/news/stock-latest"
+		}
 		params.Set("page", strconv.Itoa(page))
 	case Crypto:
-		endpoint = "/stable/news/crypto-latest"
+		if symbol != "" {
+			endpoint = "/stable/news/crypto"
+			params.Set("symbols", symbol)
+		} else {
+			endpoint = "/stable/news/crypto-latest"
+		}
 		params.Set("page", strconv.Itoa(page))
 	case Forex:
-		endpoint = "/stable/news/forex-latest"
+		if symbol != "" {
+			endpoint = "/stable/news/forex"
+			params.Set("symbols", symbol)
+		} else {
+			endpoint = "/stable/news/forex-latest"
+		}
 		params.Set("page", strconv.Itoa(page))
 	case General:
 		endpoint = "/stable/news/general-latest"
@@ -71,7 +176,7 @@ func (c *Client) GetNews(ctx context.Context, cat Category, symbol string, page,
 	case PressReleases:
 		endpoint = "/stable/news/press-releases"
 		if symbol != "" {
-			params.Set("symbol", symbol)
+			params.Set("symbols", symbol)
 		}
 		params.Set("page", strconv.Itoa(page))
 	case Articles:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -93,7 +93,7 @@ func (s *Server) loadTemplates() error {
 	layoutPath := filepath.Join(templatesDir(), "layout.html")
 	s.pages = make(map[string]*template.Template)
 
-	pageNames := []string{"watchlist", "stock", "screener", "feed", "debug", "news"}
+	pageNames := []string{"watchlist", "stock", "security", "screener", "feed", "debug", "news"}
 	for _, page := range pageNames {
 		pagePath := filepath.Join(templatesDir(), page+".html")
 		t, err := template.ParseFiles(layoutPath, pagePath)
@@ -114,6 +114,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/health", s.handleHealth)
 	mux.HandleFunc("GET /api/symbols", s.handleSymbols)
 	mux.HandleFunc("GET /api/news/{category}", s.handleNewsAPI)
+	mux.HandleFunc("GET /api/search", s.handleSearch)
 
 	// WebSocket
 	mux.HandleFunc("GET /ws", s.handleWebSocket)
@@ -123,6 +124,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /{$}", s.handleIndex)
 	mux.HandleFunc("GET /watchlist", s.handleWatchlist)
 	mux.HandleFunc("GET /stock/{symbol}", s.handleStock)
+	mux.HandleFunc("GET /security/{symbol}", s.handleSecurity)
 	mux.HandleFunc("GET /screener", s.handleScreener)
 	mux.HandleFunc("GET /feed", s.handleFeed)
 	mux.HandleFunc("GET /news", s.handleNews)
@@ -153,6 +155,15 @@ func (s *Server) handleStock(w http.ResponseWriter, r *http.Request) {
 	s.renderPage(w, r, "stock.html", map[string]any{
 		"Title":  symbol,
 		"Active": "graph",
+		"Symbol": symbol,
+	})
+}
+
+func (s *Server) handleSecurity(w http.ResponseWriter, r *http.Request) {
+	symbol := r.PathValue("symbol")
+	s.renderPage(w, r, "security.html", map[string]any{
+		"Title":  symbol + " — Info",
+		"Active": "info",
 		"Symbol": symbol,
 	})
 }
@@ -205,6 +216,24 @@ func (s *Server) handleNewsAPI(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(items)
+}
+
+func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query().Get("q")
+	if query == "" {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]any{})
+		return
+	}
+	results, err := s.news.SearchSymbol(r.Context(), query, 10)
+	if err != nil {
+		s.logger.Error("search failed", "query", query, "error", err)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]any{})
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(results)
 }
 
 func (s *Server) handleSymbols(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -169,14 +169,14 @@ body {
     position: absolute;
     top: 100%;
     left: 0;
-    right: 0;
+    min-width: 300px;
     background: var(--bg-secondary);
     border: 1px solid var(--border);
-    border-top: none;
-    border-radius: 0 0 3px 3px;
-    max-height: 200px;
+    border-radius: 0 0 6px 6px;
+    max-height: 250px;
     overflow-y: auto;
     z-index: 100;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
 }
 
 .security-dropdown.hidden {
@@ -184,16 +184,36 @@ body {
 }
 
 .security-option {
-    padding: 4px 8px;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 6px 10px;
     cursor: pointer;
-    color: var(--text-primary);
     font-size: 12px;
 }
 
 .security-option:hover,
 .security-option.active {
     background: var(--bg-tertiary);
+}
+
+.sec-sym {
     color: var(--blue);
+    font-weight: 700;
+    min-width: 70px;
+}
+
+.sec-name {
+    color: var(--text-secondary);
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.sec-exchange {
+    color: var(--text-muted);
+    font-size: 10px;
 }
 
 /* ── Connection Status ── */
@@ -404,6 +424,12 @@ body {
     background: var(--bg-tertiary);
 }
 
+.news-tab.dimmed {
+    color: var(--text-muted);
+    opacity: 0.4;
+    cursor: default;
+}
+
 .news-cards {
     display: flex;
     flex-direction: column;
@@ -461,6 +487,13 @@ body {
     display: -webkit-box;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
+}
+
+.news-loader {
+    text-align: center;
+    padding: 12px;
+    color: var(--text-muted);
+    font-size: 12px;
 }
 
 /* ── Stock / Graph View ── */

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -12,14 +12,15 @@
     let selectedSecurity = localStorage.getItem('stocktopus-security') || '';
     const commandHistory = [];
     let historyIndex = -1;
+    let newsFilterSecurity = '';
 
     // ── Commands ──
 
     const COMMANDS = {
         watchlist:  { path: '/watchlist',       needsSecurity: false, usage: 'watchlist',           desc: 'real-time price table for tracked securities' },
         graph:      { path: '/stock/{symbol}',  needsSecurity: true,  usage: 'graph <SECURITY>',    desc: 'show stock price chart for SECURITY' },
-        info:       { path: '/stock/{symbol}',  needsSecurity: true,  usage: 'info <SECURITY>',     desc: 'deep-dive company fundamentals for SECURITY' },
-        news:       { path: '/news',            needsSecurity: false, usage: 'news',                desc: 'market news, press releases, and articles' },
+        info:       { path: '/security/{symbol}', needsSecurity: true, usage: 'info <SECURITY>',     desc: 'deep-dive company fundamentals for SECURITY' },
+        news:       { path: '/news',            needsSecurity: false, usage: 'news [SECURITY]',     desc: 'market news — optionally filter by security', optionalSecurity: true },
         screener:   { path: '/screener',        needsSecurity: false, usage: 'screener',            desc: 'filter and scan stocks by criteria' },
         debug:      { path: '/debug',           needsSecurity: false, usage: 'debug',               desc: 'live server log console' },
     };
@@ -49,6 +50,13 @@
             resolved = resolved.toUpperCase();
             path = path.replace('{symbol}', resolved);
             setSecurity(resolved);
+        }
+
+        // Handle optional security (e.g. news MSFT)
+        if (cmd.optionalSecurity && security) {
+            newsFilterSecurity = security.toUpperCase();
+        } else if (cmd.optionalSecurity) {
+            newsFilterSecurity = '';
         }
 
         try {
@@ -239,43 +247,140 @@
 
     // ── News ──
 
+    var NEWS_CATEGORIES = ['press-releases', 'articles', 'stock', 'crypto', 'forex', 'general'];
+
+    var newsCurrentCategory = '';
+    var newsCurrentPage = 0;
+    var newsLoading = false;
+    var newsExhausted = false;
+    var NEWS_PAGE_SIZE = 30;
+
     function initNews() {
         var tabs = document.getElementById('news-tabs');
         if (!tabs) return;
 
         tabs.querySelectorAll('.news-tab').forEach(function (tab) {
             tab.onclick = function () {
+                if (tab.classList.contains('dimmed')) return;
                 tabs.querySelectorAll('.news-tab').forEach(function (t) { t.classList.remove('active'); });
                 tab.classList.add('active');
                 fetchNews(tab.dataset.category);
             };
         });
 
-        // Default: load press-releases
+        // Infinite scroll
+        var container = document.getElementById('news-cards');
+        if (container) {
+            container.addEventListener('scroll', function () {
+                if (newsLoading || newsExhausted) return;
+                var threshold = container.scrollHeight - container.scrollTop - container.clientHeight;
+                if (threshold < 200) {
+                    fetchNewsNextPage();
+                }
+            });
+        }
+
+        // If filtering by security, probe all tabs for results to dim empty ones
+        if (newsFilterSecurity) {
+            probeNewsTabs();
+        }
+
+        // Default: load first tab
         fetchNews('press-releases');
     }
 
+    function probeNewsTabs() {
+        var tabs = document.getElementById('news-tabs');
+        if (!tabs) return;
+
+        NEWS_CATEGORIES.forEach(function (cat) {
+            var tab = tabs.querySelector('[data-category="' + cat + '"]');
+            if (!tab) return;
+
+            var params = 'limit=1';
+            if (newsFilterSecurity) {
+                params += '&symbol=' + encodeURIComponent(newsFilterSecurity);
+            }
+
+            fetch('/api/news/' + cat + '?' + params)
+                .then(function (r) { return r.json(); })
+                .then(function (items) {
+                    if (!items || items.length === 0) {
+                        tab.classList.add('dimmed');
+                    } else {
+                        tab.classList.remove('dimmed');
+                    }
+                })
+                .catch(function () {
+                    tab.classList.add('dimmed');
+                });
+        });
+    }
+
     function fetchNews(category) {
+        newsCurrentCategory = category;
+        newsCurrentPage = 0;
+        newsLoading = false;
+        newsExhausted = false;
+
         var container = document.getElementById('news-cards');
         if (!container) return;
         container.innerHTML = '<p class="empty-state">Loading...</p>';
 
-        var params = 'limit=30';
-        if (category === 'press-releases' && selectedSecurity) {
-            params += '&symbol=' + encodeURIComponent(selectedSecurity);
+        fetchNewsPage(category, 0, function (items) {
+            if (!items || items.length === 0) {
+                container.innerHTML = '<p class="empty-state">No news available</p>';
+                newsExhausted = true;
+                return;
+            }
+            container.innerHTML = items.map(renderNewsCard).join('');
+            if (items.length < NEWS_PAGE_SIZE) newsExhausted = true;
+        });
+    }
+
+    function fetchNewsNextPage() {
+        if (newsLoading || newsExhausted || !newsCurrentCategory) return;
+        newsCurrentPage++;
+
+        var container = document.getElementById('news-cards');
+        if (!container) return;
+
+        // Add loading indicator at bottom
+        var loader = document.createElement('div');
+        loader.className = 'news-loader';
+        loader.id = 'news-loader';
+        loader.textContent = 'Loading more...';
+        container.appendChild(loader);
+
+        fetchNewsPage(newsCurrentCategory, newsCurrentPage, function (items) {
+            var el = document.getElementById('news-loader');
+            if (el) el.remove();
+
+            if (!items || items.length === 0) {
+                newsExhausted = true;
+                return;
+            }
+            container.insertAdjacentHTML('beforeend', items.map(renderNewsCard).join(''));
+            if (items.length < NEWS_PAGE_SIZE) newsExhausted = true;
+        });
+    }
+
+    function fetchNewsPage(category, page, callback) {
+        newsLoading = true;
+        var params = 'limit=' + NEWS_PAGE_SIZE + '&page=' + page;
+        if (newsFilterSecurity) {
+            params += '&symbol=' + encodeURIComponent(newsFilterSecurity);
         }
 
         fetch('/api/news/' + category + '?' + params)
             .then(function (resp) { return resp.json(); })
             .then(function (items) {
-                if (!items || items.length === 0) {
-                    container.innerHTML = '<p class="empty-state">No news available</p>';
-                    return;
-                }
-                container.innerHTML = items.map(renderNewsCard).join('');
+                newsLoading = false;
+                callback(items);
             })
             .catch(function (err) {
-                container.innerHTML = '<p class="empty-state">Failed to load news: ' + err.message + '</p>';
+                newsLoading = false;
+                callback([]);
             });
     }
 
@@ -323,17 +428,15 @@
         if (selectedSecurity) input.value = selectedSecurity;
 
         input.addEventListener('input', function () {
-            const query = input.value.trim().toUpperCase();
+            const query = input.value.trim();
             if (!query) {
                 dropdown.classList.add('hidden');
                 return;
             }
-            // Filter from subscribed securities
-            const matches = Array.from(subscribedSecurities).filter(function (s) {
-                return s.startsWith(query);
+            searchSecurities(query, function (results) {
+                renderSecurityDropdown(results, dropdown);
+                dropdownIndex = -1;
             });
-            renderSecurityDropdown(matches, dropdown);
-            dropdownIndex = -1;
         });
 
         input.addEventListener('keydown', function (e) {
@@ -350,7 +453,7 @@
             } else if (e.key === 'Enter') {
                 e.preventDefault();
                 if (dropdownIndex >= 0 && items[dropdownIndex]) {
-                    selectSecurity(items[dropdownIndex].textContent);
+                    selectSecurity(items[dropdownIndex].dataset.symbol);
                 } else {
                     const sec = input.value.trim().toUpperCase();
                     if (sec) selectSecurity(sec);
@@ -376,20 +479,36 @@
         }
     }
 
-    function renderSecurityDropdown(items, dropdown) {
-        if (items.length === 0) {
+    var searchTimer = null;
+
+    function searchSecurities(query, callback) {
+        clearTimeout(searchTimer);
+        searchTimer = setTimeout(function () {
+            fetch('/api/search?q=' + encodeURIComponent(query))
+                .then(function (r) { return r.json(); })
+                .then(callback)
+                .catch(function () { callback([]); });
+        }, 200);
+    }
+
+    function renderSecurityDropdown(results, dropdown) {
+        if (!results || results.length === 0) {
             dropdown.classList.add('hidden');
             return;
         }
-        dropdown.innerHTML = items.map(function (s) {
-            return '<div class="security-option">' + s + '</div>';
+        dropdown.innerHTML = results.map(function (r) {
+            return '<div class="security-option" data-symbol="' + escapeHtml(r.symbol) + '">'
+                + '<span class="sec-sym">' + escapeHtml(r.symbol) + '</span>'
+                + '<span class="sec-name">' + escapeHtml(r.name) + '</span>'
+                + '<span class="sec-exchange">' + escapeHtml(r.exchange) + '</span>'
+                + '</div>';
         }).join('');
         dropdown.classList.remove('hidden');
 
         dropdown.querySelectorAll('.security-option').forEach(function (el) {
             el.onmousedown = function (e) {
                 e.preventDefault();
-                selectSecurity(el.textContent);
+                selectSecurity(el.dataset.symbol);
                 dropdown.classList.add('hidden');
             };
         });
@@ -436,15 +555,31 @@
             } else if (e.key === 'Tab' && !dropdown.classList.contains('hidden')) {
                 e.preventDefault();
                 if (cmdDropdownIndex >= 0 && items[cmdDropdownIndex]) {
-                    acceptCmdCompletion(items[cmdDropdownIndex].dataset.cmd);
+                    var item = items[cmdDropdownIndex];
+                    if (item.dataset.symbol) {
+                        input.value = item.dataset.cmd + ' ' + item.dataset.symbol;
+                    } else {
+                        acceptCmdCompletion(item.dataset.cmd);
+                    }
                 } else if (items.length === 1) {
                     acceptCmdCompletion(items[0].dataset.cmd);
                 }
             } else if (e.key === 'Enter') {
                 e.preventDefault();
-                // If dropdown is visible and an item is highlighted, complete it first
+                // If dropdown is visible and a security result is highlighted, execute it
                 if (!dropdown.classList.contains('hidden') && cmdDropdownIndex >= 0 && items[cmdDropdownIndex]) {
-                    acceptCmdCompletion(items[cmdDropdownIndex].dataset.cmd);
+                    var item = items[cmdDropdownIndex];
+                    if (item.dataset.symbol) {
+                        hideCmdDropdown();
+                        commandHistory.push(item.dataset.cmd + ' ' + item.dataset.symbol);
+                        historyIndex = commandHistory.length;
+                        input.value = '';
+                        setSecurity(item.dataset.symbol);
+                        onViewLeave(currentView);
+                        navigate(item.dataset.cmd, item.dataset.symbol);
+                        return;
+                    }
+                    acceptCmdCompletion(item.dataset.cmd);
                     return;
                 }
                 hideCmdDropdown();
@@ -456,6 +591,14 @@
                 input.value = '';
 
                 const parsed = parseCommand(raw);
+                // If command not recognized, treat input as a security and go to info
+                if (!COMMANDS[parsed.command]) {
+                    var sec = raw.toUpperCase();
+                    setSecurity(sec);
+                    onViewLeave(currentView);
+                    navigate('info', sec);
+                    return;
+                }
                 const security = parsed.args[0] || '';
                 onViewLeave(currentView);
                 navigate(parsed.command, security);
@@ -536,12 +679,66 @@
     }
 
     function filterAndShowCommands(value) {
-        var raw = value.trim().toLowerCase();
-        var cmdPart = raw.split(/\s+/)[0];
+        var raw = value.trim();
+        var parts = raw.split(/\s+/);
+        var cmdPart = parts[0].toLowerCase();
+
+        // If we have a recognized command that accepts a security and there's a space,
+        // switch to security autocomplete in the command dropdown
+        var cmd = COMMANDS[cmdPart];
+        if (parts.length >= 2 && cmd && (cmd.needsSecurity || cmd.optionalSecurity)) {
+            var secQuery = parts.slice(1).join(' ');
+            if (secQuery) {
+                searchSecurities(secQuery, function (results) {
+                    renderCmdSecurityDropdown(results, cmdPart);
+                });
+            } else {
+                hideCmdDropdown();
+            }
+            return;
+        }
+
         var matches = Object.keys(COMMANDS).filter(function (name) {
             return !cmdPart || name.startsWith(cmdPart);
         });
+
+        // If no commands match, fall back to security search
+        if (matches.length === 0 && cmdPart) {
+            searchSecurities(raw, function (results) {
+                renderCmdSecurityDropdown(results, 'info');
+            });
+            return;
+        }
+
         renderCmdDropdown(matches);
+    }
+
+    function renderCmdSecurityDropdown(results, cmdName) {
+        var dropdown = document.getElementById('cmd-dropdown');
+        if (!results || results.length === 0) {
+            hideCmdDropdown();
+            return;
+        }
+        dropdown.innerHTML = results.map(function (r) {
+            return '<div class="cmd-option cmd-security-option" data-cmd="' + cmdName + '" data-symbol="' + escapeHtml(r.symbol) + '">'
+                + '<span class="cmd-option-usage">' + escapeHtml(r.symbol) + '</span>'
+                + '<span class="cmd-option-desc">' + escapeHtml(r.name) + ' · ' + escapeHtml(r.exchange) + '</span>'
+                + '</div>';
+        }).join('');
+        dropdown.classList.remove('hidden');
+        cmdDropdownIndex = -1;
+
+        dropdown.querySelectorAll('.cmd-security-option').forEach(function (el) {
+            el.onmousedown = function (e) {
+                e.preventDefault();
+                var input = document.getElementById('cmd-input');
+                hideCmdDropdown();
+                setSecurity(el.dataset.symbol);
+                onViewLeave(currentView);
+                navigate(el.dataset.cmd, el.dataset.symbol);
+                input.value = '';
+            };
+        });
     }
 
     // ── Keyboard Shortcuts ──

--- a/internal/server/templates/security.html
+++ b/internal/server/templates/security.html
@@ -1,0 +1,9 @@
+{{template "layout" .}}
+{{define "content"}}
+<div class="page-header">
+    <h1>{{.Symbol}}</h1>
+</div>
+<div class="security-info">
+    <p class="empty-state">Security info coming soon</p>
+</div>
+{{end}}

--- a/worklog/2026-04-19-security-autocomplete.md
+++ b/worklog/2026-04-19-security-autocomplete.md
@@ -1,0 +1,33 @@
+# Worklog: 2026-04-19 -- Security Autocomplete & News Enhancements
+
+## Security Search Autocomplete
+
+### FMP search integration
+- Added `SearchSymbol()` to news client — calls both `/stable/search-symbol` and `/stable/search-name` in parallel, deduplicates results
+- New server endpoint `GET /api/search?q=QUERY` proxies to FMP search
+- 200ms debounce on all search inputs to avoid hammering the API
+
+### Security selector (top-right, `s` key)
+- Now searches FMP API instead of only filtering subscribed securities
+- Dropdown shows symbol, company name, and exchange
+
+### Command bar autocomplete
+- After typing a command that takes a security (e.g. `graph `), typing more shows security search results
+- If no commands match the input, falls back to security search — selecting a result navigates to the `info` view and sets the security selector
+- Typing e.g. "apple" or "MSFT" directly in the command bar works
+
+## Info route renamed
+- `info` command now routes to `/security/{symbol}` instead of `/stock/{symbol}`
+- New `security.html` template and `handleSecurity` handler
+- `graph` still uses `/stock/{symbol}` (chart-specific)
+
+## News filtering by security
+- `news MSFT` filters all news tabs to that security
+- Uses correct FMP endpoints: `/stable/news/stock` with `symbols=` param for filtered, `/stable/news/stock-latest` for unfiltered
+- Tabs with no results are dimmed (40% opacity, non-clickable)
+- Security autocomplete works in command bar after `news `
+
+## News infinite scroll
+- Scrolling near the bottom of the news list (within 200px) auto-fetches the next page
+- "Loading more..." indicator while fetching
+- Stops when a page returns fewer than 30 items


### PR DESCRIPTION
## Summary

- **Security search autocomplete**: FMP symbol search (both ticker and company name) with 200ms debounce in command bar and security selector. Calls `/stable/search-symbol` and `/stable/search-name` in parallel, deduplicates results. Dropdown shows symbol, company name, and exchange.
- **Command bar fallback**: Unrecognized commands (e.g. typing "apple" or "MSFT") fall back to security search — selecting a result navigates to the info view and sets the security selector.
- **Info route renamed**: `/stock/{symbol}` → `/security/{symbol}` with new `security.html` template. Graph command keeps `/stock/` path.
- **News filtering**: `news MSFT` filters all tabs to that security using correct per-category FMP endpoints (`/stable/news/stock` with `symbols=` param). Tabs with no results are dimmed.
- **Infinite scroll**: News list auto-fetches the next page when scrolling near the bottom, with loading indicator. Stops when results are exhausted.

## Test plan
- [ ] Type `AAPL` or `apple` in command bar — shows security search results, selecting one goes to info view
- [ ] Type `graph ` then `MS` — shows security autocomplete, selecting one navigates to graph
- [ ] Press `s` to activate security selector, type `GOO` — shows search results from FMP
- [ ] Type `news MSFT` — press releases and stock tabs show Microsoft news, crypto/forex tabs are dimmed
- [ ] Type `news` — shows unfiltered news across all tabs
- [ ] Scroll to bottom of news list — next page loads automatically
- [ ] Type `info AAPL` — navigates to `/security/AAPL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)