### PR TITLE
feat: news polling via hub with read/unread state

### DIFF
--- a/cmd/stocktopus/main.go
+++ b/cmd/stocktopus/main.go
@@ -10,6 +10,7 @@ import (
 
 	"stocktopus/internal/hub"
 	"stocktopus/internal/news"
+	"stocktopus/internal/newspoller"
 	"stocktopus/internal/poller"
 	"stocktopus/internal/provider"
 	"stocktopus/internal/provider/alphavantage"
@@ -59,14 +60,28 @@ func main() {
 	interval := 15 * time.Second
 	poll := poller.New(p, h, interval, logger)
 
+	// News client + news poller
+	newsClient := news.New(apiKey, "https://financialmodelingprep.com")
+
+	newsPollInterval := 2 * time.Minute
+	if envInterval := os.Getenv("NEWS_POLL_INTERVAL"); envInterval != "" {
+		if d, err := time.ParseDuration(envInterval); err == nil {
+			newsPollInterval = d
+		}
+	}
+	np := newspoller.New(newsClient, h, newsPollInterval, logger)
+
+	// Composite subscription handler
+	composite := hub.NewCompositeHandler()
+	composite.Register("quote:", poll)
+	composite.Register("news:", np)
+	h.SetSubscriptionHandler(composite)
+
 	appCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
 	go poll.Run(appCtx)
-
-	// Server
-	// News client
-	newsClient := news.New(apiKey, "https://financialmodelingprep.com")
+	go np.Run(appCtx)
 
 	srv, err := server.New(server.Config{Port: 8080, Host: "localhost"}, h, debug, poll, newsClient, logger)
 	if err != nil {

--- a/internal/hub/composite.go
+++ b/internal/hub/composite.go
@@ -1,0 +1,42 @@
+package hub
+
+import "strings"
+
+// CompositeHandler routes subscription events to the appropriate handler
+// based on topic prefix. This allows multiple pollers (quotes, news, etc.)
+// to share a single hub.
+type CompositeHandler struct {
+	handlers []prefixHandler
+}
+
+type prefixHandler struct {
+	prefix  string
+	handler SubscriptionHandler
+}
+
+func NewCompositeHandler() *CompositeHandler {
+	return &CompositeHandler{}
+}
+
+// Register adds a handler for topics matching the given prefix.
+func (c *CompositeHandler) Register(prefix string, h SubscriptionHandler) {
+	c.handlers = append(c.handlers, prefixHandler{prefix: prefix, handler: h})
+}
+
+func (c *CompositeHandler) OnFirstSubscribe(topic string) {
+	for _, ph := range c.handlers {
+		if strings.HasPrefix(topic, ph.prefix) {
+			ph.handler.OnFirstSubscribe(topic)
+			return
+		}
+	}
+}
+
+func (c *CompositeHandler) OnLastUnsubscribe(topic string) {
+	for _, ph := range c.handlers {
+		if strings.HasPrefix(topic, ph.prefix) {
+			ph.handler.OnLastUnsubscribe(topic)
+			return
+		}
+	}
+}

--- a/internal/newspoller/newspoller.go
+++ b/internal/newspoller/newspoller.go
@@ -1,0 +1,154 @@
+package newspoller
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"stocktopus/internal/hub"
+	"stocktopus/internal/model"
+	"stocktopus/internal/news"
+)
+
+// Poller periodically fetches news for subscribed categories and publishes
+// new articles to the hub. All connected clients receive updates simultaneously.
+type Poller struct {
+	client   *news.Client
+	hub      *hub.Hub
+	logger   *slog.Logger
+	interval time.Duration
+
+	categories map[news.Category]bool
+	lastSeen   map[news.Category]map[string]bool // category → set of seen URLs
+	mu         sync.RWMutex
+}
+
+func New(client *news.Client, h *hub.Hub, interval time.Duration, logger *slog.Logger) *Poller {
+	return &Poller{
+		client:     client,
+		hub:        h,
+		logger:     logger.With("component", "newspoller"),
+		interval:   interval,
+		categories: make(map[news.Category]bool),
+		lastSeen:   make(map[news.Category]map[string]bool),
+	}
+}
+
+// OnFirstSubscribe is called when a client subscribes to a news topic (e.g. "news:stock").
+func (p *Poller) OnFirstSubscribe(topic string) {
+	cat := topicToCategory(topic)
+	if cat == "" {
+		return
+	}
+
+	p.mu.Lock()
+	p.categories[cat] = true
+	if p.lastSeen[cat] == nil {
+		p.lastSeen[cat] = make(map[string]bool)
+	}
+	p.mu.Unlock()
+
+	p.logger.Info("watching news category", "category", cat)
+
+	// Fetch immediately for the new subscriber
+	go p.pollCategory(context.Background(), cat)
+}
+
+// OnLastUnsubscribe is called when the last client unsubscribes from a news topic.
+func (p *Poller) OnLastUnsubscribe(topic string) {
+	cat := topicToCategory(topic)
+	if cat == "" {
+		return
+	}
+
+	p.mu.Lock()
+	delete(p.categories, cat)
+	p.mu.Unlock()
+
+	p.logger.Info("unwatching news category", "category", cat)
+}
+
+// Run starts the polling loop.
+func (p *Poller) Run(ctx context.Context) {
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	p.logger.Info("news poller started", "interval", p.interval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Info("news poller stopped")
+			return
+		case <-ticker.C:
+			p.pollAll(ctx)
+		}
+	}
+}
+
+func (p *Poller) pollAll(ctx context.Context) {
+	p.mu.RLock()
+	cats := make([]news.Category, 0, len(p.categories))
+	for cat := range p.categories {
+		cats = append(cats, cat)
+	}
+	p.mu.RUnlock()
+
+	for _, cat := range cats {
+		p.pollCategory(ctx, cat)
+	}
+}
+
+func (p *Poller) pollCategory(ctx context.Context, cat news.Category) {
+	items, err := p.client.GetNews(ctx, cat, "", 0, 20)
+	if err != nil {
+		p.logger.Error("news poll failed", "category", cat, "error", err)
+		return
+	}
+
+	p.mu.Lock()
+	seen := p.lastSeen[cat]
+	if seen == nil {
+		seen = make(map[string]bool)
+		p.lastSeen[cat] = seen
+	}
+
+	var newItems []model.NewsItem
+	for _, item := range items {
+		if !seen[item.URL] {
+			seen[item.URL] = true
+			newItems = append(newItems, item)
+		}
+	}
+	p.mu.Unlock()
+
+	if len(newItems) == 0 {
+		return
+	}
+
+	p.logger.Debug("new articles", "category", cat, "count", len(newItems))
+
+	msg := hub.OutboundMessage{
+		Type:  "news_update",
+		Topic: "news:" + string(cat),
+	}
+	payload, _ := json.Marshal(newItems)
+	msg.Payload = payload
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		p.logger.Error("failed to marshal news update", "error", err)
+		return
+	}
+	p.hub.Publish("news:"+string(cat), data)
+}
+
+func topicToCategory(topic string) news.Category {
+	if strings.HasPrefix(topic, "news:") {
+		return news.Category(strings.TrimPrefix(topic, "news:"))
+	}
+	return ""
+}

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -39,7 +39,6 @@ func New(p provider.StockProvider, h *hub.Hub, interval time.Duration, logger *s
 		symbols:  make(map[string]int),
 	}
 
-	h.SetSubscriptionHandler(poller)
 	return poller
 }
 

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -474,15 +474,28 @@ body {
 .news-card {
     background: var(--bg-secondary);
     border: 1px solid var(--border);
+    border-left: 3px solid transparent;
     border-radius: 4px;
     padding: 12px 14px;
     display: flex;
     flex-direction: column;
     gap: 6px;
+    opacity: 0.6;
 }
 
 .news-card:hover {
     border-color: var(--text-muted);
+    border-left-color: var(--text-muted);
+    opacity: 0.8;
+}
+
+.news-card.news-unread {
+    border-left-color: var(--orange);
+    opacity: 1;
+}
+
+.news-card.news-unread .news-card-title a {
+    color: var(--orange);
 }
 
 .news-card-title {
@@ -520,6 +533,26 @@ body {
     display: -webkit-box;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
+}
+
+.spinner {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border: 2px solid var(--border);
+    border-top-color: var(--orange);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+    vertical-align: middle;
+    margin-left: 6px;
+}
+
+.spinner.hidden {
+    display: none;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
 }
 
 .news-loader {

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -13,6 +13,9 @@
     const commandHistory = [];
     let historyIndex = -1;
     let newsFilterSecurity = '';
+    var newsCurrentTopic = '';
+    var newsSeenURLs = new Set();
+    var newsReadURLs = new Set();
 
     // ── Commands ──
 
@@ -121,6 +124,9 @@
             debugWs.close();
             debugWs = null;
         }
+        if (view === 'news') {
+            unsubscribeNewsTopic();
+        }
     }
 
     // ── WebSocket Manager (quotes) ──
@@ -134,6 +140,10 @@
             subscribedSecurities.forEach(function (sym) {
                 ws.send(JSON.stringify({ type: 'subscribe', topic: 'quote:' + sym }));
             });
+            // Resubscribe to active news topic
+            if (newsCurrentTopic) {
+                ws.send(JSON.stringify({ type: 'subscribe', topic: newsCurrentTopic }));
+            }
         };
 
         ws.onclose = function () {
@@ -147,6 +157,8 @@
             const msg = JSON.parse(event.data);
             if (msg.type === 'html' && msg.html) {
                 handleQuoteHTML(msg.html);
+            } else if (msg.type === 'news_update' && msg.payload) {
+                handleNewsUpdate(msg.topic, msg.payload);
             }
         };
     }
@@ -307,6 +319,46 @@
         fetchNews('press-releases');
     }
 
+    function subscribeNewsTopic(category) {
+        // Unsubscribe previous
+        if (newsCurrentTopic && ws && ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ type: 'unsubscribe', topic: newsCurrentTopic }));
+        }
+        newsCurrentTopic = 'news:' + category;
+        if (ws && ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ type: 'subscribe', topic: newsCurrentTopic }));
+        }
+    }
+
+    function unsubscribeNewsTopic() {
+        if (newsCurrentTopic && ws && ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ type: 'unsubscribe', topic: newsCurrentTopic }));
+        }
+        newsCurrentTopic = '';
+    }
+
+    function handleNewsUpdate(topic, items) {
+        if (currentView !== 'news') return;
+        // Only handle updates for the active tab
+        var expectedTopic = 'news:' + newsCurrentCategory;
+        if (topic !== expectedTopic) return;
+
+        var container = document.getElementById('news-cards');
+        if (!container) return;
+
+        var newCards = [];
+        for (var i = items.length - 1; i >= 0; i--) {
+            var item = items[i];
+            if (newsSeenURLs.has(item.url)) continue;
+            newsSeenURLs.add(item.url);
+            newCards.push(renderNewsCard(item));
+        }
+
+        if (newCards.length > 0) {
+            container.insertAdjacentHTML('afterbegin', newCards.join(''));
+        }
+    }
+
     function probeNewsTabs() {
         var tabs = document.getElementById('news-tabs');
         if (!tabs) return;
@@ -341,6 +393,9 @@
         newsLoading = false;
         newsExhausted = false;
 
+        // Subscribe to live updates for this category
+        subscribeNewsTopic(category);
+
         var container = document.getElementById('news-cards');
         if (!container) return;
         container.innerHTML = '<p class="empty-state">Loading...</p>';
@@ -351,7 +406,8 @@
                 newsExhausted = true;
                 return;
             }
-            container.innerHTML = items.map(renderNewsCard).join('');
+            items.forEach(function (item) { newsSeenURLs.add(item.url); });
+            container.innerHTML = items.map(function (item) { return renderNewsCard(item); }).join('');
             if (items.length < NEWS_PAGE_SIZE) newsExhausted = true;
         });
     }
@@ -378,13 +434,26 @@
                 newsExhausted = true;
                 return;
             }
-            container.insertAdjacentHTML('beforeend', items.map(renderNewsCard).join(''));
+            items.forEach(function (item) { newsSeenURLs.add(item.url); });
+            container.insertAdjacentHTML('beforeend', items.map(function (item) { return renderNewsCard(item); }).join(''));
             if (items.length < NEWS_PAGE_SIZE) newsExhausted = true;
         });
     }
 
+    function markNewsRead(card) {
+        card.classList.remove('news-unread');
+        var url = card.dataset.url;
+        if (url) newsReadURLs.add(url);
+    }
+
+    function showNewsSpinner(show) {
+        var el = document.getElementById('news-spinner');
+        if (el) el.classList.toggle('hidden', !show);
+    }
+
     function fetchNewsPage(category, page, callback) {
         newsLoading = true;
+        showNewsSpinner(true);
         var params = 'limit=' + NEWS_PAGE_SIZE + '&page=' + page;
         if (newsFilterSecurity) {
             params += '&symbol=' + encodeURIComponent(newsFilterSecurity);
@@ -394,15 +463,18 @@
             .then(function (resp) { return resp.json(); })
             .then(function (items) {
                 newsLoading = false;
+                showNewsSpinner(false);
                 callback(items);
             })
             .catch(function (err) {
                 newsLoading = false;
+                showNewsSpinner(false);
                 callback([]);
             });
     }
 
     function renderNewsCard(item) {
+        var unread = !newsReadURLs.has(item.url);
         var date = item.date ? new Date(item.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit' }) : '';
         var text = item.text || '';
         // Strip HTML tags for articles that contain HTML content
@@ -412,8 +484,9 @@
         if (plainText.length > 300) plainText = plainText.substring(0, 300) + '...';
 
         var symbolBadge = item.symbol ? '<span class="news-symbol">' + escapeHtml(item.symbol) + '</span>' : '';
+        var unreadClass = unread ? ' news-unread' : '';
 
-        return '<div class="news-card">'
+        return '<div class="news-card' + unreadClass + '" data-url="' + escapeHtml(item.url) + '">'
             + '<div class="news-card-title"><a href="' + escapeHtml(item.url) + '" target="_blank" rel="noopener">' + escapeHtml(item.title) + '</a></div>'
             + '<div class="news-card-meta">'
             +   symbolBadge
@@ -896,7 +969,9 @@
             activate: function () {
                 var items = this.getItems();
                 if (vimSelectedIndex < 0 || vimSelectedIndex >= items.length) return;
-                var link = items[vimSelectedIndex].querySelector('.news-card-title a');
+                var card = items[vimSelectedIndex];
+                markNewsRead(card);
+                var link = card.querySelector('.news-card-title a');
                 if (link) window.open(link.href, '_blank', 'noopener');
             }
         },

--- a/internal/server/templates/news.html
+++ b/internal/server/templates/news.html
@@ -1,7 +1,7 @@
 {{template "layout" .}}
 {{define "content"}}
 <div class="page-header">
-    <h1>News</h1>
+    <h1>News <span id="news-spinner" class="spinner hidden"></span></h1>
 </div>
 <div class="news-tabs" id="news-tabs">
     <button class="news-tab active" data-category="press-releases"><span class="tab-key">1</span> Press Releases</button>

--- a/tests/e2e/smoke_test.go
+++ b/tests/e2e/smoke_test.go
@@ -18,6 +18,7 @@ import (
 
 	"stocktopus/internal/hub"
 	"stocktopus/internal/news"
+	"stocktopus/internal/newspoller"
 	"stocktopus/internal/poller"
 	"stocktopus/internal/provider/financialmodelingprep"
 	"stocktopus/internal/server"
@@ -49,10 +50,19 @@ func TestMain(m *testing.M) {
 
 	// Poller with long interval to avoid rate-limiting during tests
 	poll := poller.New(prov, h, 5*time.Minute, logger)
-	go poll.Run(context.Background())
 
-	// News client
+	// News client + news poller (short interval for tests)
 	newsClient := news.New(apiKey, "https://financialmodelingprep.com")
+	np := newspoller.New(newsClient, h, 3*time.Second, logger)
+
+	// Composite subscription handler
+	composite := hub.NewCompositeHandler()
+	composite.Register("quote:", poll)
+	composite.Register("news:", np)
+	h.SetSubscriptionHandler(composite)
+
+	go poll.Run(context.Background())
+	go np.Run(context.Background())
 
 	// Debug broadcaster
 	debug := server.NewDebugBroadcaster()
@@ -238,6 +248,40 @@ func TestSmoke_WebSocketConnect(t *testing.T) {
 		t.Fatalf("WebSocket dial failed: %v", err)
 	}
 	conn.Close(websocket.StatusNormalClosure, "")
+}
+
+func TestSmoke_NewsWebSocketSubscribe(t *testing.T) {
+	wsURL := strings.Replace(testServer.URL, "http://", "ws://", 1) + "/ws"
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("WebSocket dial failed: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	// Subscribe to stock news
+	msg := `{"type":"subscribe","topic":"news:stock"}`
+	err = conn.Write(ctx, websocket.MessageText, []byte(msg))
+	if err != nil {
+		t.Fatalf("WebSocket write failed: %v", err)
+	}
+
+	// Wait for a news update (poller fetches immediately on subscribe)
+	// Accept no message if there are no new articles — just verify no error
+	_, data, err := conn.Read(ctx)
+	if err != nil {
+		// Timeout is acceptable — no new news is fine
+		t.Logf("no news received (this is OK if no new articles): %v", err)
+		return
+	}
+
+	var update map[string]interface{}
+	json.Unmarshal(data, &update)
+	if update["type"] != "news_update" {
+		t.Errorf("expected news_update message type, got %v", update["type"])
+	}
 }
 
 func TestSmoke_WebSocketSubscribe(t *testing.T) {


### PR DESCRIPTION
## Summary

- **CompositeHandler** (`internal/hub/composite.go`) — routes subscription events by topic prefix (`quote:` → quote poller, `news:` → news poller), enabling multiple pollers on a single hub
- **NewsPoller** (`internal/newspoller/newspoller.go`) — polls active news categories every 2 minutes (configurable via `NEWS_POLL_INTERVAL` env var), publishes new articles to all connected clients simultaneously via WebSocket
- **Read/unread state** — unread cards show orange title + left accent at full opacity; read cards dim to 60%. State persists across tab switches via `newsReadURLs` Set
- **Loading spinner** — orange spinning indicator next to "News" heading during fetches
- **Immediate fetch** on first subscribe — no waiting for the poll interval

## New files
- `internal/hub/composite.go` — CompositeHandler
- `internal/newspoller/newspoller.go` — News polling loop

## Test plan
- [ ] `make smoke` — all 13 tests pass including `TestSmoke_NewsWebSocketSubscribe`
- [ ] Open two browser tabs, navigate to news — both receive updates simultaneously
- [ ] Press Enter on a card — opens link, card dims (marked read)
- [ ] Switch tabs and back — read state persists
- [ ] Spinner shows during loading, hides when done
- [ ] `NEWS_POLL_INTERVAL=10s make dev` — updates arrive every 10 seconds