### PR TITLE
feat: security info deep dive

### DIFF
--- a/internal/news/news.go
+++ b/internal/news/news.go
@@ -149,6 +149,79 @@ func (c *Client) GetHistoricalEOD(ctx context.Context, symbol, from, to string) 
 	return items, nil
 }
 
+// fetchJSON is a generic helper that fetches a URL and returns raw JSON bytes.
+func (c *Client) fetchJSON(ctx context.Context, endpoint string, params url.Values) (json.RawMessage, error) {
+	if params == nil {
+		params = url.Values{}
+	}
+	params.Set("apikey", c.apiKey)
+
+	reqURL := c.baseURL + endpoint + "?" + params.Encode()
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API %d: %s", resp.StatusCode, string(body))
+	}
+
+	return json.RawMessage(body), nil
+}
+
+// GetProfile returns the company profile for a symbol.
+func (c *Client) GetProfile(ctx context.Context, symbol string) (json.RawMessage, error) {
+	params := url.Values{"symbol": {symbol}}
+	return c.fetchJSON(ctx, "/stable/profile", params)
+}
+
+// GetKeyMetrics returns key financial metrics.
+func (c *Client) GetKeyMetrics(ctx context.Context, symbol string) (json.RawMessage, error) {
+	params := url.Values{"symbol": {symbol}, "limit": {"1"}}
+	return c.fetchJSON(ctx, "/stable/key-metrics", params)
+}
+
+// GetRatiosTTM returns trailing twelve month ratios.
+func (c *Client) GetRatiosTTM(ctx context.Context, symbol string) (json.RawMessage, error) {
+	params := url.Values{"symbol": {symbol}}
+	return c.fetchJSON(ctx, "/stable/ratios-ttm", params)
+}
+
+// GetIncomeStatement returns annual income statements.
+func (c *Client) GetIncomeStatement(ctx context.Context, symbol string, limit int) (json.RawMessage, error) {
+	params := url.Values{"symbol": {symbol}, "period": {"annual"}, "limit": {strconv.Itoa(limit)}}
+	return c.fetchJSON(ctx, "/stable/income-statement", params)
+}
+
+// GetBalanceSheet returns annual balance sheets.
+func (c *Client) GetBalanceSheet(ctx context.Context, symbol string, limit int) (json.RawMessage, error) {
+	params := url.Values{"symbol": {symbol}, "period": {"annual"}, "limit": {strconv.Itoa(limit)}}
+	return c.fetchJSON(ctx, "/stable/balance-sheet-statement", params)
+}
+
+// GetCashFlow returns annual cash flow statements.
+func (c *Client) GetCashFlow(ctx context.Context, symbol string, limit int) (json.RawMessage, error) {
+	params := url.Values{"symbol": {symbol}, "period": {"annual"}, "limit": {strconv.Itoa(limit)}}
+	return c.fetchJSON(ctx, "/stable/cash-flow-statement", params)
+}
+
+// GetAnalystEstimates returns forward analyst estimates.
+func (c *Client) GetAnalystEstimates(ctx context.Context, symbol string, limit int) (json.RawMessage, error) {
+	params := url.Values{"symbol": {symbol}, "period": {"annual"}, "limit": {strconv.Itoa(limit)}}
+	return c.fetchJSON(ctx, "/stable/analyst-estimates", params)
+}
+
 // Category represents a news feed type.
 type Category string
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -121,6 +121,10 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/news/{category}", s.handleNewsAPI)
 	mux.HandleFunc("GET /api/search", s.handleSearch)
 	mux.HandleFunc("GET /api/chart/eod/{symbol}", s.handleChartEOD)
+	mux.HandleFunc("GET /api/security/{symbol}/profile", s.handleSecurityProfile)
+	mux.HandleFunc("GET /api/security/{symbol}/metrics", s.handleSecurityMetrics)
+	mux.HandleFunc("GET /api/security/{symbol}/financials", s.handleSecurityFinancials)
+	mux.HandleFunc("GET /api/security/{symbol}/estimates", s.handleSecurityEstimates)
 
 	// WebSocket
 	mux.HandleFunc("GET /ws", s.handleWebSocket)
@@ -222,6 +226,79 @@ func (s *Server) handleNewsAPI(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(items)
+}
+
+func (s *Server) handleSecurityProfile(w http.ResponseWriter, r *http.Request) {
+	s.proxyFMP(w, r, func(sym string) (json.RawMessage, error) {
+		return s.news.GetProfile(r.Context(), sym)
+	})
+}
+
+func (s *Server) handleSecurityMetrics(w http.ResponseWriter, r *http.Request) {
+	symbol := r.PathValue("symbol")
+	metrics, err1 := s.news.GetKeyMetrics(r.Context(), symbol)
+	ratios, err2 := s.news.GetRatiosTTM(r.Context(), symbol)
+
+	result := map[string]json.RawMessage{}
+	if err1 == nil {
+		result["metrics"] = metrics
+	}
+	if err2 == nil {
+		result["ratios"] = ratios
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+func (s *Server) handleSecurityFinancials(w http.ResponseWriter, r *http.Request) {
+	symbol := r.PathValue("symbol")
+	typ := r.URL.Query().Get("type")
+	limit := 4
+
+	var data json.RawMessage
+	var err error
+	switch typ {
+	case "income":
+		data, err = s.news.GetIncomeStatement(r.Context(), symbol, limit)
+	case "balance":
+		data, err = s.news.GetBalanceSheet(r.Context(), symbol, limit)
+	case "cashflow":
+		data, err = s.news.GetCashFlow(r.Context(), symbol, limit)
+	default:
+		data, err = s.news.GetIncomeStatement(r.Context(), symbol, limit)
+	}
+
+	if err != nil {
+		s.logger.Error("financials fetch failed", "symbol", symbol, "type", typ, "error", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(data)
+}
+
+func (s *Server) handleSecurityEstimates(w http.ResponseWriter, r *http.Request) {
+	s.proxyFMP(w, r, func(sym string) (json.RawMessage, error) {
+		return s.news.GetAnalystEstimates(r.Context(), sym, 5)
+	})
+}
+
+// proxyFMP is a helper for simple pass-through FMP API handlers.
+func (s *Server) proxyFMP(w http.ResponseWriter, r *http.Request, fetch func(string) (json.RawMessage, error)) {
+	symbol := r.PathValue("symbol")
+	data, err := fetch(symbol)
+	if err != nil {
+		s.logger.Error("fmp proxy failed", "symbol", symbol, "error", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(data)
 }
 
 func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -1,0 +1,511 @@
+// Stocktopus Info — Security deep dive
+
+(function () {
+    'use strict';
+
+    var container = document.getElementById('info-content');
+    if (!container) return;
+
+    var symbol = container.dataset.symbol;
+    if (!symbol) return;
+
+    // ── Help Text ──
+
+    var HELP = {
+        'market-cap':     'Total market value of all outstanding shares',
+        'p-e--ttm-':      'Price-to-Earnings ratio (trailing 12 months) — how much investors pay per dollar of earnings',
+        'eps--ttm-':      'Earnings Per Share — net income divided by shares outstanding',
+        'dividend':       'Most recent annual dividend payment per share',
+        'beta':           'Volatility relative to the market — 1.0 = moves with market, >1 = more volatile',
+        '52w-range':      'Lowest and highest price over the past 52 weeks',
+        'volume':         'Number of shares traded in the most recent session',
+        'avg-volume':     'Average daily trading volume',
+        'ev-ebitda':      'Enterprise Value / EBITDA — valuation metric comparing total company value to operating earnings',
+        'ev-sales':       'Enterprise Value / Sales — valuation relative to revenue',
+        'current-ratio':  'Current assets / current liabilities — ability to pay short-term obligations (>1 = healthy)',
+        'debt-equity':    'Total debt / shareholder equity — financial leverage',
+        'roe':            'Return on Equity — net income / equity — profitability of shareholder investment',
+        'gross-margin':   'Gross profit / revenue — percentage retained after cost of goods',
+        'net-margin':     'Net income / revenue — percentage retained after all expenses',
+        'p-b':            'Price-to-Book — market price / book value per share',
+        'revenue':        'Total income from business operations before any deductions',
+        'cost-of-revenue':'Direct costs of producing goods/services sold',
+        'gross-profit':   'Revenue minus cost of revenue',
+        'r-d-expenses':   'Spending on research and development of new products',
+        'operating-income':'Profit from core business operations before interest and taxes',
+        'ebitda':         'Earnings Before Interest, Taxes, Depreciation & Amortization — operating profitability',
+        'net-income':     'Total profit after all expenses, taxes, and interest',
+        'eps':            'Earnings Per Share — net income divided by outstanding shares',
+        'total-assets':   'Everything the company owns — cash, property, equipment, investments',
+        'current-assets': 'Assets expected to be converted to cash within one year',
+        'cash---equivalents':'Cash on hand and highly liquid short-term investments',
+        'total-liabilities':'Everything the company owes — loans, bonds, payables',
+        'current-liabilities':'Obligations due within one year',
+        'long-term-debt': 'Debt obligations due after one year',
+        'total-equity':   'Assets minus liabilities — shareholder ownership value',
+        'retained-earnings':'Accumulated profits not distributed as dividends',
+        'operating-cf':   'Cash generated from core business operations',
+        'investing-cf':   'Cash spent on or received from investments, acquisitions, assets',
+        'financing-cf':   'Cash from issuing/repaying debt, equity, dividends',
+        'capex':          'Capital Expenditure — money spent on physical assets (property, equipment)',
+        'free-cash-flow': 'Operating cash flow minus CapEx — cash available for dividends, buybacks, debt reduction',
+        'dividends-paid': 'Total cash distributed to shareholders as dividends',
+        'share-buyback':  'Cash spent repurchasing the company\'s own shares',
+        'revenue-est':    'Analyst consensus forecast for total revenue — average with low–high range',
+        'eps-est':        'Analyst consensus forecast for Earnings Per Share — average with low–high range',
+        'ebitda-est':     'Analyst consensus forecast for EBITDA (operating earnings before depreciation)',
+        'net-income-est': 'Analyst consensus forecast for total net profit',
+    };
+
+    var helpVisible = false;
+
+    function toggleHelp() {
+        helpVisible = !helpVisible;
+        document.querySelectorAll('.help-tip').forEach(function (el) {
+            el.classList.toggle('hidden', !helpVisible);
+        });
+        // Update help indicator
+        var indicator = document.getElementById('help-indicator');
+        if (indicator) indicator.classList.toggle('hidden', !helpVisible);
+    }
+
+    // Expose for vim
+    window._infoToggleHelp = toggleHelp;
+
+    // ── Number Formatting ──
+
+    function fmt(n) {
+        if (n == null || isNaN(n)) return '—';
+        var abs = Math.abs(n);
+        var str;
+        if (abs >= 1e12) str = (n / 1e12).toFixed(2) + 'T';
+        else if (abs >= 1e9) str = (n / 1e9).toFixed(2) + 'B';
+        else if (abs >= 1e6) str = (n / 1e6).toFixed(2) + 'M';
+        else if (abs >= 1e3) str = (n / 1e3).toFixed(1) + 'K';
+        else str = n.toFixed(2);
+        return n < 0 ? '<span class="price-down">' + str + '</span>' : str;
+    }
+
+    function pct(n) {
+        if (n == null || isNaN(n)) return '—';
+        return (n * 100).toFixed(2) + '%';
+    }
+
+    function esc(s) {
+        if (!s) return '';
+        return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    // ── Tab Switching ──
+
+    var tabs = document.getElementById('info-tabs');
+    if (tabs) {
+        tabs.querySelectorAll('.info-tab').forEach(function (tab) {
+            tab.onclick = function () {
+                tabs.querySelectorAll('.info-tab').forEach(function (t) { t.classList.remove('active'); });
+                tab.classList.add('active');
+                loadTab(tab.dataset.tab);
+            };
+        });
+    }
+
+    // Expose for vim keybindings
+    window._infoJumpToTab = function (n) {
+        var allTabs = tabs.querySelectorAll('.info-tab');
+        if (n < allTabs.length) allTabs[n].click();
+    };
+
+    // ── Sparkline ──
+
+    function initSparkline() {
+        var el = document.getElementById('info-sparkline');
+        if (!el || !window.LightweightCharts) return;
+
+        var from = new Date();
+        from.setMonth(from.getMonth() - 6);
+        var to = new Date();
+        var fromStr = to.getFullYear() === from.getFullYear()
+            ? from.toISOString().slice(0, 10)
+            : from.toISOString().slice(0, 10);
+
+        fetch('/api/chart/eod/' + symbol + '?from=' + from.toISOString().slice(0, 10) + '&to=' + to.toISOString().slice(0, 10))
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (!data || data.length < 2) return;
+
+                var first = data[0].close;
+                var last = data[data.length - 1].close;
+                var color = last >= first ? '#00cc66' : '#ff4444';
+
+                var chart = LightweightCharts.createChart(el, {
+                    width: 200,
+                    height: 50,
+                    layout: { background: { color: 'transparent' }, textColor: 'transparent' },
+                    grid: { vertLines: { visible: false }, horzLines: { visible: false } },
+                    rightPriceScale: { visible: false },
+                    timeScale: { visible: false },
+                    handleScroll: false,
+                    handleScale: false,
+                    crosshair: { vertLine: { visible: false }, horzLine: { visible: false } },
+                });
+
+                var series = chart.addSeries(LightweightCharts.AreaSeries, {
+                    lineColor: color,
+                    topColor: color.replace(')', ', 0.2)').replace('rgb', 'rgba'),
+                    bottomColor: 'transparent',
+                    lineWidth: 2,
+                    priceLineVisible: false,
+                    lastValueVisible: false,
+                });
+
+                series.setData(data.map(function (d) { return { time: d.date, value: d.close }; }));
+                chart.timeScale().fitContent();
+            });
+    }
+
+    // ── Load Header (profile price/change) ──
+
+    function loadHeader() {
+        fetch('/api/security/' + symbol + '/profile')
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (!data || !data.length) return;
+                var p = data[0];
+                var nameEl = document.getElementById('info-company-name');
+                var priceEl = document.getElementById('info-price');
+                var changeEl = document.getElementById('info-change');
+                if (nameEl) nameEl.textContent = p.companyName || '';
+                if (priceEl) priceEl.textContent = p.price ? p.price.toFixed(2) : '';
+                if (changeEl) {
+                    var chg = p.change || 0;
+                    var chgPct = p.changePercentage || 0;
+                    changeEl.textContent = (chg >= 0 ? '+' : '') + chg.toFixed(2) + ' (' + chgPct.toFixed(2) + '%)';
+                    changeEl.className = 'info-change ' + (chg >= 0 ? 'price-up' : 'price-down');
+                }
+            });
+    }
+
+    // ── Tab Loaders ──
+
+    function loadTab(tab) {
+        container.innerHTML = '<p class="empty-state">Loading...</p>';
+        switch (tab) {
+            case 'overview': loadOverview(); break;
+            case 'financials': loadFinancials('income'); break;
+            case 'estimates': loadEstimates(); break;
+            case 'news': loadNews(); break;
+        }
+    }
+
+    // ── Overview ──
+
+    function loadOverview() {
+        Promise.all([
+            fetch('/api/security/' + symbol + '/profile').then(function (r) { return r.json(); }),
+            fetch('/api/security/' + symbol + '/metrics').then(function (r) { return r.json(); }),
+        ]).then(function (results) {
+            var profile = results[0] && results[0][0] ? results[0][0] : {};
+            var metricsData = results[1] || {};
+            var metrics = metricsData.metrics && metricsData.metrics[0] ? metricsData.metrics[0] : {};
+            var ratios = metricsData.ratios && metricsData.ratios[0] ? metricsData.ratios[0] : {};
+
+            var html = '<div class="info-overview">';
+
+            // Key stats grid
+            html += '<div class="info-grid">';
+            html += stat('Market Cap', fmt(profile.marketCap));
+            html += stat('P/E (TTM)', ratios.priceToEarningsRatioTTM ? ratios.priceToEarningsRatioTTM.toFixed(2) : '—');
+            html += stat('EPS (TTM)', profile.eps ? profile.eps.toFixed(2) : '—');
+            html += stat('Dividend', profile.lastDividend ? '$' + profile.lastDividend.toFixed(2) : '—');
+            html += stat('Beta', profile.beta ? profile.beta.toFixed(3) : '—');
+            html += stat('52W Range', profile.range || '—');
+            html += stat('Volume', fmt(profile.volume));
+            html += stat('Avg Volume', fmt(profile.averageVolume));
+            html += '</div>';
+
+            // Metrics grid
+            html += '<div class="info-grid">';
+            html += stat('EV/EBITDA', metrics.evToEBITDA ? metrics.evToEBITDA.toFixed(2) : '—');
+            html += stat('EV/Sales', metrics.evToSales ? metrics.evToSales.toFixed(2) : '—');
+            html += stat('Current Ratio', ratios.currentRatioTTM ? ratios.currentRatioTTM.toFixed(2) : '—');
+            html += stat('Debt/Equity', ratios.debtToEquityRatioTTM ? ratios.debtToEquityRatioTTM.toFixed(2) : '—');
+            html += stat('ROE', pct(ratios.returnOnEquityTTM));
+            html += stat('Gross Margin', pct(ratios.grossProfitMarginTTM));
+            html += stat('Net Margin', pct(ratios.netProfitMarginTTM));
+            html += stat('P/B', ratios.priceToBookRatioTTM ? ratios.priceToBookRatioTTM.toFixed(2) : '—');
+            html += '</div>';
+
+            // Company info
+            html += '<div class="info-company">';
+            html += '<div class="info-company-meta">';
+            html += '<span>' + esc(profile.sector) + ' / ' + esc(profile.industry) + '</span>';
+            html += '<span>CEO: ' + esc(profile.ceo) + '</span>';
+            html += '<span>' + esc(profile.fullTimeEmployees) + ' employees</span>';
+            html += '<span>' + esc(profile.exchange) + '</span>';
+            if (profile.website) html += '<span><a href="' + esc(profile.website) + '" target="_blank" rel="noopener">' + esc(profile.website) + '</a></span>';
+            html += '</div>';
+            if (profile.description) {
+                var desc = profile.description;
+                html += '<p class="info-description">' + esc(desc) + '</p>';
+            }
+            html += '</div>';
+
+            html += '</div>';
+            container.innerHTML = html;
+        }).catch(function () {
+            container.innerHTML = '<p class="empty-state">Failed to load overview</p>';
+        });
+    }
+
+    function stat(label, value) {
+        var field = label.toLowerCase().replace(/[^a-z0-9]/g, '-');
+        var tip = HELP[field] ? '<span class="help-tip hidden">' + esc(HELP[field]) + '</span>' : '';
+        return '<div class="info-stat"><span class="info-stat-label">' + label + tip + '</span><span class="info-stat-value" data-field="' + field + '">' + value + '</span></div>';
+    }
+
+    // ── Financials ──
+
+    var finSubTypes = [
+        { key: 'income',   label: 'Income',        hotkey: 'i' },
+        { key: 'balance',  label: 'Balance Sheet',  hotkey: 'b' },
+        { key: 'cashflow', label: 'Cash Flow',      hotkey: 'c' },
+    ];
+
+    function loadFinancials(type) {
+        // Sub-tab bar with keycap badges
+        var subHtml = '<div class="info-sub-tabs" id="fin-sub-tabs">';
+        finSubTypes.forEach(function (t, i) {
+            var active = t.key === type ? ' active' : '';
+            subHtml += '<button class="info-sub-tab' + active + '" data-ftype="' + t.key + '"><span class="tab-key">' + t.hotkey + '</span> ' + t.label + '</button>';
+        });
+        subHtml += '</div><div id="fin-table-container"><p class="empty-state">Loading...</p></div>';
+        container.innerHTML = subHtml;
+
+        container.querySelectorAll('.info-sub-tab').forEach(function (btn) {
+            btn.onclick = function () {
+                container.querySelectorAll('.info-sub-tab').forEach(function (b) { b.classList.remove('active'); });
+                btn.classList.add('active');
+                loadFinancialTable(btn.dataset.ftype);
+            };
+        });
+
+        loadFinancialTable(type);
+    }
+
+    // Expose for vim sub-tab navigation
+    window._infoFinSubTabs = function () {
+        return Array.from(document.querySelectorAll('#fin-sub-tabs .info-sub-tab'));
+    };
+    window._infoFinJumpToSub = function (n) {
+        var tabs = window._infoFinSubTabs();
+        if (n >= 0 && n < tabs.length) tabs[n].click();
+    };
+
+    function loadFinancialTable(type) {
+        var tc = document.getElementById('fin-table-container');
+        if (!tc) return;
+        tc.innerHTML = '<p class="empty-state">Loading...</p>';
+
+        fetch('/api/security/' + symbol + '/financials?type=' + type)
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (!data || data.length === 0) {
+                    tc.innerHTML = '<p class="empty-state">No data available</p>';
+                    return;
+                }
+
+                var rows;
+                if (type === 'income') {
+                    rows = [
+                        ['Revenue', 'revenue'],
+                        ['Cost of Revenue', 'costOfRevenue'],
+                        ['Gross Profit', 'grossProfit'],
+                        ['R&D Expenses', 'researchAndDevelopmentExpenses'],
+                        ['Operating Income', 'operatingIncome'],
+                        ['EBITDA', 'ebitda'],
+                        ['Net Income', 'netIncome'],
+                        ['EPS', 'eps'],
+                    ];
+                } else if (type === 'balance') {
+                    rows = [
+                        ['Total Assets', 'totalAssets'],
+                        ['Current Assets', 'totalCurrentAssets'],
+                        ['Cash & Equivalents', 'cashAndCashEquivalents'],
+                        ['Total Liabilities', 'totalLiabilities'],
+                        ['Current Liabilities', 'totalCurrentLiabilities'],
+                        ['Long-Term Debt', 'longTermDebt'],
+                        ['Total Equity', 'totalStockholdersEquity'],
+                        ['Retained Earnings', 'retainedEarnings'],
+                    ];
+                } else {
+                    rows = [
+                        ['Operating CF', 'operatingCashFlow'],
+                        ['Investing CF', 'netCashUsedForInvestingActivities'],
+                        ['Financing CF', 'netCashUsedProvidedByFinancingActivities'],
+                        ['CapEx', 'capitalExpenditure'],
+                        ['Free Cash Flow', 'freeCashFlow'],
+                        ['Dividends Paid', 'dividendsPaid'],
+                        ['Share Buyback', 'commonStockRepurchased'],
+                    ];
+                }
+
+                var html = '<table class="fin-table"><thead><tr><th></th>';
+                data.forEach(function (d) {
+                    html += '<th>' + (d.fiscalYear || d.date || '').substring(0, 4) + '</th>';
+                });
+                html += '</tr></thead><tbody>';
+
+                rows.forEach(function (row) {
+                    var field = row[0].toLowerCase().replace(/[^a-z0-9]/g, '-');
+                    var tip = HELP[field] ? '<span class="help-tip hidden">' + esc(HELP[field]) + '</span>' : '';
+                    html += '<tr><td class="fin-label">' + row[0] + tip + '</td>';
+                    data.forEach(function (d) {
+                        html += '<td>' + fmt(d[row[1]]) + '</td>';
+                    });
+                    html += '</tr>';
+                });
+
+                html += '</tbody></table>';
+                tc.innerHTML = html;
+            })
+            .catch(function () {
+                tc.innerHTML = '<p class="empty-state">Failed to load financials</p>';
+            });
+    }
+
+    // ── Estimates ──
+
+    function loadEstimates() {
+        fetch('/api/security/' + symbol + '/estimates')
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (!data || data.length === 0) {
+                    container.innerHTML = '<p class="empty-state">No estimates available</p>';
+                    return;
+                }
+
+                // Sort by date ascending
+                data.sort(function (a, b) { return a.date.localeCompare(b.date); });
+
+                var estCols = [
+                    ['Year', ''],
+                    ['Revenue Est', 'revenue-est'],
+                    ['EPS Est', 'eps-est'],
+                    ['EBITDA Est', 'ebitda-est'],
+                    ['Net Income Est', 'net-income-est'],
+                ];
+                var html = '<table class="fin-table"><thead><tr>';
+                estCols.forEach(function (col) {
+                    var tip = col[1] && HELP[col[1]] ? '<span class="help-tip hidden">' + esc(HELP[col[1]]) + '</span>' : '';
+                    html += '<th>' + col[0] + tip + '</th>';
+                });
+                html += '</tr></thead><tbody>';
+
+                data.forEach(function (d) {
+                    var year = (d.date || '').substring(0, 4);
+                    html += '<tr>';
+                    html += '<td class="fin-label">' + year + '</td>';
+                    html += '<td>' + fmt(d.revenueAvg) + ' <span class="est-range">' + fmt(d.revenueLow) + '–' + fmt(d.revenueHigh) + '</span></td>';
+                    html += '<td>' + (d.epsAvg != null ? d.epsAvg.toFixed(2) : '—') + ' <span class="est-range">' + (d.epsLow != null ? d.epsLow.toFixed(2) : '—') + '–' + (d.epsHigh != null ? d.epsHigh.toFixed(2) : '—') + '</span></td>';
+                    html += '<td>' + fmt(d.ebitdaAvg) + '</td>';
+                    html += '<td>' + fmt(d.netIncomeAvg) + '</td>';
+                    html += '</tr>';
+                });
+
+                html += '</tbody></table>';
+                container.innerHTML = html;
+            })
+            .catch(function () {
+                container.innerHTML = '<p class="empty-state">Failed to load estimates</p>';
+            });
+    }
+
+    // ── News (reuse existing pattern) ──
+
+    function loadNews() {
+        container.innerHTML = '<p class="empty-state">Loading...</p>';
+
+        fetch('/api/news/press-releases?symbol=' + symbol + '&limit=20')
+            .then(function (r) { return r.json(); })
+            .then(function (items) {
+                if (!items || items.length === 0) {
+                    container.innerHTML = '<p class="empty-state">No news available for ' + symbol + '</p>';
+                    return;
+                }
+                container.innerHTML = '<div class="news-cards" style="max-height:calc(100vh - 220px)">' +
+                    items.map(function (item) {
+                        var date = item.date ? new Date(item.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : '';
+                        var text = item.text || '';
+                        if (text.length > 200) text = text.substring(0, 200) + '...';
+                        return '<div class="news-card news-unread">'
+                            + '<div class="news-card-title"><a href="' + esc(item.url) + '" target="_blank" rel="noopener">' + esc(item.title) + '</a></div>'
+                            + '<div class="news-card-meta"><span>' + esc(item.source) + '</span><span>' + date + '</span></div>'
+                            + '<div class="news-card-text">' + esc(text) + '</div>'
+                            + '</div>';
+                    }).join('') + '</div>';
+            })
+            .catch(function () {
+                container.innerHTML = '<p class="empty-state">Failed to load news</p>';
+            });
+    }
+
+    // ── Refresh ──
+
+    var currentTab = 'overview';
+
+    // Override loadTab to track current tab
+    var _origLoadTab = loadTab;
+    loadTab = function (tab) {
+        currentTab = tab;
+        _origLoadTab(tab);
+    };
+
+    function refresh() {
+        // Snapshot current values
+        var snapshot = {};
+        container.querySelectorAll('[data-field]').forEach(function (el) {
+            snapshot[el.dataset.field] = el.textContent;
+        });
+
+        // Also snapshot header
+        var priceEl = document.getElementById('info-price');
+        var changeEl = document.getElementById('info-change');
+        var oldPrice = priceEl ? priceEl.textContent : '';
+        var oldChange = changeEl ? changeEl.textContent : '';
+
+        // Reload header
+        loadHeader();
+
+        // Reload current tab content
+        loadTab(currentTab);
+
+        // After a short delay for fetch to complete, check for changes and pulse
+        setTimeout(function () {
+            // Pulse header if changed
+            if (priceEl && priceEl.textContent !== oldPrice) pulseEl(priceEl);
+            if (changeEl && changeEl.textContent !== oldChange) pulseEl(changeEl);
+
+            // Pulse changed stat values
+            container.querySelectorAll('[data-field]').forEach(function (el) {
+                var key = el.dataset.field;
+                if (snapshot[key] !== undefined && snapshot[key] !== el.textContent) {
+                    pulseEl(el);
+                }
+            });
+        }, 800);
+    }
+
+    function pulseEl(el) {
+        el.classList.add('info-pulse');
+        setTimeout(function () { el.classList.remove('info-pulse'); }, 1500);
+    }
+
+    // Expose for vim
+    window._infoRefresh = refresh;
+
+    // ── Init ──
+
+    loadHeader();
+    initSparkline();
+    loadTab('overview');
+})();

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -411,6 +411,266 @@ body {
     padding: 40px 20px;
 }
 
+/* ── Security Info View ── */
+
+.info-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+    gap: 16px;
+}
+
+.info-title {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.info-title h1 {
+    font-size: 16px;
+    font-weight: 700;
+}
+
+.info-company-name {
+    color: var(--text-secondary);
+    font-size: 13px;
+}
+
+.info-price {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.info-change {
+    font-size: 13px;
+}
+
+.info-sparkline {
+    flex-shrink: 0;
+    width: 200px;
+    height: 50px;
+}
+
+.info-tabs {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 12px;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 8px;
+}
+
+.info-tab {
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    padding: 5px 12px;
+    cursor: pointer;
+}
+
+.info-tab:hover {
+    color: var(--text-primary);
+    background: var(--bg-tertiary);
+}
+
+.info-tab.active {
+    color: var(--orange);
+    border-color: var(--orange);
+    background: var(--bg-tertiary);
+}
+
+.info-content {
+    max-height: calc(100vh - 200px);
+    overflow-y: auto;
+}
+
+.info-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.info-stat {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 8px 10px;
+}
+
+.info-stat-label {
+    display: block;
+    font-size: 10px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 2px;
+}
+
+.info-stat-value {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.info-company {
+    margin-top: 12px;
+}
+
+.info-company-meta {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-bottom: 10px;
+}
+
+.info-company-meta a {
+    color: var(--blue);
+    text-decoration: none;
+}
+
+.info-description {
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.6;
+    max-height: 100px;
+    overflow-y: auto;
+}
+
+.info-sub-tabs {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 12px;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 8px;
+}
+
+.info-sub-tab {
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    padding: 4px 10px;
+    cursor: pointer;
+}
+
+.info-sub-tab:hover {
+    color: var(--text-primary);
+    background: var(--bg-tertiary);
+}
+
+.info-sub-tab.active {
+    color: var(--blue);
+    border-color: var(--blue);
+    background: var(--bg-tertiary);
+}
+
+.fin-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+}
+
+.fin-table th {
+    text-align: right;
+    padding: 6px 12px;
+    color: var(--text-muted);
+    font-size: 11px;
+    font-weight: 500;
+    border-bottom: 1px solid var(--border);
+}
+
+.fin-table th:first-child {
+    text-align: left;
+}
+
+.fin-table td {
+    text-align: right;
+    padding: 6px 12px;
+    border-bottom: 1px solid rgba(42, 42, 42, 0.5);
+}
+
+.fin-table tr:hover {
+    background: var(--bg-secondary);
+}
+
+.fin-label {
+    text-align: left !important;
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+
+.est-range {
+    font-size: 10px;
+    color: var(--text-muted);
+}
+
+.info-tabs.tab-row-focused {
+    border-bottom-color: var(--orange) !important;
+}
+
+.info-sub-tabs.tab-row-focused {
+    border-bottom-color: var(--blue) !important;
+}
+
+.help-tip {
+    display: block;
+    font-size: 10px;
+    font-weight: 400;
+    color: var(--yellow);
+    line-height: 1.4;
+    margin-top: 2px;
+    font-style: italic;
+    letter-spacing: 0;
+    text-transform: none;
+}
+
+.help-tip.hidden {
+    display: none;
+}
+
+.help-indicator {
+    font-size: 10px;
+    color: var(--yellow);
+    padding: 2px 8px;
+    border: 1px solid var(--yellow);
+    border-radius: 3px;
+    margin-bottom: 8px;
+    display: inline-block;
+}
+
+.help-indicator.hidden {
+    display: none;
+}
+
+.info-pulse {
+    animation: info-pulse-fade 1.5s ease-out;
+}
+
+@keyframes info-pulse-fade {
+    0% { color: var(--orange); text-shadow: 0 0 6px rgba(255, 136, 0, 0.5); }
+    100% { color: inherit; text-shadow: none; }
+}
+
+@media (max-width: 900px) {
+    .info-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    .info-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
 /* ── News View ── */
 
 .news-tabs {

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -975,6 +975,120 @@
                 if (link) window.open(link.href, '_blank', 'noopener');
             }
         },
+        info: {
+            // focus: 'main' = main tabs, 'sub' = sub-tabs, 'content' = scrolling
+            _focus: 'main',
+            getAllTabs: function () { return Array.from(document.querySelectorAll('#info-tabs .info-tab')); },
+            getActiveTab: function () {
+                var el = document.querySelector('#info-tabs .info-tab.active');
+                return el ? el.dataset.tab : '';
+            },
+            hasSubTabs: function () {
+                return this.getActiveTab() === 'financials' && window._infoFinSubTabs && window._infoFinSubTabs().length > 0;
+            },
+            isNewsTab: function () { return this.getActiveTab() === 'news'; },
+            getNewsCards: function () { return document.querySelectorAll('#info-content .news-card'); },
+            move: function (dir) {
+                var hasSub = this.hasSubTabs();
+
+                if (dir === 'k') {
+                    // If on news tab in content mode, navigate cards up
+                    if (this._focus === 'content' && this.isNewsTab()) {
+                        if (vimSelectedIndex > 0) {
+                            var cards = this.getNewsCards();
+                            vimSelectedIndex = Math.max(vimSelectedIndex - 1, 0);
+                            vimSelect(cards, vimSelectedIndex);
+                            return;
+                        }
+                        // At top of cards, move focus back to main tabs
+                        clearVimSelection();
+                        this._focus = 'main';
+                        this._highlightFocus();
+                        return;
+                    }
+                    // Move up through layers: content → sub → main
+                    if (this._focus === 'content' && hasSub) {
+                        this._focus = 'sub';
+                    } else if (this._focus === 'content' || this._focus === 'sub') {
+                        this._focus = 'main';
+                    }
+                    this._highlightFocus();
+                    return;
+                }
+                if (dir === 'j') {
+                    // Move down through layers: main → sub → content
+                    if (this._focus === 'main' && hasSub) {
+                        this._focus = 'sub';
+                        this._highlightFocus();
+                    } else {
+                        this._focus = 'content';
+                        this._highlightFocus();
+                        if (this.isNewsTab()) {
+                            var cards = this.getNewsCards();
+                            if (cards.length > 0) {
+                                vimSelectedIndex = Math.min(vimSelectedIndex + 1, cards.length - 1);
+                                vimSelect(cards, vimSelectedIndex);
+                            }
+                        } else {
+                            var content = document.getElementById('info-content');
+                            if (content) content.scrollTop += 60;
+                        }
+                    }
+                    return;
+                }
+                if (dir === 'h' || dir === 'l') {
+                    if (this._focus === 'sub' && hasSub) {
+                        var subTabs = window._infoFinSubTabs();
+                        var activeIdx = subTabs.findIndex(function (t) { return t.classList.contains('active'); });
+                        if (dir === 'l') activeIdx = Math.min(activeIdx + 1, subTabs.length - 1);
+                        else activeIdx = Math.max(activeIdx - 1, 0);
+                        subTabs[activeIdx].click();
+                        return;
+                    }
+                    // Main tabs
+                    this._focus = 'main';
+                    var tabs = this.getAllTabs();
+                    if (tabs.length === 0) return;
+                    var activeIdx = tabs.findIndex(function (t) { return t.classList.contains('active'); });
+                    if (dir === 'l') activeIdx = Math.min(activeIdx + 1, tabs.length - 1);
+                    else activeIdx = Math.max(activeIdx - 1, 0);
+                    tabs[activeIdx].click();
+                    this._highlightFocus();
+                    return;
+                }
+            },
+            _highlightFocus: function () {
+                // Visual indicator of which tab row has focus
+                var mainTabs = document.getElementById('info-tabs');
+                var subTabs = document.getElementById('fin-sub-tabs');
+                if (mainTabs) mainTabs.classList.toggle('tab-row-focused', this._focus === 'main');
+                if (subTabs) subTabs.classList.toggle('tab-row-focused', this._focus === 'sub');
+            },
+            jumpToTab: function (n) {
+                this._focus = 'main';
+                if (window._infoJumpToTab) window._infoJumpToTab(n);
+                this._highlightFocus();
+            },
+            jumpToSubTab: function (n) {
+                if (this.hasSubTabs() && window._infoFinJumpToSub) {
+                    this._focus = 'sub';
+                    window._infoFinJumpToSub(n);
+                    this._highlightFocus();
+                }
+            },
+            refresh: function () {
+                if (window._infoRefresh) window._infoRefresh();
+            },
+            activate: function () {
+                if (this.isNewsTab()) {
+                    var cards = this.getNewsCards();
+                    if (vimSelectedIndex >= 0 && vimSelectedIndex < cards.length) {
+                        var link = cards[vimSelectedIndex].querySelector('.news-card-title a');
+                        if (link) window.open(link.href, '_blank', 'noopener');
+                    }
+                }
+            }
+        },
         debug: {
             move: function (dir) {
                 var console = document.getElementById('debug-console');
@@ -1059,6 +1173,23 @@
             case 'g':
                 e.preventDefault();
                 if (handler && handler.graph) handler.graph();
+                return;
+            case 'r':
+                e.preventDefault();
+                if (handler && handler.refresh) handler.refresh();
+                return;
+            case '?':
+                e.preventDefault();
+                if (window._infoToggleHelp) window._infoToggleHelp();
+                return;
+            case 'i':
+                if (handler && handler.jumpToSubTab) { e.preventDefault(); handler.jumpToSubTab(0); }
+                return;
+            case 'b':
+                if (handler && handler.jumpToSubTab) { e.preventDefault(); handler.jumpToSubTab(1); }
+                return;
+            case 'c':
+                if (handler && handler.jumpToSubTab) { e.preventDefault(); handler.jumpToSubTab(2); }
                 return;
             case '1': case '2': case '3': case '4': case '5': case '6':
                 if (handler && handler.jumpToTab) {

--- a/internal/server/templates/security.html
+++ b/internal/server/templates/security.html
@@ -1,9 +1,24 @@
 {{template "layout" .}}
 {{define "content"}}
-<div class="page-header">
-    <h1>{{.Symbol}}</h1>
+<div class="info-header">
+    <div class="info-title">
+        <h1>{{.Symbol}}</h1>
+        <span id="info-company-name" class="info-company-name"></span>
+        <span id="info-price" class="info-price"></span>
+        <span id="info-change" class="info-change"></span>
+    </div>
+    <div id="info-sparkline" class="info-sparkline"></div>
 </div>
-<div class="security-info">
-    <p class="empty-state">Security info coming soon</p>
+<span id="help-indicator" class="help-indicator hidden">? help on</span>
+<div class="info-tabs" id="info-tabs">
+    <button class="info-tab active" data-tab="overview"><span class="tab-key">1</span> Overview</button>
+    <button class="info-tab" data-tab="financials"><span class="tab-key">2</span> Financials</button>
+    <button class="info-tab" data-tab="estimates"><span class="tab-key">3</span> Estimates</button>
+    <button class="info-tab" data-tab="news"><span class="tab-key">4</span> News</button>
 </div>
+<div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
+    <p class="empty-state">Loading...</p>
+</div>
+<script src="/static/lightweight-charts.js"></script>
+<script src="/static/info.js"></script>
 {{end}}

--- a/tests/e2e/smoke_test.go
+++ b/tests/e2e/smoke_test.go
@@ -193,6 +193,50 @@ func TestSmoke_NewsAPI(t *testing.T) {
 	}
 }
 
+func TestSmoke_SecurityProfile(t *testing.T) {
+	resp := get(t, "/api/security/AAPL/profile")
+	defer resp.Body.Close()
+	assertStatus(t, resp, 200)
+
+	var data []map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&data)
+	if len(data) == 0 {
+		t.Fatal("expected profile data")
+	}
+	if data[0]["companyName"] == nil {
+		t.Error("expected companyName field")
+	}
+}
+
+func TestSmoke_SecurityMetrics(t *testing.T) {
+	resp := get(t, "/api/security/AAPL/metrics")
+	defer resp.Body.Close()
+	assertStatus(t, resp, 200)
+
+	var data map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&data)
+	if data["metrics"] == nil && data["ratios"] == nil {
+		t.Error("expected metrics or ratios data")
+	}
+}
+
+func TestSmoke_SecurityFinancials(t *testing.T) {
+	types := []string{"income", "balance", "cashflow"}
+	for _, typ := range types {
+		t.Run(typ, func(t *testing.T) {
+			resp := get(t, "/api/security/AAPL/financials?type="+typ)
+			defer resp.Body.Close()
+			assertStatus(t, resp, 200)
+		})
+	}
+}
+
+func TestSmoke_SecurityEstimates(t *testing.T) {
+	resp := get(t, "/api/security/AAPL/estimates")
+	defer resp.Body.Close()
+	assertStatus(t, resp, 200)
+}
+
 func TestSmoke_NewsCategories(t *testing.T) {
 	categories := []string{"press-releases", "articles", "stock", "crypto", "forex", "general"}
 	for _, cat := range categories {


### PR DESCRIPTION
## Summary

- **Overview tab**: Company profile (name, CEO, sector, employees, description), key stats grid (Market Cap, P/E, EPS, Beta, 52W Range, Volume), financial metrics (EV/EBITDA, ROE, margins, Debt/Equity), 6-month sparkline mini-chart (green if up, red if down)
- **Financials tab**: Income / Balance Sheet / Cash Flow sub-tabs with 4-year comparison tables. Sub-tab hotkeys: `[i]` Income, `[b]` Balance Sheet, `[c]` Cash Flow
- **Estimates tab**: Analyst forward estimates with Revenue, EPS, EBITDA, Net Income (avg + low–high ranges)
- **News tab**: Security-filtered press releases with card selection
- **Help text** (`?` toggle): Yellow descriptions for every financial term across all tabs
- **Refresh** (`r` key): Re-fetches data, pulses changed values with orange glow
- **Vim navigation**: j/k moves focus between main tabs → sub-tabs → content, h/l navigates within focused row, orange/blue underline shows active layer

## New endpoints
- `GET /api/security/{symbol}/profile` — company profile
- `GET /api/security/{symbol}/metrics` — key metrics + TTM ratios
- `GET /api/security/{symbol}/financials?type=income|balance|cashflow` — financial statements
- `GET /api/security/{symbol}/estimates` — analyst estimates

## Test plan
- [ ] `make smoke` — all 17 tests pass (4 new security API tests)
- [ ] `info AAPL` — overview loads with profile, stats, sparkline
- [ ] Tab 2 (Financials) → `i`/`b`/`c` switches sub-tabs, j/k navigates layers
- [ ] Tab 3 (Estimates) → shows forward estimates table
- [ ] `?` toggles help text on all tabs
- [ ] `r` refreshes data with pulse animation on changes