### PR TITLE
fix: news view uses selected security as default filter

### DIFF
--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -310,13 +310,17 @@
             });
         }
 
-        // If filtering by security, probe all tabs for results to dim empty ones
-        if (newsFilterSecurity) {
+        // Probe tabs for results to dim empty ones when filtering by security
+        if (getNewsSymbol()) {
             probeNewsTabs();
         }
 
         // Default: load first tab
         fetchNews('press-releases');
+    }
+
+    function getNewsSymbol() {
+        return newsFilterSecurity || selectedSecurity || '';
     }
 
     function subscribeNewsTopic(category) {
@@ -368,8 +372,9 @@
             if (!tab) return;
 
             var params = 'limit=1';
-            if (newsFilterSecurity) {
-                params += '&symbol=' + encodeURIComponent(newsFilterSecurity);
+            var sym = getNewsSymbol();
+            if (sym) {
+                params += '&symbol=' + encodeURIComponent(sym);
             }
 
             fetch('/api/news/' + cat + '?' + params)
@@ -455,8 +460,9 @@
         newsLoading = true;
         showNewsSpinner(true);
         var params = 'limit=' + NEWS_PAGE_SIZE + '&page=' + page;
-        if (newsFilterSecurity) {
-            params += '&symbol=' + encodeURIComponent(newsFilterSecurity);
+        var sym = getNewsSymbol();
+        if (sym) {
+            params += '&symbol=' + encodeURIComponent(sym);
         }
 
         fetch('/api/news/' + category + '?' + params)


### PR DESCRIPTION
## Summary

News view now uses the selected security from the security picker as the default filter, instead of showing unfiltered (noisy) news. Priority order:

1. Explicit `news MSFT` command argument
2. Selected security from the security picker
3. Unfiltered (only when no security is selected at all)

This applies to all news fetches, tab probing (dimming), and pagination.

## Test plan
- [ ] Select AAPL in security picker, type `news` — shows AAPL-filtered news
- [ ] Type `news MSFT` — overrides picker, shows MSFT news
- [ ] Clear security picker, type `news` — shows unfiltered news
- [ ] `make smoke` — all 17 tests pass