### PR TITLE
feat: AI company intelligence system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,9 @@ stocktopus  # Project binary
 *.out       # Go output files
 vendor/     # Go dependency directory
 bin/        # Build output directory
+.venv/      # Python virtual environment
+.models/    # Downloaded GGUF model files
+*.db        # SQLite databases
 
 # --- Secrets & Environment Variables ---
 .env*       # Environment files (contains API keys!)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,3 +49,4 @@ make clean    # Remove bin/
 - **Always run `make smoke` before pushing** — verify nothing is broken
 - UI uses the term "Security" (not "Symbol") in all user-facing text
 - Internal Go code and WebSocket protocol still use "symbol" for data model fields
+- **Always store dates in UTC** — use `time.Now().UTC()` for storage, parse as UTC, only convert for display

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: dev build test smoke clean
+.PHONY: dev build test smoke clean setup-agents agent-train
 
 dev: build
 	./bin/stocktopus
 
 build:
-	go build -o bin/stocktopus ./cmd/stocktopus
+	CGO_ENABLED=1 go build -o bin/stocktopus ./cmd/stocktopus
 
 test:
 	go test ./...
@@ -12,5 +12,18 @@ test:
 smoke:
 	go test -tags e2e -v -count=1 ./tests/e2e/
 
+setup-agents:
+	@echo "Installing Ollama (if not present)..."
+	@which ollama > /dev/null 2>&1 || (echo "Please install Ollama from https://ollama.ai/download" && exit 1)
+	ollama pull gemma4
+	python3 -m venv .venv
+	.venv/bin/pip install requests beautifulsoup4 feedparser
+	@echo "Agent setup complete"
+
+agent-train:
+	@echo "Exporting training data and creating model..."
+	CGO_ENABLED=1 go run ./cmd/stocktopus -train
+	@echo "Training complete"
+
 clean:
-	rm -rf bin/
+	rm -rf bin/ stocktopus.db

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
-.PHONY: dev build test smoke clean setup-agents agent-train
+.PHONY: dev build test smoke clean setup-agents agent-train lint-js
 
 dev: build
 	./bin/stocktopus
 
-build:
+lint-js:
+	@node --check internal/server/static/terminal.js 2>&1 && echo "terminal.js OK" || (echo "terminal.js has syntax errors" && exit 1)
+	@node --check internal/server/static/info.js 2>&1 && echo "info.js OK" || (echo "info.js has syntax errors" && exit 1)
+	@node --check internal/server/static/chart.js 2>&1 && echo "chart.js OK" || (echo "chart.js has syntax errors" && exit 1)
+
+build: lint-js
 	CGO_ENABLED=1 go build -o bin/stocktopus ./cmd/stocktopus
 
 test:

--- a/README.md
+++ b/README.md
@@ -106,3 +106,7 @@ Uses [Financial Modeling Prep](https://financialmodelingprep.com/) stable API fo
 - Historical EOD data (`/stable/historical-price-eod/full`)
 - News across 6 categories (`/stable/news/*`)
 - Security search by ticker and name (`/stable/search-symbol`, `/stable/search-name`)
+
+## Credits
+
+- Charts powered by [TradingView Lightweight Charts](https://www.tradingview.com/lightweight-charts/) (Apache 2.0)

--- a/agents/rss_news.py
+++ b/agents/rss_news.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""RSS news agent — aggregates financial news from RSS feeds filtered by company."""
+
+import json
+import sys
+import feedparser
+
+# Major financial news RSS feeds
+FEEDS = [
+    "https://feeds.finance.yahoo.com/rss/2.0/headline?s={symbol}&region=US&lang=en-US",
+    "https://www.investing.com/rss/news.rss",
+    "https://feeds.marketwatch.com/marketwatch/topstories/",
+]
+
+def fetch_feed(url, symbol, max_items=5):
+    """Fetch and filter an RSS feed for mentions of the symbol."""
+    try:
+        feed = feedparser.parse(url)
+        results = []
+        symbol_lower = symbol.lower()
+
+        for entry in feed.entries[:20]:
+            title = entry.get("title", "")
+            summary = entry.get("summary", entry.get("description", ""))
+            link = entry.get("link", "")
+
+            # Check if entry mentions the symbol
+            text = (title + " " + summary).lower()
+            if symbol_lower in text or symbol.upper() in title:
+                results.append({
+                    "title": title,
+                    "summary": summary[:300] if summary else "",
+                    "url": link,
+                    "published": entry.get("published", ""),
+                    "source": feed.feed.get("title", url),
+                })
+
+            if len(results) >= max_items:
+                break
+
+        return results
+    except Exception as e:
+        return [{"error": str(e), "feed": url}]
+
+def main():
+    if len(sys.argv) < 2:
+        print(json.dumps({"error": "no symbol provided"}))
+        sys.exit(1)
+
+    symbol = sys.argv[1]
+    all_articles = []
+    sources = []
+
+    for feed_url in FEEDS:
+        url = feed_url.format(symbol=symbol)
+        articles = fetch_feed(url, symbol)
+        for a in articles:
+            if "error" not in a:
+                all_articles.append(a)
+                if a.get("url"):
+                    sources.append(a["url"])
+
+    output = {
+        "symbol": symbol,
+        "source": "rss_news",
+        "articles": all_articles,
+        "sources": sources,
+        "article_count": len(all_articles),
+    }
+
+    print(json.dumps(output))
+
+if __name__ == "__main__":
+    main()

--- a/agents/sec_filings.py
+++ b/agents/sec_filings.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""SEC EDGAR agent — fetches recent SEC filings for a company."""
+
+import json
+import sys
+import requests
+
+EDGAR_SEARCH = "https://efts.sec.gov/LATEST/search-index?q=%22{company}%22&dateRange=custom&startdt=2025-01-01&forms=10-K,10-Q,8-K&hits.hits.total=5"
+EDGAR_COMPANY = "https://data.sec.gov/submissions/CIK{cik}.json"
+
+# Common CIK lookups (extend as needed)
+CIK_MAP = {
+    "AAPL": "0000320193",
+    "MSFT": "0000789019",
+    "GOOGL": "0001652044",
+    "AMZN": "0001018724",
+    "META": "0001326801",
+    "TSLA": "0001318605",
+    "NVDA": "0001045810",
+    "JPM": "0000019617",
+}
+
+HEADERS = {
+    "User-Agent": "Stocktopus Research Agent research@stocktopus.dev",
+    "Accept": "application/json",
+}
+
+def fetch_filings(symbol):
+    """Fetch recent SEC filings from EDGAR."""
+    cik = CIK_MAP.get(symbol.upper())
+    if not cik:
+        return {"filings": [], "note": f"CIK not found for {symbol}, skipping SEC lookup"}
+
+    try:
+        url = f"https://data.sec.gov/submissions/CIK{cik}.json"
+        resp = requests.get(url, headers=HEADERS, timeout=10)
+        if resp.status_code != 200:
+            return {"error": f"EDGAR returned {resp.status_code}"}
+
+        data = resp.json()
+        recent = data.get("filings", {}).get("recent", {})
+
+        forms = recent.get("form", [])
+        dates = recent.get("filingDate", [])
+        descriptions = recent.get("primaryDocument", [])
+        accessions = recent.get("accessionNumber", [])
+
+        filings = []
+        target_forms = {"10-K", "10-Q", "8-K", "10-K/A", "10-Q/A"}
+
+        for i in range(min(len(forms), 20)):
+            if forms[i] in target_forms:
+                accession_clean = accessions[i].replace("-", "")
+                filing_url = f"https://www.sec.gov/Archives/edgar/data/{cik}/{accession_clean}/{descriptions[i]}"
+                filings.append({
+                    "form": forms[i],
+                    "date": dates[i],
+                    "document": descriptions[i],
+                    "url": filing_url,
+                })
+            if len(filings) >= 5:
+                break
+
+        return {
+            "companyName": data.get("name", ""),
+            "cik": cik,
+            "filings": filings,
+        }
+
+    except Exception as e:
+        return {"error": str(e)}
+
+def main():
+    if len(sys.argv) < 2:
+        print(json.dumps({"error": "no symbol provided"}))
+        sys.exit(1)
+
+    symbol = sys.argv[1]
+    result = fetch_filings(symbol)
+
+    output = {
+        "symbol": symbol,
+        "source": "sec_filings",
+        "sources": [f.get("url", "") for f in result.get("filings", [])],
+        **result,
+    }
+
+    print(json.dumps(output))
+
+if __name__ == "__main__":
+    main()

--- a/agents/social_sentiment.py
+++ b/agents/social_sentiment.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Social sentiment agent — gathers public social media mentions via Bluesky AT Protocol."""
+
+import json
+import sys
+import requests
+
+BSKY_SEARCH = "https://public.api.bsky.app/xrpc/app.bsky.feed.searchPosts"
+
+def search_bluesky(query, limit=10):
+    """Search Bluesky public posts."""
+    try:
+        resp = requests.get(
+            BSKY_SEARCH,
+            params={"q": query, "limit": limit, "sort": "latest"},
+            timeout=10,
+        )
+        if resp.status_code != 200:
+            return []
+
+        data = resp.json()
+        posts = []
+        for post in data.get("posts", []):
+            record = post.get("record", {})
+            author = post.get("author", {})
+            posts.append({
+                "text": record.get("text", ""),
+                "author": author.get("handle", ""),
+                "displayName": author.get("displayName", ""),
+                "createdAt": record.get("createdAt", ""),
+                "likes": post.get("likeCount", 0),
+                "reposts": post.get("repostCount", 0),
+            })
+        return posts
+    except Exception as e:
+        return [{"error": str(e)}]
+
+def simple_sentiment(text):
+    """Very basic keyword sentiment scoring."""
+    positive = ["bullish", "buy", "growth", "strong", "beat", "upgrade", "positive",
+                "opportunity", "momentum", "outperform", "breakout", "surge"]
+    negative = ["bearish", "sell", "decline", "weak", "miss", "downgrade", "negative",
+                "risk", "crash", "underperform", "drop", "warning"]
+
+    text_lower = text.lower()
+    pos = sum(1 for w in positive if w in text_lower)
+    neg = sum(1 for w in negative if w in text_lower)
+    total = pos + neg
+    if total == 0:
+        return 0
+    return (pos - neg) / total
+
+def main():
+    if len(sys.argv) < 2:
+        print(json.dumps({"error": "no symbol provided"}))
+        sys.exit(1)
+
+    symbol = sys.argv[1]
+
+    # Search with different queries
+    queries = [f"${symbol}", f"{symbol} stock"]
+    all_posts = []
+
+    for query in queries:
+        posts = search_bluesky(query)
+        for p in posts:
+            if "error" not in p:
+                all_posts.append(p)
+
+    # Compute aggregate sentiment
+    sentiments = [simple_sentiment(p["text"]) for p in all_posts if p.get("text")]
+    avg_sentiment = sum(sentiments) / len(sentiments) if sentiments else 0
+
+    # Top posts by engagement
+    all_posts.sort(key=lambda p: p.get("likes", 0) + p.get("reposts", 0), reverse=True)
+
+    output = {
+        "symbol": symbol,
+        "source": "social_sentiment",
+        "platform": "bluesky",
+        "posts": all_posts[:10],
+        "aggregateSentiment": round(avg_sentiment, 3),
+        "postCount": len(all_posts),
+        "sources": ["https://bsky.app"],
+    }
+
+    print(json.dumps(output))
+
+if __name__ == "__main__":
+    main()

--- a/agents/web_search.py
+++ b/agents/web_search.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Web search agent — searches DuckDuckGo for company info and summarizes results."""
+
+import json
+import sys
+import requests
+from bs4 import BeautifulSoup
+
+def search_ddg(query, num_results=5):
+    """Search DuckDuckGo and return results."""
+    url = "https://html.duckduckgo.com/html/"
+    headers = {"User-Agent": "Mozilla/5.0 (Stocktopus Research Agent)"}
+
+    try:
+        resp = requests.post(url, data={"q": query}, headers=headers, timeout=10)
+        soup = BeautifulSoup(resp.text, "html.parser")
+
+        results = []
+        for r in soup.select(".result__body")[:num_results]:
+            title_el = r.select_one(".result__title")
+            snippet_el = r.select_one(".result__snippet")
+            link_el = r.select_one(".result__url")
+
+            results.append({
+                "title": title_el.get_text(strip=True) if title_el else "",
+                "snippet": snippet_el.get_text(strip=True) if snippet_el else "",
+                "url": link_el.get_text(strip=True) if link_el else "",
+            })
+        return results
+    except Exception as e:
+        return [{"error": str(e)}]
+
+def main():
+    if len(sys.argv) < 2:
+        print(json.dumps({"error": "no symbol provided"}))
+        sys.exit(1)
+
+    symbol = sys.argv[1]
+
+    queries = [
+        f"{symbol} stock analysis 2026",
+        f"{symbol} company risks opportunities",
+        f"{symbol} earnings outlook",
+    ]
+
+    all_results = []
+    sources = []
+
+    for query in queries:
+        results = search_ddg(query)
+        for r in results:
+            if "error" not in r:
+                all_results.append(r)
+                if r.get("url"):
+                    sources.append(r["url"])
+
+    output = {
+        "symbol": symbol,
+        "source": "web_search",
+        "results": all_results,
+        "sources": sources,
+        "query_count": len(queries),
+        "result_count": len(all_results),
+    }
+
+    print(json.dumps(output))
+
+if __name__ == "__main__":
+    main()

--- a/cmd/stocktopus/main.go
+++ b/cmd/stocktopus/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
+	"stocktopus/internal/agent"
 	"stocktopus/internal/hub"
 	"stocktopus/internal/news"
 	"stocktopus/internal/newspoller"
@@ -17,6 +19,7 @@ import (
 	"stocktopus/internal/provider/financialmodelingprep"
 	"stocktopus/internal/provider/polygon"
 	"stocktopus/internal/server"
+	"stocktopus/internal/store"
 )
 
 func main() {
@@ -83,7 +86,56 @@ func main() {
 	go poll.Run(appCtx)
 	go np.Run(appCtx)
 
-	srv, err := server.New(server.Config{Port: 8080, Host: "localhost"}, h, debug, poll, newsClient, logger)
+	// Agent pipeline
+	dbPath := "stocktopus.db"
+	if envDB := os.Getenv("STOCKTOPUS_DB"); envDB != "" {
+		dbPath = envDB
+	}
+	st, err := store.New(dbPath)
+	if err != nil {
+		slog.Warn("failed to open intelligence store (continuing without agents)", "error", err)
+	}
+
+	var pipeline *agent.Pipeline
+	if st != nil {
+		geminiKey := os.Getenv("GEMINI_API_KEY")
+		ollamaHost := os.Getenv("OLLAMA_HOST")
+		ollamaModel := os.Getenv("OLLAMA_MODEL")
+		if ollamaModel == "" {
+			ollamaModel = "gemma4"
+		}
+		agentWorkers := 3
+		cacheTTL := 24 * time.Hour
+		if envTTL := os.Getenv("AGENT_CACHE_TTL"); envTTL != "" {
+			if d, err := time.ParseDuration(envTTL); err == nil {
+				cacheTTL = d
+			}
+		}
+
+		pipeline = agent.NewPipeline(agent.PipelineConfig{
+			GeminiAPIKey: geminiKey,
+			OllamaHost:   ollamaHost,
+			OllamaModel:  ollamaModel,
+			NumWorkers:   agentWorkers,
+			CacheTTL:     cacheTTL,
+			PythonPath:   "python3",
+			AgentsDir:    "agents",
+		}, st, logger)
+
+		// Publish agent status updates via hub
+		pipeline.SetStatusCallback(func(status agent.PipelineStatus) {
+			data, _ := json.Marshal(map[string]interface{}{
+				"type":   "agent_status",
+				"topic":  "agent:" + status.Symbol,
+				"status": status,
+			})
+			h.Publish("agent:"+status.Symbol, data)
+		})
+
+		slog.Info("agent pipeline ready", "ollamaModel", ollamaModel, "cacheTTL", cacheTTL)
+	}
+
+	srv, err := server.New(server.Config{Port: 8080, Host: "localhost"}, h, debug, poll, newsClient, pipeline, logger)
 	if err != nil {
 		slog.Error("failed to create server", "error", err)
 		os.Exit(1)

--- a/cmd/stocktopus/main.go
+++ b/cmd/stocktopus/main.go
@@ -65,6 +65,7 @@ func main() {
 
 	// News client + news poller
 	newsClient := news.New(apiKey, "https://financialmodelingprep.com")
+	newsClient.SetGeminiKey(os.Getenv("GEMINI_API_KEY"))
 
 	newsPollInterval := 2 * time.Minute
 	if envInterval := os.Getenv("NEWS_POLL_INTERVAL"); envInterval != "" {

--- a/docs/TODO-security-types.md
+++ b/docs/TODO-security-types.md
@@ -1,0 +1,87 @@
+# TODO: Security Type Handling
+
+The info page currently assumes all securities are US equities. Crypto, forex, indices, and ETFs need different treatment.
+
+## Immediate Fix
+- [ ] Detect security type from FMP profile response (`exchange` field: "CRYPTO", "FOREX", "INDEX", etc.)
+- [ ] Gracefully handle missing data — don't crash if financials/estimates return empty
+- [ ] Show appropriate tabs per security type (hide irrelevant ones)
+
+## Security Types & Relevant Data
+
+### Stocks (current default)
+- Overview: profile, key metrics, ratios
+- Financials: income, balance sheet, cash flow
+- Estimates: analyst forecasts
+- News: press releases, stock news
+- AI Analysis: full pipeline
+
+### Crypto (e.g. BTCUSD, ETHUSD)
+- **Show**: Price, market cap, volume, 24h change, 7d change
+- **Show**: On-chain metrics (if available from API)
+- **Show**: Social sentiment (Bluesky, Reddit mentions)
+- **Show**: Crypto-specific news
+- **Show**: Historical chart (already works via EOD)
+- **Hide**: Financials (no income statement for BTC)
+- **Hide**: Estimates (no analyst EPS forecasts)
+- **Hide**: SEC filings
+- **Agent**: Skip SEC agent, focus on social + web search + news
+
+### Indices (e.g. ^DJI, ^GSPC, ^IXIC)
+- **Show**: Price, change, components list
+- **Show**: Historical chart
+- **Show**: Sector breakdown
+- **Show**: Top gainers/losers in index
+- **Hide**: Financials (no single company)
+- **Hide**: Estimates
+- **Agent**: Macro analysis, sector sentiment
+
+### Forex (e.g. EURUSD, GBPUSD)
+- **Show**: Exchange rate, bid/ask, daily range
+- **Show**: Historical chart
+- **Show**: Forex-specific news
+- **Show**: Central bank rate context
+- **Hide**: Financials, estimates, SEC
+- **Agent**: Macro/geopolitical analysis
+
+### ETFs (e.g. SPY, QQQ, VOO)
+- **Show**: Price, NAV, expense ratio, holdings
+- **Show**: Top holdings list
+- **Show**: Sector allocation
+- **Show**: Historical chart, performance vs benchmark
+- **Show**: Dividend info
+- **Hide**: Individual company financials (show aggregate)
+- **Agent**: Holdings analysis, sector outlook
+
+## Implementation Approach
+
+### Phase 1: Don't crash
+- Detect type from profile `exchange` field
+- Wrap all tab loaders in error handling
+- Hide tabs that will return empty data
+- Show "Not available for {type}" instead of errors
+
+### Phase 2: Type-specific views
+- Create `info-crypto.js`, `info-index.js` etc. (or sections within info.js)
+- Route to correct view based on detected type
+- Type-specific agent task lists (skip SEC for crypto, etc.)
+
+### Phase 3: Type-specific agents
+- Crypto agent: on-chain data, DEX volumes, whale tracking
+- Index agent: component analysis, sector rotation
+- Forex agent: central bank calendar, rate differentials
+
+## FMP Endpoints by Type
+
+### Crypto
+- `/stable/cryptocurrency/quote?symbol=BTCUSD` — crypto quote
+- `/stable/cryptocurrency/daily?symbol=BTCUSD` — daily prices
+- `/stable/news/crypto?symbols=BTCUSD` — crypto news
+
+### Index
+- `/stable/quote?symbol=^GSPC` — index quote
+- `/stable/index-constituent?symbol=dowjones` — index components
+
+### ETF
+- `/stable/etf/holder?symbol=SPY` — ETF holdings
+- `/stable/etf/info?symbol=SPY` — ETF info

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-playground/validator/v10 v10.23.0 // indirect
 	github.com/go-resty/resty/v2 v2.13.1 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.42 // indirect
 	golang.org/x/crypto v0.23.0 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/jarcoal/httpmock v1.4.0 h1:BvhqnH0JAYbNudL2GMJKgOHe2CtKlzJ/5rWKyp+hc2
 github.com/jarcoal/httpmock v1.4.0/go.mod h1:ftW1xULwo+j0R0JJkJIIi7UKigZUXCLLanykgjwBXL0=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
+github.com/mattn/go-sqlite3 v1.14.42 h1:MigqEP4ZmHw3aIdIT7T+9TLa90Z6smwcthx+Azv4Cgo=
+github.com/mattn/go-sqlite3 v1.14.42/go.mod h1:pjEuOr8IwzLJP2MfGeTb0A35jauH+C2kbHKBr7yXKVQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polygon-io/client-go v1.16.13 h1:OB2Iy37AKws3tL11lurgluKc/ItFr4eI6JRQ9EriAU4=

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -130,10 +131,15 @@ func (p *Pipeline) OllamaAvailable() bool {
 	return p.workers.OllamaAvailable()
 }
 
-// Analyze triggers an analysis for a symbol. Returns immediately.
-// Results are stored in SQLite and pushed via status callback.
+// Analyze triggers an analysis for a symbol at the given depth.
+// depth=1 means this is a parent that can spawn competitor analyses.
+// depth=0 means this is a child — no further spawning.
 // Uses a detached context so the pipeline survives after the HTTP request ends.
 func (p *Pipeline) Analyze(_ context.Context, symbol string, fmpData json.RawMessage) {
+	p.analyzeAtDepth(symbol, fmpData, 1)
+}
+
+func (p *Pipeline) analyzeAtDepth(symbol string, fmpData json.RawMessage, depth int) {
 	p.mu.Lock()
 	if existing, ok := p.active[symbol]; ok && existing.Status == StatusRunning {
 		p.mu.Unlock()
@@ -148,15 +154,14 @@ func (p *Pipeline) Analyze(_ context.Context, symbol string, fmpData json.RawMes
 	p.active[symbol] = status
 	p.mu.Unlock()
 
-	// Use a background context with a generous timeout — not tied to HTTP request
 	bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	go func() {
 		defer cancel()
-		p.runPipeline(bgCtx, symbol, fmpData, status)
+		p.runPipeline(bgCtx, symbol, fmpData, status, depth)
 	}()
 }
 
-func (p *Pipeline) runPipeline(ctx context.Context, symbol string, fmpData json.RawMessage, status *PipelineStatus) {
+func (p *Pipeline) runPipeline(ctx context.Context, symbol string, fmpData json.RawMessage, status *PipelineStatus, depth int) {
 	defer func() {
 		if r := recover(); r != nil {
 			p.logger.Error("pipeline panic", "symbol", symbol, "panic", r)
@@ -243,7 +248,24 @@ func (p *Pipeline) runPipeline(ctx context.Context, symbol string, fmpData json.
 	status.FinishedAt = time.Now()
 	p.emitStatus(*status)
 
-	p.logger.Info("pipeline complete", "symbol", symbol, "duration", time.Since(status.StartedAt))
+	p.logger.Info("pipeline complete", "symbol", symbol, "depth", depth, "duration", time.Since(status.StartedAt))
+
+	// Spawn competitor analyses one level deep
+	if depth > 0 && analysis.Competitors != nil {
+		for _, comp := range analysis.Competitors {
+			comp = strings.TrimSpace(comp)
+			if comp == "" || comp == symbol {
+				continue
+			}
+			// Skip if already cached
+			if p.store.IsFresh(comp, p.cacheTTL) {
+				p.logger.Debug("competitor already cached", "competitor", comp)
+				continue
+			}
+			p.logger.Info("spawning competitor analysis", "parent", symbol, "competitor", comp)
+			p.analyzeAtDepth(comp, nil, 0) // depth=0: no further spawning
+		}
+	}
 }
 
 func (p *Pipeline) emitStatus(status PipelineStatus) {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -131,6 +131,22 @@ func (p *Pipeline) OllamaAvailable() bool {
 	return p.workers.OllamaAvailable()
 }
 
+// GetUsage returns the orchestrator's API usage stats.
+func (p *Pipeline) GetUsage() UsageStats {
+	return p.orchestrator.GetUsage()
+}
+
+// GetAllStatuses returns all active/recent pipeline statuses.
+func (p *Pipeline) GetAllStatuses() []PipelineStatus {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	result := make([]PipelineStatus, 0, len(p.active))
+	for _, s := range p.active {
+		result = append(result, *s)
+	}
+	return result
+}
+
 // Analyze triggers an analysis for a symbol at the given depth.
 // depth=1 means this is a parent that can spawn competitor analyses.
 // depth=0 means this is a child — no further spawning.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,0 +1,253 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"stocktopus/internal/store"
+)
+
+// TaskType identifies what kind of work a task does.
+type TaskType string
+
+const (
+	TaskFMPProfile     TaskType = "fmp_profile"
+	TaskFMPFinancials  TaskType = "fmp_financials"
+	TaskWebSearch      TaskType = "web_search"
+	TaskSocialSentiment TaskType = "social_sentiment"
+	TaskRSSNews        TaskType = "rss_news"
+	TaskSECFilings     TaskType = "sec_filings"
+	TaskSynthesize     TaskType = "synthesize"
+)
+
+// TaskStatus tracks a task's progress.
+type TaskStatus string
+
+const (
+	StatusPending  TaskStatus = "pending"
+	StatusRunning  TaskStatus = "running"
+	StatusComplete TaskStatus = "complete"
+	StatusFailed   TaskStatus = "failed"
+)
+
+// Task represents a unit of work for an agent.
+type Task struct {
+	ID       string          `json:"id"`
+	Type     TaskType        `json:"type"`
+	Symbol   string          `json:"symbol"`
+	Prompt   string          `json:"prompt"`
+	Context  json.RawMessage `json:"context,omitempty"`
+	Result   json.RawMessage `json:"result,omitempty"`
+	Status   TaskStatus      `json:"status"`
+	Error    string          `json:"error,omitempty"`
+	Duration time.Duration   `json:"duration,omitempty"`
+}
+
+// PipelineStatus represents the overall state of a company analysis.
+type PipelineStatus struct {
+	Symbol     string     `json:"symbol"`
+	Status     TaskStatus `json:"status"`
+	Tasks      []Task     `json:"tasks"`
+	StartedAt  time.Time  `json:"startedAt"`
+	FinishedAt time.Time  `json:"finishedAt,omitempty"`
+	Error      string     `json:"error,omitempty"`
+}
+
+// StatusCallback is called when pipeline status changes.
+type StatusCallback func(status PipelineStatus)
+
+// Pipeline orchestrates the full analysis of a company.
+type Pipeline struct {
+	orchestrator *Orchestrator
+	workers      *WorkerPool
+	store        *store.Store
+	logger       *slog.Logger
+	cacheTTL     time.Duration
+
+	// Active pipelines
+	active map[string]*PipelineStatus
+	mu     sync.RWMutex
+
+	onStatus StatusCallback
+}
+
+// PipelineConfig holds configuration for the pipeline.
+type PipelineConfig struct {
+	GeminiAPIKey string
+	OllamaHost   string
+	OllamaModel  string
+	NumWorkers   int
+	CacheTTL     time.Duration
+	PythonPath   string
+	AgentsDir    string
+}
+
+func NewPipeline(cfg PipelineConfig, st *store.Store, logger *slog.Logger) *Pipeline {
+	orch := NewOrchestrator(cfg.GeminiAPIKey, logger)
+	workers := NewWorkerPool(cfg.OllamaHost, cfg.OllamaModel, cfg.NumWorkers, cfg.PythonPath, cfg.AgentsDir, logger)
+
+	return &Pipeline{
+		orchestrator: orch,
+		workers:      workers,
+		store:        st,
+		logger:       logger.With("component", "pipeline"),
+		cacheTTL:     cfg.CacheTTL,
+		active:       make(map[string]*PipelineStatus),
+	}
+}
+
+// SetStatusCallback sets the function called on status changes.
+func (p *Pipeline) SetStatusCallback(cb StatusCallback) {
+	p.onStatus = cb
+}
+
+// GetStatus returns the current pipeline status for a symbol.
+func (p *Pipeline) GetStatus(symbol string) *PipelineStatus {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.active[symbol]
+}
+
+// GetCached returns cached intelligence from the store.
+func (p *Pipeline) GetCached(symbol string) (*store.CompanyIntelligence, error) {
+	if p.store.IsFresh(symbol, p.cacheTTL) {
+		return p.store.Get(symbol)
+	}
+	return nil, nil
+}
+
+// GetDirect returns intelligence from the store without freshness check.
+func (p *Pipeline) GetDirect(symbol string) (*store.CompanyIntelligence, error) {
+	return p.store.Get(symbol)
+}
+
+// OllamaAvailable checks if the Ollama worker pool can reach its backend.
+func (p *Pipeline) OllamaAvailable() bool {
+	return p.workers.OllamaAvailable()
+}
+
+// Analyze triggers an analysis for a symbol. Returns immediately.
+// Results are stored in SQLite and pushed via status callback.
+// Uses a detached context so the pipeline survives after the HTTP request ends.
+func (p *Pipeline) Analyze(_ context.Context, symbol string, fmpData json.RawMessage) {
+	p.mu.Lock()
+	if existing, ok := p.active[symbol]; ok && existing.Status == StatusRunning {
+		p.mu.Unlock()
+		return // Already running
+	}
+
+	status := &PipelineStatus{
+		Symbol:    symbol,
+		Status:    StatusRunning,
+		StartedAt: time.Now(),
+	}
+	p.active[symbol] = status
+	p.mu.Unlock()
+
+	// Use a background context with a generous timeout — not tied to HTTP request
+	bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	go func() {
+		defer cancel()
+		p.runPipeline(bgCtx, symbol, fmpData, status)
+	}()
+}
+
+func (p *Pipeline) runPipeline(ctx context.Context, symbol string, fmpData json.RawMessage, status *PipelineStatus) {
+	defer func() {
+		if r := recover(); r != nil {
+			p.logger.Error("pipeline panic", "symbol", symbol, "panic", r)
+			status.Status = StatusFailed
+			status.Error = fmt.Sprintf("panic: %v", r)
+			status.FinishedAt = time.Now()
+			p.emitStatus(*status)
+		}
+	}()
+
+	p.logger.Info("pipeline started", "symbol", symbol)
+
+	// Phase 1: Gather data from multiple sources in parallel
+	tasks := []Task{
+		{ID: "web", Type: TaskWebSearch, Symbol: symbol, Status: StatusPending},
+		{ID: "rss", Type: TaskRSSNews, Symbol: symbol, Status: StatusPending},
+		{ID: "sec", Type: TaskSECFilings, Symbol: symbol, Status: StatusPending},
+		{ID: "social", Type: TaskSocialSentiment, Symbol: symbol, Status: StatusPending},
+	}
+
+	status.Tasks = tasks
+	p.emitStatus(*status)
+
+	// Run all worker tasks in parallel
+	var wg sync.WaitGroup
+	for i := range tasks {
+		wg.Add(1)
+		go func(t *Task) {
+			defer wg.Done()
+			start := time.Now()
+			t.Status = StatusRunning
+			p.emitStatus(*status)
+
+			result, err := p.workers.Execute(ctx, *t)
+			t.Duration = time.Since(start)
+			if err != nil {
+				t.Status = StatusFailed
+				t.Error = err.Error()
+				p.logger.Warn("task failed", "task", t.ID, "symbol", symbol, "error", err)
+			} else {
+				t.Status = StatusComplete
+				t.Result = result
+			}
+			p.emitStatus(*status)
+		}(&tasks[i])
+	}
+	wg.Wait()
+
+	// Phase 2: Synthesize with orchestrator (Gemini)
+	p.logger.Info("synthesizing", "symbol", symbol)
+
+	// Collect all results
+	gathered := map[string]json.RawMessage{
+		"fmp": fmpData,
+	}
+	for _, t := range tasks {
+		if t.Status == StatusComplete && t.Result != nil {
+			gathered[t.ID] = t.Result
+		}
+	}
+
+	gatheredJSON, _ := json.Marshal(gathered)
+	analysis, err := p.orchestrator.Synthesize(ctx, symbol, gatheredJSON)
+	if err != nil {
+		p.logger.Error("synthesis failed", "symbol", symbol, "error", err)
+		status.Status = StatusFailed
+		status.Error = err.Error()
+		status.FinishedAt = time.Now()
+		p.emitStatus(*status)
+		return
+	}
+
+	// Store result
+	if err := p.store.Put(analysis); err != nil {
+		p.logger.Error("store failed", "symbol", symbol, "error", err)
+	}
+
+	// Store training data from this run
+	prompt := "Analyze " + symbol + " given the following data"
+	completion, _ := json.Marshal(analysis)
+	p.store.AddTrainingPair(symbol, prompt, string(completion), "pipeline", 0.8)
+
+	status.Status = StatusComplete
+	status.FinishedAt = time.Now()
+	p.emitStatus(*status)
+
+	p.logger.Info("pipeline complete", "symbol", symbol, "duration", time.Since(status.StartedAt))
+}
+
+func (p *Pipeline) emitStatus(status PipelineStatus) {
+	if p.onStatus != nil {
+		p.onStatus(status)
+	}
+}

--- a/internal/agent/finetune.go
+++ b/internal/agent/finetune.go
@@ -1,0 +1,113 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"stocktopus/internal/store"
+)
+
+// FineTuner manages training data export and Ollama model creation.
+type FineTuner struct {
+	store       *store.Store
+	ollamaModel string
+	outputDir   string
+}
+
+func NewFineTuner(st *store.Store, baseModel, outputDir string) *FineTuner {
+	if baseModel == "" {
+		baseModel = "gemma4"
+	}
+	return &FineTuner{
+		store:       st,
+		ollamaModel: baseModel,
+		outputDir:   outputDir,
+	}
+}
+
+// ExportTrainingData exports training pairs as JSONL for fine-tuning.
+func (ft *FineTuner) ExportTrainingData(minQuality float64) (string, error) {
+	pairs, err := ft.store.ExportTrainingData(minQuality)
+	if err != nil {
+		return "", fmt.Errorf("export: %w", err)
+	}
+
+	if len(pairs) == 0 {
+		return "", fmt.Errorf("no training data above quality threshold %.1f", minQuality)
+	}
+
+	os.MkdirAll(ft.outputDir, 0755)
+	filename := filepath.Join(ft.outputDir, fmt.Sprintf("training-%s.jsonl", time.Now().Format("20060102-150405")))
+
+	f, err := os.Create(filename)
+	if err != nil {
+		return "", fmt.Errorf("create file: %w", err)
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	for _, pair := range pairs {
+		entry := map[string]string{
+			"prompt":     pair.Prompt,
+			"completion": pair.Completion,
+		}
+		if err := enc.Encode(entry); err != nil {
+			return "", fmt.Errorf("encode: %w", err)
+		}
+	}
+
+	return filename, nil
+}
+
+// GenerateModelfile creates an Ollama Modelfile for a fine-tuned model.
+func (ft *FineTuner) GenerateModelfile(version string) (string, error) {
+	os.MkdirAll(ft.outputDir, 0755)
+	modelfile := filepath.Join(ft.outputDir, "Modelfile")
+
+	content := fmt.Sprintf(`FROM %s
+
+SYSTEM """You are a financial analyst AI trained on company analysis data from Stocktopus.
+When given a company symbol and financial data, you produce structured analysis including:
+- Executive summary
+- Sentiment score (-1 to 1)
+- Risk assessment (0-100)
+- Key risks and opportunities
+- Competitor analysis
+- Sector outlook
+
+Always respond with valid JSON matching the requested schema."""
+
+PARAMETER temperature 0.3
+PARAMETER num_predict 4096
+`, ft.ollamaModel)
+
+	if err := os.WriteFile(modelfile, []byte(content), 0644); err != nil {
+		return "", fmt.Errorf("write modelfile: %w", err)
+	}
+
+	return modelfile, nil
+}
+
+// CreateModel creates a new Ollama model from the Modelfile.
+func (ft *FineTuner) CreateModel(version string) error {
+	modelfile, err := ft.GenerateModelfile(version)
+	if err != nil {
+		return err
+	}
+
+	modelName := fmt.Sprintf("stocktopus-gemma-%s", version)
+	cmd := exec.Command("ollama", "create", modelName, "-f", modelfile)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+// TrainingStats returns stats about available training data.
+func (ft *FineTuner) TrainingStats() (int, error) {
+	return ft.store.TrainingDataCount()
+}

--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -8,16 +8,34 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"sync"
 	"time"
 
 	"stocktopus/internal/store"
 )
+
+// UsageStats tracks API usage for cost estimation.
+type UsageStats struct {
+	TotalRequests     int64 `json:"totalRequests"`
+	TotalPromptTokens int64 `json:"totalPromptTokens"`
+	TotalOutputTokens int64 `json:"totalOutputTokens"`
+	TotalTokens       int64 `json:"totalTokens"`
+}
 
 // Orchestrator uses the Gemini API to plan research and synthesize analysis.
 type Orchestrator struct {
 	apiKey string
 	logger *slog.Logger
 	client *http.Client
+	usage  UsageStats
+	mu     sync.Mutex
+}
+
+// GetUsage returns current API usage stats.
+func (o *Orchestrator) GetUsage() UsageStats {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.usage
 }
 
 func NewOrchestrator(geminiAPIKey string, logger *slog.Logger) *Orchestrator {
@@ -148,11 +166,29 @@ func (o *Orchestrator) callGemini(ctx context.Context, prompt string) (string, e
 				} `json:"parts"`
 			} `json:"content"`
 		} `json:"candidates"`
+		UsageMetadata struct {
+			PromptTokenCount     int64 `json:"promptTokenCount"`
+			CandidatesTokenCount int64 `json:"candidatesTokenCount"`
+			TotalTokenCount      int64 `json:"totalTokenCount"`
+		} `json:"usageMetadata"`
 	}
 
 	if err := json.Unmarshal(body, &geminiResp); err != nil {
 		return "", fmt.Errorf("gemini parse: %w", err)
 	}
+
+	// Track usage
+	o.mu.Lock()
+	o.usage.TotalRequests++
+	o.usage.TotalPromptTokens += geminiResp.UsageMetadata.PromptTokenCount
+	o.usage.TotalOutputTokens += geminiResp.UsageMetadata.CandidatesTokenCount
+	o.usage.TotalTokens += geminiResp.UsageMetadata.TotalTokenCount
+	o.mu.Unlock()
+
+	o.logger.Info("gemini usage",
+		"promptTokens", geminiResp.UsageMetadata.PromptTokenCount,
+		"outputTokens", geminiResp.UsageMetadata.CandidatesTokenCount,
+		"totalTokens", geminiResp.UsageMetadata.TotalTokenCount)
 
 	if len(geminiResp.Candidates) == 0 || len(geminiResp.Candidates[0].Content.Parts) == 0 {
 		return "", fmt.Errorf("gemini returned empty response")

--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -1,0 +1,175 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"stocktopus/internal/store"
+)
+
+// Orchestrator uses the Gemini API to plan research and synthesize analysis.
+type Orchestrator struct {
+	apiKey string
+	logger *slog.Logger
+	client *http.Client
+}
+
+func NewOrchestrator(geminiAPIKey string, logger *slog.Logger) *Orchestrator {
+	return &Orchestrator{
+		apiKey: geminiAPIKey,
+		logger: logger.With("component", "orchestrator"),
+		client: &http.Client{Timeout: 180 * time.Second},
+	}
+}
+
+// Synthesize takes all gathered data and produces a structured company analysis.
+func (o *Orchestrator) Synthesize(ctx context.Context, symbol string, gatheredData json.RawMessage) (*store.CompanyIntelligence, error) {
+	prompt := fmt.Sprintf(`You are a senior financial analyst. Analyze the company %s using the data provided below.
+
+Return ONLY valid JSON (no markdown, no code blocks) with this exact structure:
+{
+  "summary": "One paragraph executive summary of the company's current position",
+  "sentiment": <number from -1.0 (very bearish) to 1.0 (very bullish)>,
+  "riskScore": <number from 0 (low risk) to 100 (extreme risk)>,
+  "confidence": <number from 0.0 to 1.0 indicating your confidence in this analysis>,
+  "keyRisks": ["risk 1", "risk 2", "risk 3"],
+  "opportunities": ["opportunity 1", "opportunity 2", "opportunity 3"],
+  "competitors": ["competitor ticker 1", "competitor ticker 2", "competitor ticker 3"],
+  "sectorAnalysis": "Brief analysis of the sector outlook",
+  "catalysts": ["upcoming catalyst 1", "upcoming catalyst 2"],
+  "technicalOutlook": "Brief technical analysis based on price data"
+}
+
+Data:
+%s`, symbol, string(gatheredData))
+
+	response, err := o.callGemini(ctx, prompt)
+	if err != nil {
+		return nil, fmt.Errorf("gemini synthesis: %w", err)
+	}
+
+	// Parse the structured response
+	var analysis struct {
+		Summary         string   `json:"summary"`
+		Sentiment       float64  `json:"sentiment"`
+		RiskScore       float64  `json:"riskScore"`
+		Confidence      float64  `json:"confidence"`
+		KeyRisks        []string `json:"keyRisks"`
+		Opportunities   []string `json:"opportunities"`
+		Competitors     []string `json:"competitors"`
+		SectorAnalysis  string   `json:"sectorAnalysis"`
+		Catalysts       []string `json:"catalysts"`
+		TechnicalOutlook string  `json:"technicalOutlook"`
+	}
+
+	if err := json.Unmarshal([]byte(response), &analysis); err != nil {
+		o.logger.Warn("failed to parse structured analysis, using raw", "error", err)
+		// Fall back to storing raw text
+		return &store.CompanyIntelligence{
+			Symbol:       symbol,
+			Summary:      response,
+			Sentiment:    0,
+			RiskScore:    50,
+			Confidence:   0.3,
+			GeneratedAt:  time.Now().UTC(),
+			ModelVersion: "gemini-fallback",
+		}, nil
+	}
+
+	// Build full analysis JSON
+	fullAnalysis, _ := json.Marshal(analysis)
+
+	return &store.CompanyIntelligence{
+		Symbol:        symbol,
+		Summary:       analysis.Summary,
+		Sentiment:     analysis.Sentiment,
+		RiskScore:     analysis.RiskScore,
+		Confidence:    analysis.Confidence,
+		KeyRisks:      analysis.KeyRisks,
+		Opportunities: analysis.Opportunities,
+		Competitors:   analysis.Competitors,
+		Analysis:      fullAnalysis,
+		GeneratedAt:   time.Now(),
+		ModelVersion:  "gemini-orchestrated",
+	}, nil
+}
+
+// callGemini sends a prompt to the Gemini API and returns the text response.
+func (o *Orchestrator) callGemini(ctx context.Context, prompt string) (string, error) {
+	url := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent?key=%s", o.apiKey)
+
+	reqBody, _ := json.Marshal(map[string]interface{}{
+		"contents": []map[string]interface{}{
+			{
+				"parts": []map[string]string{
+					{"text": prompt},
+				},
+			},
+		},
+		"generationConfig": map[string]interface{}{
+			"temperature":     0.3,
+			"maxOutputTokens": 4096,
+		},
+	})
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("gemini request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("gemini read: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("gemini %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Parse Gemini response
+	var geminiResp struct {
+		Candidates []struct {
+			Content struct {
+				Parts []struct {
+					Text string `json:"text"`
+				} `json:"parts"`
+			} `json:"content"`
+		} `json:"candidates"`
+	}
+
+	if err := json.Unmarshal(body, &geminiResp); err != nil {
+		return "", fmt.Errorf("gemini parse: %w", err)
+	}
+
+	if len(geminiResp.Candidates) == 0 || len(geminiResp.Candidates[0].Content.Parts) == 0 {
+		return "", fmt.Errorf("gemini returned empty response")
+	}
+
+	text := geminiResp.Candidates[0].Content.Parts[0].Text
+
+	// Strip markdown code blocks if present
+	if len(text) > 7 && text[:7] == "```json" {
+		text = text[7:]
+	}
+	if len(text) > 3 && text[:3] == "```" {
+		text = text[3:]
+	}
+	if len(text) > 3 && text[len(text)-3:] == "```" {
+		text = text[:len(text)-3]
+	}
+
+	return text, nil
+}

--- a/internal/agent/worker.go
+++ b/internal/agent/worker.go
@@ -1,0 +1,174 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// WorkerPool manages Ollama workers and Python agent scripts.
+type WorkerPool struct {
+	ollamaHost  string
+	ollamaModel string
+	pythonPath  string
+	agentsDir   string
+	logger      *slog.Logger
+	client      *http.Client
+	sem         chan struct{} // concurrency limiter
+}
+
+func NewWorkerPool(ollamaHost, ollamaModel string, numWorkers int, pythonPath, agentsDir string, logger *slog.Logger) *WorkerPool {
+	if ollamaHost == "" {
+		ollamaHost = "http://localhost:11434"
+	}
+	if ollamaModel == "" {
+		ollamaModel = "gemma4"
+	}
+	if pythonPath == "" {
+		pythonPath = "python3"
+	}
+	if numWorkers <= 0 {
+		numWorkers = 3
+	}
+
+	return &WorkerPool{
+		ollamaHost:  ollamaHost,
+		ollamaModel: ollamaModel,
+		pythonPath:  pythonPath,
+		agentsDir:   agentsDir,
+		logger:      logger.With("component", "worker-pool"),
+		client:      &http.Client{Timeout: 120 * time.Second},
+		sem:         make(chan struct{}, numWorkers),
+	}
+}
+
+// Execute runs a task either via Python script or Ollama.
+func (wp *WorkerPool) Execute(ctx context.Context, task Task) (json.RawMessage, error) {
+	// Acquire semaphore
+	select {
+	case wp.sem <- struct{}{}:
+		defer func() { <-wp.sem }()
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	switch task.Type {
+	case TaskWebSearch:
+		return wp.runPythonAgent(ctx, "web_search.py", task.Symbol)
+	case TaskRSSNews:
+		return wp.runPythonAgent(ctx, "rss_news.py", task.Symbol)
+	case TaskSECFilings:
+		return wp.runPythonAgent(ctx, "sec_filings.py", task.Symbol)
+	case TaskSocialSentiment:
+		return wp.runPythonAgent(ctx, "social_sentiment.py", task.Symbol)
+	default:
+		return wp.callOllama(ctx, task.Prompt)
+	}
+}
+
+// runPythonAgent executes a Python script and returns its JSON output.
+func (wp *WorkerPool) runPythonAgent(ctx context.Context, script, symbol string) (json.RawMessage, error) {
+	scriptPath := filepath.Join(wp.agentsDir, script)
+	venvPython := filepath.Join(wp.agentsDir, "..", ".venv", "bin", "python3")
+
+	// Prefer venv python if available
+	pythonCmd := wp.pythonPath
+	if _, err := exec.LookPath(venvPython); err == nil {
+		pythonCmd = venvPython
+	}
+
+	cmd := exec.CommandContext(ctx, pythonCmd, scriptPath, symbol)
+	cmd.Env = append(cmd.Environ(),
+		"OLLAMA_HOST="+wp.ollamaHost,
+		"OLLAMA_MODEL="+wp.ollamaModel,
+	)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	wp.logger.Debug("running agent", "script", script, "symbol", symbol)
+
+	if err := cmd.Run(); err != nil {
+		wp.logger.Warn("agent failed", "script", script, "stderr", stderr.String(), "error", err)
+		// Return empty result rather than failing the whole pipeline
+		return json.RawMessage(`{"error":"` + script + ` failed: ` + err.Error() + `"}`), nil
+	}
+
+	output := stdout.Bytes()
+	if !json.Valid(output) {
+		wp.logger.Warn("agent returned invalid JSON", "script", script, "output", stdout.String())
+		return json.RawMessage(`{"error":"invalid JSON from ` + script + `","raw":"` + stdout.String() + `"}`), nil
+	}
+
+	return json.RawMessage(output), nil
+}
+
+// callOllama sends a prompt to the local Ollama instance.
+func (wp *WorkerPool) callOllama(ctx context.Context, prompt string) (json.RawMessage, error) {
+	reqBody, _ := json.Marshal(map[string]interface{}{
+		"model":  wp.ollamaModel,
+		"prompt": prompt,
+		"stream": false,
+		"options": map[string]interface{}{
+			"temperature": 0.3,
+			"num_predict": 2048,
+		},
+	})
+
+	req, err := http.NewRequestWithContext(ctx, "POST", wp.ollamaHost+"/api/generate", bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("ollama request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := wp.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("ollama call: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("ollama read: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ollama %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Extract the response text
+	var ollamaResp struct {
+		Response string `json:"response"`
+	}
+	if err := json.Unmarshal(body, &ollamaResp); err != nil {
+		return nil, fmt.Errorf("ollama parse: %w", err)
+	}
+
+	return json.RawMessage(`{"text":` + string(mustJSON(ollamaResp.Response)) + `}`), nil
+}
+
+// OllamaAvailable checks if Ollama is reachable.
+func (wp *WorkerPool) OllamaAvailable() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, "GET", wp.ollamaHost+"/api/tags", nil)
+	resp, err := wp.client.Do(req)
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+func mustJSON(s string) []byte {
+	b, _ := json.Marshal(s)
+	return b
+}

--- a/internal/news/news.go
+++ b/internal/news/news.go
@@ -1,6 +1,7 @@
 package news
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"net/url"
 	"stocktopus/internal/model"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -20,8 +22,13 @@ type SearchResult struct {
 	Exchange string `json:"exchange"`
 }
 
+// SetGeminiKey sets the Gemini API key for AI-assisted search fallback.
+func (c *Client) SetGeminiKey(key string) {
+	c.geminiKey = key
+}
+
 // SearchSymbol searches for securities by ticker and company name in parallel,
-// merging and deduplicating the results.
+// merging and deduplicating the results. Falls back to AI interpretation if empty.
 func (c *Client) SearchSymbol(ctx context.Context, query string, limit int) ([]SearchResult, error) {
 	if limit <= 0 {
 		limit = 10
@@ -62,10 +69,87 @@ func (c *Client) SearchSymbol(ctx context.Context, query string, limit int) ([]S
 		}
 	}
 
+	// AI fallback: if no results, ask Gemini to interpret the query
+	if len(merged) == 0 && c.geminiKey != "" {
+		tickers := c.aiSearchFallback(ctx, query)
+		for _, ticker := range tickers {
+			results, err := c.searchEndpoint(ctx, "/stable/search-symbol", ticker, 3)
+			if err == nil {
+				for _, r := range results {
+					if !seen[r.Symbol] {
+						seen[r.Symbol] = true
+						merged = append(merged, r)
+					}
+				}
+			}
+		}
+	}
+
 	if len(merged) > limit {
 		merged = merged[:limit]
 	}
 	return merged, nil
+}
+
+// aiSearchFallback asks Gemini to interpret a search query as stock tickers.
+func (c *Client) aiSearchFallback(ctx context.Context, query string) []string {
+	prompt := fmt.Sprintf(`The user searched for "%s" but no stock ticker or company name matched.
+What stock ticker symbols are they most likely looking for?
+Return ONLY a JSON array of ticker strings, e.g. ["AAPL","MSFT"]. No explanation.`, query)
+
+	reqBody, _ := json.Marshal(map[string]interface{}{
+		"contents": []map[string]interface{}{
+			{"parts": []map[string]string{{"text": prompt}}},
+		},
+		"generationConfig": map[string]interface{}{
+			"temperature": 0.1, "maxOutputTokens": 100,
+		},
+	})
+
+	url := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=%s", c.geminiKey)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+
+	// Extract text from response
+	var gemResp struct {
+		Candidates []struct {
+			Content struct {
+				Parts []struct {
+					Text string `json:"text"`
+				} `json:"parts"`
+			} `json:"content"`
+		} `json:"candidates"`
+	}
+	json.Unmarshal(body, &gemResp)
+	if len(gemResp.Candidates) == 0 || len(gemResp.Candidates[0].Content.Parts) == 0 {
+		return nil
+	}
+
+	text := gemResp.Candidates[0].Content.Parts[0].Text
+	// Strip markdown
+	text = strings.TrimSpace(text)
+	text = strings.TrimPrefix(text, "```json")
+	text = strings.TrimPrefix(text, "```")
+	text = strings.TrimSuffix(text, "```")
+	text = strings.TrimSpace(text)
+
+	var tickers []string
+	json.Unmarshal([]byte(text), &tickers)
+	return tickers
 }
 
 func (c *Client) searchEndpoint(ctx context.Context, endpoint, query string, limit int) ([]SearchResult, error) {
@@ -236,9 +320,10 @@ const (
 
 // Client fetches news from the FMP stable API.
 type Client struct {
-	apiKey  string
-	baseURL string
-	http    *http.Client
+	apiKey    string
+	baseURL   string
+	geminiKey string
+	http      *http.Client
 }
 
 func New(apiKey, baseURL string) *Client {

--- a/internal/provider/financialmodelingprep/fmp.go
+++ b/internal/provider/financialmodelingprep/fmp.go
@@ -209,7 +209,7 @@ func (p *Provider) normalizeQuote(data *QuoteResponse) (*model.Quote, error) {
 		return nil, fmt.Errorf("invalid price: %f", data.Price)
 	}
 	if data.Volume < 0 {
-		return nil, fmt.Errorf("invalid volume: %d", data.Volume)
+		return nil, fmt.Errorf("invalid volume: %f", data.Volume)
 	}
 
 	// FMP timestamp is Unix seconds
@@ -227,7 +227,7 @@ func (p *Provider) normalizeQuote(data *QuoteResponse) (*model.Quote, error) {
 	quote := &model.Quote{
 		Symbol:        symbol,
 		Price:         data.Price,
-		Volume:        data.Volume,
+		Volume:        int64(data.Volume),
 		Timestamp:     timestamp,
 		Change:        change,
 		ChangePercent: changePercent,
@@ -250,7 +250,7 @@ type QuoteResponse struct {
 	MarketCap         float64 `json:"marketCap"`
 	PriceAvg50        float64 `json:"priceAvg50"`
 	PriceAvg200       float64 `json:"priceAvg200"`
-	Volume            int64   `json:"volume"`
+	Volume            float64 `json:"volume"`
 	AvgVolume         int64   `json:"avgVolume"`
 	Open              float64 `json:"open"`
 	PreviousClose     float64 `json:"previousClose"`

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -328,12 +328,13 @@ func (s *Server) handleIntelligence(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if already running
+	// Check if running or recently failed
 	status := s.pipeline.GetStatus(symbol)
-	if status != nil && status.Status == agent.StatusRunning {
+	if status != nil && (status.Status == agent.StatusRunning || status.Status == agent.StatusFailed) {
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"status": status.Status,
 			"symbol": symbol,
+			"error":  status.Error,
 		})
 		return
 	}
@@ -406,6 +407,8 @@ func (s *Server) handleAgentStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	if s.pipeline != nil {
 		status["ollamaAvailable"] = s.pipeline.OllamaAvailable()
+		status["usage"] = s.pipeline.GetUsage()
+		status["pipelines"] = s.pipeline.GetAllStatuses()
 	}
 	json.NewEncoder(w).Encode(status)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -132,6 +132,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/security/{symbol}/intelligence/status", s.handleIntelligenceStatus)
 	mux.HandleFunc("POST /api/security/{symbol}/intelligence/refresh", s.handleIntelligenceRefresh)
 	mux.HandleFunc("GET /api/agent/status", s.handleAgentStatus)
+	mux.HandleFunc("GET /api/security/{symbol}/competitors", s.handleCompetitors)
 
 	// WebSocket
 	mux.HandleFunc("GET /ws", s.handleWebSocket)
@@ -407,6 +408,59 @@ func (s *Server) handleAgentStatus(w http.ResponseWriter, r *http.Request) {
 		status["ollamaAvailable"] = s.pipeline.OllamaAvailable()
 	}
 	json.NewEncoder(w).Encode(status)
+}
+
+func (s *Server) handleCompetitors(w http.ResponseWriter, r *http.Request) {
+	symbol := r.PathValue("symbol")
+	w.Header().Set("Content-Type", "application/json")
+
+	if s.pipeline == nil {
+		json.NewEncoder(w).Encode([]any{})
+		return
+	}
+
+	// Get the parent's analysis to find competitors
+	parent, _ := s.pipeline.GetDirect(symbol)
+	if parent == nil || len(parent.Competitors) == 0 {
+		json.NewEncoder(w).Encode([]any{})
+		return
+	}
+
+	type CompetitorScore struct {
+		Symbol    string  `json:"symbol"`
+		Sentiment float64 `json:"sentiment"`
+		RiskScore float64 `json:"riskScore"`
+		Summary   string  `json:"summary"`
+		Status    string  `json:"status"` // "ready", "pending", "none"
+	}
+
+	var results []CompetitorScore
+	for _, comp := range parent.Competitors {
+		ci, _ := s.pipeline.GetDirect(comp)
+		if ci != nil {
+			results = append(results, CompetitorScore{
+				Symbol:    comp,
+				Sentiment: ci.Sentiment,
+				RiskScore: ci.RiskScore,
+				Summary:   ci.Summary,
+				Status:    "ready",
+			})
+		} else {
+			status := "none"
+			ps := s.pipeline.GetStatus(comp)
+			if ps != nil && ps.Status == agent.StatusRunning {
+				status = "pending"
+			}
+			results = append(results, CompetitorScore{
+				Symbol:    comp,
+				Sentiment: 0,
+				RiskScore: 0,
+				Status:    status,
+			})
+		}
+	}
+
+	json.NewEncoder(w).Encode(results)
 }
 
 // gatherFMPData collects all available FMP data for a symbol as JSON context.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"time"
 
+	"stocktopus/internal/agent"
 	"stocktopus/internal/hub"
 	"stocktopus/internal/news"
 )
@@ -46,15 +47,17 @@ type Server struct {
 	debug      *DebugBroadcaster
 	symbols    SymbolLister
 	news       *news.Client
+	pipeline   *agent.Pipeline
 }
 
-func New(cfg Config, h *hub.Hub, debug *DebugBroadcaster, symbols SymbolLister, newsClient *news.Client, logger *slog.Logger) (*Server, error) {
+func New(cfg Config, h *hub.Hub, debug *DebugBroadcaster, symbols SymbolLister, newsClient *news.Client, pipeline *agent.Pipeline, logger *slog.Logger) (*Server, error) {
 	s := &Server{
-		config:  cfg,
-		logger:  logger,
-		hub:     h,
-		debug:   debug,
-		symbols: symbols,
+		config:   cfg,
+		logger:   logger,
+		hub:      h,
+		debug:    debug,
+		symbols:  symbols,
+		pipeline: pipeline,
 		news:    newsClient,
 	}
 
@@ -125,6 +128,10 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/security/{symbol}/metrics", s.handleSecurityMetrics)
 	mux.HandleFunc("GET /api/security/{symbol}/financials", s.handleSecurityFinancials)
 	mux.HandleFunc("GET /api/security/{symbol}/estimates", s.handleSecurityEstimates)
+	mux.HandleFunc("GET /api/security/{symbol}/intelligence", s.handleIntelligence)
+	mux.HandleFunc("GET /api/security/{symbol}/intelligence/status", s.handleIntelligenceStatus)
+	mux.HandleFunc("POST /api/security/{symbol}/intelligence/refresh", s.handleIntelligenceRefresh)
+	mux.HandleFunc("GET /api/agent/status", s.handleAgentStatus)
 
 	// WebSocket
 	mux.HandleFunc("GET /ws", s.handleWebSocket)
@@ -299,6 +306,125 @@ func (s *Server) proxyFMP(w http.ResponseWriter, r *http.Request, fetch func(str
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(data)
+}
+
+func (s *Server) handleIntelligence(w http.ResponseWriter, r *http.Request) {
+	symbol := r.PathValue("symbol")
+	w.Header().Set("Content-Type", "application/json")
+
+	if s.pipeline == nil {
+		json.NewEncoder(w).Encode(map[string]string{"error": "agent pipeline not configured"})
+		return
+	}
+
+	// Check cache first
+	ci, err := s.pipeline.GetCached(symbol)
+	if err != nil {
+		s.logger.Warn("intelligence cache error", "symbol", symbol, "error", err)
+	}
+	if ci != nil {
+		json.NewEncoder(w).Encode(ci)
+		return
+	}
+
+	// Check if already running
+	status := s.pipeline.GetStatus(symbol)
+	if status != nil && status.Status == agent.StatusRunning {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status": status.Status,
+			"symbol": symbol,
+		})
+		return
+	}
+
+	// Check store directly (bypass freshness check)
+	direct, _ := s.pipeline.GetDirect(symbol)
+	if direct != nil {
+		json.NewEncoder(w).Encode(direct)
+		return
+	}
+
+	// Trigger analysis
+	fmpData := s.gatherFMPData(r.Context(), symbol)
+	s.pipeline.Analyze(r.Context(), symbol, fmpData)
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status": "pending",
+		"symbol": symbol,
+	})
+}
+
+func (s *Server) handleIntelligenceStatus(w http.ResponseWriter, r *http.Request) {
+	symbol := r.PathValue("symbol")
+	w.Header().Set("Content-Type", "application/json")
+
+	if s.pipeline == nil {
+		json.NewEncoder(w).Encode(map[string]string{"status": "unavailable"})
+		return
+	}
+
+	status := s.pipeline.GetStatus(symbol)
+	if status != nil {
+		json.NewEncoder(w).Encode(status)
+	} else {
+		// Check if we have cached data
+		ci, _ := s.pipeline.GetCached(symbol)
+		if ci != nil {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "complete",
+				"symbol": symbol,
+			})
+		} else {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "none",
+				"symbol": symbol,
+			})
+		}
+	}
+}
+
+func (s *Server) handleIntelligenceRefresh(w http.ResponseWriter, r *http.Request) {
+	symbol := r.PathValue("symbol")
+	w.Header().Set("Content-Type", "application/json")
+
+	if s.pipeline == nil {
+		json.NewEncoder(w).Encode(map[string]string{"error": "agent pipeline not configured"})
+		return
+	}
+
+	fmpData := s.gatherFMPData(r.Context(), symbol)
+	s.pipeline.Analyze(r.Context(), symbol, fmpData)
+
+	json.NewEncoder(w).Encode(map[string]string{"status": "started", "symbol": symbol})
+}
+
+func (s *Server) handleAgentStatus(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	status := map[string]interface{}{
+		"available": s.pipeline != nil,
+	}
+	if s.pipeline != nil {
+		status["ollamaAvailable"] = s.pipeline.OllamaAvailable()
+	}
+	json.NewEncoder(w).Encode(status)
+}
+
+// gatherFMPData collects all available FMP data for a symbol as JSON context.
+func (s *Server) gatherFMPData(ctx context.Context, symbol string) json.RawMessage {
+	data := map[string]json.RawMessage{}
+
+	if profile, err := s.news.GetProfile(ctx, symbol); err == nil {
+		data["profile"] = profile
+	}
+	if metrics, err := s.news.GetKeyMetrics(ctx, symbol); err == nil {
+		data["metrics"] = metrics
+	}
+	if ratios, err := s.news.GetRatiosTTM(ctx, symbol); err == nil {
+		data["ratios"] = ratios
+	}
+
+	result, _ := json.Marshal(data)
+	return result
 }
 
 func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -15,7 +15,7 @@ func testServer(t *testing.T) (*Server, *http.ServeMux) {
 	logger := slog.Default()
 	h := hub.New(logger)
 	debug := NewDebugBroadcaster()
-	srv, err := New(Config{Port: 0}, h, debug, nil, nil, logger)
+	srv, err := New(Config{Port: 0}, h, debug, nil, nil, nil, logger)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -115,6 +115,43 @@
         if (n < allTabs.length) allTabs[n].click();
     };
 
+    // ── Security Type Detection ──
+
+    var securityType = 'stock'; // default
+
+    function detectSecurityType(profile) {
+        if (!profile) return 'stock';
+        var ex = (profile.exchange || '').toUpperCase();
+        if (ex === 'CRYPTO' || ex === 'CCC') return 'crypto';
+        if (ex === 'FOREX') return 'forex';
+        if ((profile.symbol || '').charAt(0) === '^') return 'index';
+        if (profile.isEtf) return 'etf';
+        return 'stock';
+    }
+
+    function applySecurityType(type) {
+        securityType = type;
+        var hideTabs = [];
+        if (type === 'crypto' || type === 'forex' || type === 'index') {
+            hideTabs = ['financials', 'estimates'];
+        }
+        document.querySelectorAll('#info-tabs .info-tab').forEach(function (tab) {
+            if (hideTabs.indexOf(tab.dataset.tab) >= 0) {
+                tab.style.display = 'none';
+            }
+        });
+    }
+
+    // Detect type early from profile
+    fetch('/api/security/' + symbol + '/profile')
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+            if (data && data[0]) {
+                applySecurityType(detectSecurityType(data[0]));
+            }
+        })
+        .catch(function () {});
+
     // ── Company Panel (shared from terminal.js) ──
 
     function initCompanyPanel() {
@@ -130,12 +167,17 @@
 
     function loadTab(tab) {
         container.innerHTML = '<p class="empty-state">Loading...</p>';
-        switch (tab) {
-            case 'overview': loadOverview(); break;
-            case 'financials': loadFinancials('income'); break;
-            case 'estimates': loadEstimates(); break;
-            case 'news': loadNews(); break;
-            case 'ai': loadAI(); break;
+        try {
+            switch (tab) {
+                case 'overview': loadOverview(); break;
+                case 'financials': loadFinancials('income'); break;
+                case 'estimates': loadEstimates(); break;
+                case 'news': loadNews(); break;
+                case 'ai': loadAI(); break;
+            }
+        } catch (e) {
+            console.error('Tab load error:', tab, e);
+            container.innerHTML = '<p class="empty-state">Failed to load ' + tab + '</p>';
         }
     }
 

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -194,6 +194,7 @@
             case 'financials': loadFinancials('income'); break;
             case 'estimates': loadEstimates(); break;
             case 'news': loadNews(); break;
+            case 'ai': loadAI(); break;
         }
     }
 
@@ -447,6 +448,182 @@
             .catch(function () {
                 container.innerHTML = '<p class="empty-state">Failed to load news</p>';
             });
+    }
+
+    // ── AI Analysis ──
+
+    function loadAI() {
+        container.innerHTML = '<p class="empty-state">Loading AI analysis...</p>';
+
+        fetch('/api/security/' + symbol + '/intelligence')
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                // Status response (pipeline running/pending) vs full analysis
+                if (data.status && !data.summary) {
+                    if (data.status === 'running' || data.status === 'pending') {
+                        container.innerHTML = renderAIProgress(data);
+                        pollAIStatus();
+                        return;
+                    }
+                    if (data.status === 'failed') {
+                        container.innerHTML = '<p class="empty-state">AI analysis failed: ' + esc(data.error || 'unknown') + '</p>';
+                        return;
+                    }
+                }
+                if (data.error && !data.summary) {
+                    container.innerHTML = '<p class="empty-state">AI analysis unavailable: ' + esc(data.error) + '</p>';
+                    return;
+                }
+                container.innerHTML = renderAIAnalysis(data);
+            })
+            .catch(function () {
+                container.innerHTML = '<p class="empty-state">Failed to load AI analysis</p>';
+            });
+    }
+
+    function pollAIStatus() {
+        var pollInterval = setInterval(function () {
+            fetch('/api/security/' + symbol + '/intelligence/status')
+                .then(function (r) { return r.json(); })
+                .then(function (status) {
+                    if (status.status === 'complete') {
+                        clearInterval(pollInterval);
+                        // Fetch the full result
+                        fetch('/api/security/' + symbol + '/intelligence')
+                            .then(function (r) { return r.json(); })
+                            .then(function (data) {
+                                container.innerHTML = renderAIAnalysis(data);
+                            });
+                    } else if (status.status === 'failed') {
+                        clearInterval(pollInterval);
+                        container.innerHTML = '<p class="empty-state">AI analysis failed: ' + esc(status.error || 'unknown error') + '</p>';
+                    } else {
+                        // Update progress
+                        container.innerHTML = renderAIProgress(status);
+                    }
+                });
+        }, 2000);
+    }
+
+    function renderAIProgress(data) {
+        var html = '<div class="ai-progress">';
+        html += '<div class="ai-progress-header"><span class="spinner"></span> Analyzing ' + esc(symbol) + '...</div>';
+        if (data.tasks) {
+            html += '<div class="ai-tasks">';
+            data.tasks.forEach(function (t) {
+                var icon = t.status === 'complete' ? '&#10003;' : t.status === 'running' ? '&#9679;' : '&#9675;';
+                var cls = 'ai-task ai-task-' + t.status;
+                html += '<div class="' + cls + '">' + icon + ' ' + esc(t.id || t.type) + '</div>';
+            });
+            html += '</div>';
+        }
+        html += '</div>';
+        return html;
+    }
+
+    function renderAIAnalysis(data) {
+        var html = '<div class="ai-analysis">';
+
+        // Summary
+        if (data.summary) {
+            html += '<div class="ai-section">';
+            html += '<div class="ai-section-title">Executive Summary</div>';
+            html += '<p class="ai-summary">' + esc(data.summary) + '</p>';
+            html += '</div>';
+        }
+
+        // Scores row
+        html += '<div class="ai-scores">';
+        var sent = data.sentiment || 0;
+        var risk = data.riskScore || 0;
+        var conf = data.confidence ? data.confidence * 100 : 0;
+        html += renderScore('Sentiment', sent, -1, 1, sent >= 0 ? 'price-up' : 'price-down');
+        html += renderScore('Risk', risk, 0, 100, risk > 60 ? 'price-down' : 'price-up');
+        html += renderScore('Confidence', conf, 0, 100, '');
+        html += '</div>';
+
+        // Key Risks
+        if (data.keyRisks && data.keyRisks.length > 0) {
+            html += '<div class="ai-section">';
+            html += '<div class="ai-section-title">Key Risks</div>';
+            html += '<ul class="ai-list ai-risks">';
+            data.keyRisks.forEach(function (r) { html += '<li>' + esc(r) + '</li>'; });
+            html += '</ul></div>';
+        }
+
+        // Opportunities
+        if (data.opportunities && data.opportunities.length > 0) {
+            html += '<div class="ai-section">';
+            html += '<div class="ai-section-title">Opportunities</div>';
+            html += '<ul class="ai-list ai-opps">';
+            data.opportunities.forEach(function (o) { html += '<li>' + esc(o) + '</li>'; });
+            html += '</ul></div>';
+        }
+
+        // Competitors
+        if (data.competitors && data.competitors.length > 0) {
+            html += '<div class="ai-section">';
+            html += '<div class="ai-section-title">Competitors</div>';
+            html += '<div class="ai-competitors">';
+            data.competitors.forEach(function (c) {
+                html += '<span class="ai-competitor">' + esc(c) + '</span>';
+            });
+            html += '</div></div>';
+        }
+
+        // Analysis details (if available)
+        if (data.analysis) {
+            var a = typeof data.analysis === 'string' ? JSON.parse(data.analysis) : data.analysis;
+            if (a.sectorAnalysis) {
+                html += '<div class="ai-section">';
+                html += '<div class="ai-section-title">Sector Outlook</div>';
+                html += '<p class="ai-text">' + esc(a.sectorAnalysis) + '</p>';
+                html += '</div>';
+            }
+            if (a.technicalOutlook) {
+                html += '<div class="ai-section">';
+                html += '<div class="ai-section-title">Technical Outlook</div>';
+                html += '<p class="ai-text">' + esc(a.technicalOutlook) + '</p>';
+                html += '</div>';
+            }
+            if (a.catalysts && a.catalysts.length > 0) {
+                html += '<div class="ai-section">';
+                html += '<div class="ai-section-title">Catalysts</div>';
+                html += '<ul class="ai-list">';
+                a.catalysts.forEach(function (c) { html += '<li>' + esc(c) + '</li>'; });
+                html += '</ul></div>';
+            }
+        }
+
+        // Sources
+        if (data.sources && data.sources.length > 0) {
+            html += '<div class="ai-section">';
+            html += '<div class="ai-section-title">Sources</div>';
+            html += '<div class="ai-sources">';
+            data.sources.forEach(function (s) {
+                html += '<a href="' + esc(s) + '" target="_blank" rel="noopener" class="ai-source">' + esc(s.replace(/^https?:\/\//, '').substring(0, 40)) + '</a>';
+            });
+            html += '</div></div>';
+        }
+
+        // Meta
+        html += '<div class="ai-meta">';
+        if (data.modelVersion) html += '<span>Model: ' + esc(data.modelVersion) + '</span>';
+        if (data.generatedAt) html += '<span>Generated: ' + new Date(data.generatedAt).toLocaleString() + '</span>';
+        html += '</div>';
+
+        html += '</div>';
+        return html;
+    }
+
+    function renderScore(label, value, min, max, colorClass) {
+        var pct = ((value - min) / (max - min)) * 100;
+        var display = typeof value === 'number' ? value.toFixed(1) : '—';
+        return '<div class="ai-score">'
+            + '<div class="ai-score-label">' + label + '</div>'
+            + '<div class="ai-score-value ' + colorClass + '">' + display + '</div>'
+            + '<div class="ai-score-bar"><div class="ai-score-fill" style="width:' + Math.max(0, Math.min(100, pct)) + '%"></div></div>'
+            + '</div>';
     }
 
     // ── Refresh ──

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -115,74 +115,15 @@
         if (n < allTabs.length) allTabs[n].click();
     };
 
-    // ── Sparkline ──
+    // ── Company Panel (shared from terminal.js) ──
 
-    function initSparkline() {
-        var el = document.getElementById('info-sparkline');
-        if (!el || !window.LightweightCharts) return;
-
-        var from = new Date();
-        from.setMonth(from.getMonth() - 6);
-        var to = new Date();
-        var fromStr = to.getFullYear() === from.getFullYear()
-            ? from.toISOString().slice(0, 10)
-            : from.toISOString().slice(0, 10);
-
-        fetch('/api/chart/eod/' + symbol + '?from=' + from.toISOString().slice(0, 10) + '&to=' + to.toISOString().slice(0, 10))
-            .then(function (r) { return r.json(); })
-            .then(function (data) {
-                if (!data || data.length < 2) return;
-
-                var first = data[0].close;
-                var last = data[data.length - 1].close;
-                var color = last >= first ? '#00cc66' : '#ff4444';
-
-                var chart = LightweightCharts.createChart(el, {
-                    width: 200,
-                    height: 50,
-                    layout: { background: { color: 'transparent' }, textColor: 'transparent' },
-                    grid: { vertLines: { visible: false }, horzLines: { visible: false } },
-                    rightPriceScale: { visible: false },
-                    timeScale: { visible: false },
-                    handleScroll: false,
-                    handleScale: false,
-                    crosshair: { vertLine: { visible: false }, horzLine: { visible: false } },
-                });
-
-                var series = chart.addSeries(LightweightCharts.AreaSeries, {
-                    lineColor: color,
-                    topColor: color.replace(')', ', 0.2)').replace('rgb', 'rgba'),
-                    bottomColor: 'transparent',
-                    lineWidth: 2,
-                    priceLineVisible: false,
-                    lastValueVisible: false,
-                });
-
-                series.setData(data.map(function (d) { return { time: d.date, value: d.close }; }));
-                chart.timeScale().fitContent();
-            });
-    }
-
-    // ── Load Header (profile price/change) ──
-
-    function loadHeader() {
-        fetch('/api/security/' + symbol + '/profile')
-            .then(function (r) { return r.json(); })
-            .then(function (data) {
-                if (!data || !data.length) return;
-                var p = data[0];
-                var nameEl = document.getElementById('info-company-name');
-                var priceEl = document.getElementById('info-price');
-                var changeEl = document.getElementById('info-change');
-                if (nameEl) nameEl.textContent = p.companyName || '';
-                if (priceEl) priceEl.textContent = p.price ? p.price.toFixed(2) : '';
-                if (changeEl) {
-                    var chg = p.change || 0;
-                    var chgPct = p.changePercentage || 0;
-                    changeEl.textContent = (chg >= 0 ? '+' : '') + chg.toFixed(2) + ' (' + chgPct.toFixed(2) + '%)';
-                    changeEl.className = 'info-change ' + (chg >= 0 ? 'price-up' : 'price-down');
-                }
-            });
+    function initCompanyPanel() {
+        if (window._renderCompanyPanel) {
+            window._renderCompanyPanel('company-panel', symbol);
+        } else {
+            // terminal.js may not have loaded yet (direct page load)
+            setTimeout(initCompanyPanel, 100);
+        }
     }
 
     // ── Tab Loaders ──
@@ -286,6 +227,7 @@
             btn.onclick = function () {
                 container.querySelectorAll('.info-sub-tab').forEach(function (b) { b.classList.remove('active'); });
                 btn.classList.add('active');
+                history.replaceState(null, '', location.pathname + '#financials-' + btn.dataset.ftype);
                 loadFinancialTable(btn.dataset.ftype);
             };
         });
@@ -475,6 +417,8 @@
                     return;
                 }
                 container.innerHTML = renderAIAnalysis(data);
+                wireCompetitorLinks();
+                loadCompetitorScores();
             })
             .catch(function () {
                 container.innerHTML = '<p class="empty-state">Failed to load AI analysis</p>';
@@ -493,6 +437,8 @@
                             .then(function (r) { return r.json(); })
                             .then(function (data) {
                                 container.innerHTML = renderAIAnalysis(data);
+                wireCompetitorLinks();
+                loadCompetitorScores();
                             });
                     } else if (status.status === 'failed') {
                         clearInterval(pollInterval);
@@ -560,13 +506,16 @@
             html += '</ul></div>';
         }
 
-        // Competitors
+        // Competitors — loaded async with scores
         if (data.competitors && data.competitors.length > 0) {
             html += '<div class="ai-section">';
             html += '<div class="ai-section-title">Competitors</div>';
-            html += '<div class="ai-competitors">';
+            html += '<div class="ai-competitors" id="ai-competitors">';
             data.competitors.forEach(function (c) {
-                html += '<span class="ai-competitor">' + esc(c) + '</span>';
+                html += '<div class="ai-competitor-card" data-symbol="' + esc(c) + '" data-nav="security">'
+                    + '<span class="ai-competitor-sym">' + esc(c) + '</span>'
+                    + '<span class="ai-competitor-scores">loading...</span>'
+                    + '</div>';
             });
             html += '</div></div>';
         }
@@ -626,14 +575,74 @@
             + '</div>';
     }
 
+    function wireCompetitorLinks() {
+        var cards = document.querySelectorAll('.ai-competitor-card[data-nav="security"]');
+        cards.forEach(function (card) {
+            card.addEventListener('click', function (e) {
+                // Don't navigate if clicking the analyze button
+                if (e.target.closest('.ai-analyze-btn')) return;
+                var sym = card.dataset.symbol;
+                if (sym && window._navigateToSecurity) {
+                    window._navigateToSecurity(sym);
+                }
+            });
+        });
+    }
+
+    window._triggerAnalysis = function (sym, btn) {
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner" style="width:10px;height:10px;display:inline-block"></span> analyzing...';
+        fetch('/api/security/' + sym + '/intelligence')
+            .then(function () {
+                // Start polling for this competitor's completion
+                setTimeout(loadCompetitorScores, 3000);
+            });
+    };
+
+    function loadCompetitorScores() {
+        var el = document.getElementById('ai-competitors');
+        if (!el) return;
+
+        fetch('/api/security/' + symbol + '/competitors')
+            .then(function (r) { return r.json(); })
+            .then(function (comps) {
+                if (!comps || comps.length === 0) return;
+
+                comps.forEach(function (c) {
+                    var card = el.querySelector('[data-symbol="' + c.symbol + '"]');
+                    if (!card) return;
+                    var scoresEl = card.querySelector('.ai-competitor-scores');
+                    if (!scoresEl) return;
+
+                    if (c.status === 'ready') {
+                        var sentClass = c.sentiment >= 0 ? 'price-up' : 'price-down';
+                        var riskClass = c.riskScore > 60 ? 'price-down' : 'price-up';
+                        scoresEl.innerHTML = '<span class="' + sentClass + '">S:' + c.sentiment.toFixed(1) + '</span>'
+                            + ' <span class="' + riskClass + '">R:' + c.riskScore.toFixed(0) + '</span>';
+                    } else if (c.status === 'pending') {
+                        scoresEl.innerHTML = '<span class="spinner" style="width:10px;height:10px"></span> analyzing...';
+                    } else {
+                        scoresEl.innerHTML = '<button class="ai-analyze-btn" onclick="event.preventDefault();event.stopPropagation();window._triggerAnalysis(\'' + c.symbol + '\',this)">&#129302; analyze</button>';
+                    }
+                });
+
+                // Poll again if any are still pending
+                var hasPending = comps.some(function (c) { return c.status !== 'ready'; });
+                if (hasPending) {
+                    setTimeout(loadCompetitorScores, 5000);
+                }
+            });
+    }
+
     // ── Refresh ──
 
     var currentTab = 'overview';
 
-    // Override loadTab to track current tab
+    // Override loadTab to track current tab and update URL hash
     var _origLoadTab = loadTab;
     loadTab = function (tab) {
         currentTab = tab;
+        history.replaceState(null, '', location.pathname + '#' + tab);
         _origLoadTab(tab);
     };
 
@@ -651,7 +660,7 @@
         var oldChange = changeEl ? changeEl.textContent : '';
 
         // Reload header
-        loadHeader();
+        initCompanyPanel();
 
         // Reload current tab content
         loadTab(currentTab);
@@ -682,7 +691,27 @@
 
     // ── Init ──
 
-    loadHeader();
-    initSparkline();
-    loadTab('overview');
+    initCompanyPanel();
+
+    // Read initial tab from URL hash, default to overview
+    var initTab = 'overview';
+    var initSubTab = '';
+    var hash = location.hash.replace('#', '');
+    if (hash) {
+        var parts = hash.split('-');
+        var mainTab = parts[0];
+        if (['overview', 'financials', 'estimates', 'news', 'ai'].indexOf(mainTab) >= 0) {
+            initTab = mainTab;
+            if (parts.length > 1) initSubTab = parts.slice(1).join('-');
+        }
+        var allTabs = document.querySelectorAll('#info-tabs .info-tab');
+        allTabs.forEach(function (t) {
+            t.classList.toggle('active', t.dataset.tab === initTab);
+        });
+    }
+    if (initTab === 'financials' && initSubTab) {
+        loadFinancials(initSubTab);
+    } else {
+        loadTab(initTab);
+    }
 })();

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -652,6 +652,180 @@ body {
     display: none;
 }
 
+/* ── AI Analysis ── */
+
+.ai-analysis {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.ai-section {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 12px 14px;
+}
+
+.ai-section-title {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 8px;
+}
+
+.ai-summary {
+    font-size: 13px;
+    color: var(--text-primary);
+    line-height: 1.6;
+}
+
+.ai-scores {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+}
+
+.ai-score {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 10px 12px;
+    text-align: center;
+}
+
+.ai-score-label {
+    font-size: 10px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    margin-bottom: 4px;
+}
+
+.ai-score-value {
+    font-size: 20px;
+    font-weight: 700;
+    margin-bottom: 6px;
+}
+
+.ai-score-bar {
+    height: 3px;
+    background: var(--border);
+    border-radius: 2px;
+}
+
+.ai-score-fill {
+    height: 100%;
+    background: var(--orange);
+    border-radius: 2px;
+}
+
+.ai-list {
+    list-style: none;
+    padding: 0;
+}
+
+.ai-list li {
+    font-size: 12px;
+    color: var(--text-secondary);
+    padding: 4px 0;
+    border-bottom: 1px solid rgba(42, 42, 42, 0.3);
+}
+
+.ai-list li:last-child {
+    border-bottom: none;
+}
+
+.ai-risks li::before {
+    content: "\25B2 ";
+    color: var(--red);
+    font-size: 8px;
+}
+
+.ai-opps li::before {
+    content: "\25B2 ";
+    color: var(--green);
+    font-size: 8px;
+}
+
+.ai-competitors {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.ai-competitor {
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 4px 10px;
+    font-size: 12px;
+    color: var(--blue);
+    font-weight: 600;
+}
+
+.ai-text {
+    font-size: 12px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
+.ai-sources {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.ai-source {
+    font-size: 11px;
+    color: var(--text-muted);
+    text-decoration: none;
+}
+
+.ai-source:hover {
+    color: var(--blue);
+}
+
+.ai-meta {
+    display: flex;
+    gap: 16px;
+    font-size: 10px;
+    color: var(--text-muted);
+    padding-top: 8px;
+    border-top: 1px solid var(--border);
+}
+
+.ai-progress {
+    padding: 40px 20px;
+    text-align: center;
+}
+
+.ai-progress-header {
+    font-size: 14px;
+    color: var(--text-primary);
+    margin-bottom: 16px;
+}
+
+.ai-tasks {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.ai-task {
+    font-size: 12px;
+    padding: 4px 10px;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+}
+
+.ai-task-pending { color: var(--text-muted); }
+.ai-task-running { color: var(--orange); border-color: var(--orange); }
+.ai-task-complete { color: var(--green); border-color: var(--green); }
+.ai-task-failed { color: var(--red); border-color: var(--red); }
+
 .info-pulse {
     animation: info-pulse-fade 1.5s ease-out;
 }

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -1090,6 +1090,125 @@ body {
     overflow: hidden;
 }
 
+/* ── Debug Panels ── */
+
+.debug-panels {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    gap: 12px;
+    height: calc(100vh - 140px);
+}
+
+.debug-agent-panel {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 10px;
+    overflow-y: auto;
+}
+
+.agent-panel-header,
+.agent-pipelines-header {
+    font-size: 10px;
+    font-weight: 700;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 8px;
+}
+
+.agent-pipelines-header {
+    margin-top: 12px;
+    padding-top: 8px;
+    border-top: 1px solid var(--border);
+}
+
+.agent-stats {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.agent-stat {
+    display: flex;
+    justify-content: space-between;
+    font-size: 12px;
+}
+
+.agent-stat-label {
+    color: var(--text-muted);
+}
+
+.agent-stat-value {
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+.agent-pipelines {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.agent-pipeline {
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 6px 8px;
+    font-size: 11px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+}
+
+.pip-symbol {
+    color: var(--blue);
+    font-weight: 700;
+}
+
+.pip-status {
+    font-size: 10px;
+    padding: 1px 5px;
+    border-radius: 3px;
+}
+
+.agent-pip-running .pip-status {
+    color: var(--orange);
+    border: 1px solid var(--orange);
+}
+
+.agent-pip-complete .pip-status {
+    color: var(--green);
+    border: 1px solid var(--green);
+}
+
+.agent-pip-failed .pip-status {
+    color: var(--red);
+    border: 1px solid var(--red);
+}
+
+.pip-dur {
+    color: var(--text-muted);
+    font-size: 10px;
+}
+
+.pip-tasks {
+    width: 100%;
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.pip-task {
+    font-size: 10px;
+    color: var(--text-muted);
+}
+
+.pip-task-complete { color: var(--green); }
+.pip-task-running { color: var(--orange); }
+.pip-task-failed { color: var(--red); }
+
 /* ── Debug Console ── */
 
 .debug-console {

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -413,45 +413,63 @@ body {
 
 /* ── Security Info View ── */
 
-.info-header {
+/* ── Company Panel (shared) ── */
+
+.company-panel {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    margin-bottom: 12px;
-    gap: 16px;
+    gap: 10px;
+    flex-shrink: 0;
 }
 
-.info-title {
-    display: flex;
-    align-items: baseline;
-    gap: 12px;
-    flex-wrap: wrap;
-}
-
-.info-title h1 {
-    font-size: 16px;
+.cpanel-sym {
     font-weight: 700;
-}
-
-.info-company-name {
-    color: var(--text-secondary);
     font-size: 13px;
+    color: var(--blue);
+    display: none; /* hidden when h1 already shows symbol */
 }
 
-.info-price {
-    font-size: 16px;
+.cpanel-name {
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.cpanel-price {
+    font-size: 14px;
     font-weight: 700;
     color: var(--text-primary);
 }
 
-.info-change {
-    font-size: 13px;
+.cpanel-change {
+    font-size: 12px;
 }
 
-.info-sparkline {
+.cpanel-spark-wrap {
+    display: flex;
+    align-items: center;
+    gap: 4px;
     flex-shrink: 0;
-    width: 200px;
-    height: 50px;
+}
+
+.cpanel-spark-label {
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.cpanel-spark {
+    width: 160px;
+    height: 40px;
+}
+
+.cpanel-spark a[href*="tradingview"],
+.chart-container a[href*="tradingview"] {
+    display: none !important;
+}
+
+/* Show symbol in panel on news page (no h1 with symbol) */
+.news-cards ~ .company-panel .cpanel-sym,
+.page-header .company-panel .cpanel-sym {
+    display: inline;
 }
 
 .info-tabs {
@@ -755,14 +773,55 @@ body {
     flex-wrap: wrap;
 }
 
-.ai-competitor {
+.ai-competitor-card {
     background: var(--bg-tertiary);
     border: 1px solid var(--border);
     border-radius: 4px;
-    padding: 4px 10px;
-    font-size: 12px;
+    padding: 8px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 100px;
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.ai-competitor-card:hover {
+    border-color: var(--blue);
+}
+
+.ai-competitor-sym {
+    font-size: 13px;
     color: var(--blue);
-    font-weight: 600;
+    font-weight: 700;
+}
+
+.ai-analyze-btn {
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    color: var(--orange);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    padding: 2px 8px;
+    cursor: pointer;
+}
+
+.ai-analyze-btn:hover {
+    border-color: var(--orange);
+}
+
+.ai-analyze-btn:disabled {
+    cursor: default;
+    color: var(--text-muted);
+    border-color: var(--border);
+}
+
+.ai-competitor-scores {
+    font-size: 11px;
+    color: var(--text-muted);
+    display: flex;
+    gap: 8px;
 }
 
 .ai-text {
@@ -839,9 +898,8 @@ body {
     .info-grid {
         grid-template-columns: repeat(2, 1fr);
     }
-    .info-header {
-        flex-direction: column;
-        align-items: flex-start;
+    .company-panel {
+        flex-wrap: wrap;
     }
 }
 

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -289,6 +289,12 @@
         var tabs = document.getElementById('news-tabs');
         if (!tabs) return;
 
+        // Show company panel if a security is selected
+        var sym = getNewsSymbol();
+        if (sym && window._renderCompanyPanel) {
+            window._renderCompanyPanel('company-panel', sym);
+        }
+
         tabs.querySelectorAll('.news-tab').forEach(function (tab) {
             tab.onclick = function () {
                 if (tab.classList.contains('dimmed')) return;
@@ -1235,6 +1241,114 @@
     }
 
     // ── Init ──
+
+    // Expose navigation for info.js competitor links
+    window._navigateToSecurity = function (sym) {
+        setSecurity(sym);
+        onViewLeave(currentView);
+        navigate('info', sym);
+    };
+
+    window._navigateToGraph = function (sym) {
+        setSecurity(sym);
+        onViewLeave(currentView);
+        navigate('graph', sym);
+    };
+
+    // ── Shared Company Panel ──
+    // Renders price, change, and sparkline into a container element.
+    // Used by info and news views.
+    window._renderCompanyPanel = function (containerId, symbol) {
+        var el = document.getElementById(containerId);
+        if (!el || !symbol) return;
+
+        el.innerHTML = '<span class="cpanel-sym">' + symbol + '</span>'
+            + '<span id="cpanel-name" class="cpanel-name"></span>'
+            + '<span id="cpanel-price" class="cpanel-price"></span>'
+            + '<span id="cpanel-change" class="cpanel-change"></span>'
+            + '<div class="cpanel-spark-wrap"><span class="cpanel-spark-label">6M</span><div id="cpanel-spark" class="cpanel-spark"></div></div>';
+
+        // Make sparkline clickable
+        var spark = document.getElementById('cpanel-spark');
+        if (spark) {
+            spark.style.cursor = 'pointer';
+            spark.title = 'Open chart';
+            spark.addEventListener('click', function () {
+                localStorage.setItem('stocktopus-chart-range', '6M');
+                if (window._navigateToGraph) window._navigateToGraph(symbol);
+            });
+        }
+
+        // Fetch profile
+        fetch('/api/security/' + symbol + '/profile')
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (!data || !data.length) return;
+                var p = data[0];
+                var nameEl = document.getElementById('cpanel-name');
+                var priceEl = document.getElementById('cpanel-price');
+                var changeEl = document.getElementById('cpanel-change');
+                if (nameEl) nameEl.textContent = p.companyName || '';
+                if (priceEl) priceEl.textContent = p.price ? p.price.toFixed(2) : '';
+                if (changeEl) {
+                    var chg = p.change || 0;
+                    var chgPct = p.changePercentage || 0;
+                    changeEl.textContent = (chg >= 0 ? '+' : '') + chg.toFixed(2) + ' (' + chgPct.toFixed(2) + '%)';
+                    changeEl.className = 'cpanel-change ' + (chg >= 0 ? 'price-up' : 'price-down');
+                }
+            });
+
+        // Fetch sparkline (needs lightweight-charts loaded)
+        if (!spark) return;
+
+        function renderSpark() {
+            if (!window.LightweightCharts) {
+                // Retry — library may still be loading from fragment script
+                setTimeout(renderSpark, 200);
+                return;
+            }
+            loadSparkData();
+        }
+
+        function loadSparkData() {
+            var from = new Date();
+            from.setMonth(from.getMonth() - 6);
+            var to = new Date();
+            fetch('/api/chart/eod/' + symbol + '?from=' + from.toISOString().slice(0, 10) + '&to=' + to.toISOString().slice(0, 10))
+                .then(function (r) { return r.json(); })
+                .then(function (data) {
+                    if (!data || data.length < 2) return;
+                    var first = data[0].close;
+                    var last = data[data.length - 1].close;
+                    var color = last >= first ? '#00cc66' : '#ff4444';
+
+                    var chart = LightweightCharts.createChart(spark, {
+                        width: 160, height: 40,
+                        layout: { background: { color: 'transparent' }, textColor: 'transparent' },
+                        grid: { vertLines: { visible: false }, horzLines: { visible: false } },
+                        rightPriceScale: { visible: false },
+                        timeScale: { visible: false },
+                        handleScroll: false, handleScale: false,
+                        crosshair: { vertLine: { visible: false }, horzLine: { visible: false } },
+                    });
+                    var series = chart.addSeries(LightweightCharts.AreaSeries, {
+                        lineColor: color,
+                        topColor: color.replace(')', ', 0.2)').replace('rgb', 'rgba'),
+                        bottomColor: 'transparent',
+                        lineWidth: 2,
+                        priceLineVisible: false, lastValueVisible: false,
+                    });
+                    series.setData(data.map(function (d) { return { time: d.date, value: d.close }; }));
+                    chart.timeScale().fitContent();
+
+                    // Colour the 6M label to match the sparkline
+                    var label = document.querySelector('.cpanel-spark-label');
+                    if (label) label.style.color = color;
+                });
+        }
+
+        renderSpark();
+    };
 
     function init() {
         initCommandBar();

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -1,5 +1,11 @@
 // Stocktopus Terminal — command bar, view router, WebSocket manager, security selector
 
+window.onerror = function (msg, src, line, col, err) {
+    console.error('JS error:', msg, 'at', src + ':' + line + ':' + col);
+    var el = document.getElementById('conn-status');
+    if (el) { el.textContent = 'JS ERROR'; el.style.color = '#ff4444'; el.style.borderColor = '#ff4444'; el.title = msg + ' at line ' + line; }
+};
+
 (function () {
     'use strict';
 
@@ -12,6 +18,7 @@
     let selectedSecurity = localStorage.getItem('stocktopus-security') || '';
     const commandHistory = [];
     let historyIndex = -1;
+    var wsRetryDelay = 1000;
     let newsFilterSecurity = '';
     var newsCurrentTopic = '';
     var newsSeenURLs = new Set();
@@ -136,6 +143,7 @@
         ws = new WebSocket(proto + '//' + location.host + '/ws');
 
         ws.onopen = function () {
+            wsRetryDelay = 1000; // reset on successful connect
             setConnStatus(true);
             subscribedSecurities.forEach(function (sym) {
                 ws.send(JSON.stringify({ type: 'subscribe', topic: 'quote:' + sym }));
@@ -148,7 +156,8 @@
 
         ws.onclose = function () {
             setConnStatus(false);
-            setTimeout(connectWS, 2000);
+            setTimeout(connectWS, wsRetryDelay);
+            wsRetryDelay = Math.min(wsRetryDelay * 2, 30000); // backoff up to 30s
         };
 
         ws.onerror = function () { ws.close(); };
@@ -165,6 +174,7 @@
 
     function setConnStatus(connected) {
         const el = document.getElementById('conn-status');
+        if (!el) return;
         el.textContent = connected ? 'CONNECTED' : 'DISCONNECTED';
         if (connected) {
             el.classList.add('connected');
@@ -1019,9 +1029,16 @@
                         return;
                     }
                     // Move up through layers: content → sub → main
-                    if (this._focus === 'content' && hasSub) {
-                        this._focus = 'sub';
-                    } else if (this._focus === 'content' || this._focus === 'sub') {
+                    if (this._focus === 'content') {
+                        // Scroll up first if not at top
+                        var content = document.getElementById('info-content');
+                        if (content && content.scrollTop > 0) {
+                            content.scrollTop -= 60;
+                            return;
+                        }
+                        // At top — move to sub-tabs or main
+                        this._focus = hasSub ? 'sub' : 'main';
+                    } else if (this._focus === 'sub') {
                         this._focus = 'main';
                     }
                     this._highlightFocus();
@@ -1032,19 +1049,20 @@
                     if (this._focus === 'main' && hasSub) {
                         this._focus = 'sub';
                         this._highlightFocus();
-                    } else {
-                        this._focus = 'content';
-                        this._highlightFocus();
-                        if (this.isNewsTab()) {
-                            var cards = this.getNewsCards();
-                            if (cards.length > 0) {
-                                vimSelectedIndex = Math.min(vimSelectedIndex + 1, cards.length - 1);
-                                vimSelect(cards, vimSelectedIndex);
-                            }
-                        } else {
-                            var content = document.getElementById('info-content');
-                            if (content) content.scrollTop += 60;
+                        return;
+                    }
+                    // Go straight to content (skip focus-only transition)
+                    this._focus = 'content';
+                    this._highlightFocus();
+                    if (this.isNewsTab()) {
+                        var cards = this.getNewsCards();
+                        if (cards.length > 0) {
+                            vimSelectedIndex = Math.min(vimSelectedIndex + 1, cards.length - 1);
+                            vimSelect(cards, vimSelectedIndex);
                         }
+                    } else {
+                        var content = document.getElementById('info-content');
+                        if (content) content.scrollTop += 60;
                     }
                     return;
                 }
@@ -1362,5 +1380,11 @@
         history.replaceState({ view: currentView, security: selectedSecurity }, '');
     }
 
-    init();
+    try {
+        init();
+    } catch (e) {
+        console.error('terminal.js init failed:', e);
+        var el = document.getElementById('conn-status');
+        if (el) { el.textContent = 'JS ERROR'; el.style.color = '#ff4444'; el.style.borderColor = '#ff4444'; }
+    }
 })();

--- a/internal/server/templates/debug.html
+++ b/internal/server/templates/debug.html
@@ -7,16 +7,114 @@
         <label><input type="checkbox" id="autoscroll" checked> Auto-scroll</label>
     </div>
 </div>
-<div class="debug-console" id="debug-console">
-    <div id="log-entries">
-        {{range .Entries}}
-        <div class="log-entry log-{{.Level}}">
-            <span class="log-time">{{.Time}}</span>
-            <span class="log-level">{{.Level}}</span>
-            <span class="log-msg">{{.Message}}</span>
-            {{if .Attrs}}<span class="log-attrs">{{.Attrs}}</span>{{end}}
+
+<div class="debug-panels">
+    <div class="debug-agent-panel" id="agent-panel">
+        <div class="agent-panel-header">Agent Status</div>
+        <div class="agent-stats" id="agent-stats">
+            <div class="agent-stat">
+                <span class="agent-stat-label">Gemini Requests</span>
+                <span class="agent-stat-value" id="stat-requests">—</span>
+            </div>
+            <div class="agent-stat">
+                <span class="agent-stat-label">Prompt Tokens</span>
+                <span class="agent-stat-value" id="stat-prompt-tokens">—</span>
+            </div>
+            <div class="agent-stat">
+                <span class="agent-stat-label">Output Tokens</span>
+                <span class="agent-stat-value" id="stat-output-tokens">—</span>
+            </div>
+            <div class="agent-stat">
+                <span class="agent-stat-label">Total Tokens</span>
+                <span class="agent-stat-value" id="stat-total-tokens">—</span>
+            </div>
+            <div class="agent-stat">
+                <span class="agent-stat-label">Ollama</span>
+                <span class="agent-stat-value" id="stat-ollama">—</span>
+            </div>
         </div>
-        {{end}}
+        <div class="agent-pipelines-header">Pipelines</div>
+        <div id="agent-pipelines" class="agent-pipelines"></div>
+    </div>
+
+    <div class="debug-console" id="debug-console">
+        <div id="log-entries">
+            {{range .Entries}}
+            <div class="log-entry log-{{.Level}}">
+                <span class="log-time">{{.Time}}</span>
+                <span class="log-level">{{.Level}}</span>
+                <span class="log-msg">{{.Message}}</span>
+                {{if .Attrs}}<span class="log-attrs">{{.Attrs}}</span>{{end}}
+            </div>
+            {{end}}
+        </div>
     </div>
 </div>
+
+<script>
+(function() {
+    function refreshAgentStatus() {
+        fetch('/api/agent/status')
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (!data.available) {
+                    document.getElementById('agent-stats').innerHTML = '<p style="color:var(--text-muted);font-size:12px">Agent pipeline not configured</p>';
+                    return;
+                }
+
+                var u = data.usage || {};
+                setText('stat-requests', u.totalRequests || 0);
+                setText('stat-prompt-tokens', formatNum(u.totalPromptTokens || 0));
+                setText('stat-output-tokens', formatNum(u.totalOutputTokens || 0));
+                setText('stat-total-tokens', formatNum(u.totalTokens || 0));
+
+                var ollamaEl = document.getElementById('stat-ollama');
+                if (ollamaEl) {
+                    ollamaEl.textContent = data.ollamaAvailable ? 'connected' : 'offline';
+                    ollamaEl.style.color = data.ollamaAvailable ? 'var(--green)' : 'var(--red)';
+                }
+
+                var pipelines = data.pipelines || [];
+                var pEl = document.getElementById('agent-pipelines');
+                if (pEl) {
+                    if (pipelines.length === 0) {
+                        pEl.innerHTML = '<p style="color:var(--text-muted);font-size:11px">No active pipelines</p>';
+                    } else {
+                        pEl.innerHTML = pipelines.map(function(p) {
+                            var statusClass = 'agent-pip-' + p.status;
+                            var dur = p.finishedAt && p.startedAt
+                                ? Math.round((new Date(p.finishedAt) - new Date(p.startedAt)) / 1000) + 's'
+                                : 'running...';
+                            var tasks = (p.tasks || []).map(function(t) {
+                                var icon = t.status === 'complete' ? '&#10003;' : t.status === 'running' ? '&#9679;' : t.status === 'failed' ? '&#10007;' : '&#9675;';
+                                return '<span class="pip-task pip-task-' + t.status + '">' + icon + ' ' + (t.id || t.type) + '</span>';
+                            }).join(' ');
+                            return '<div class="agent-pipeline ' + statusClass + '">'
+                                + '<span class="pip-symbol">' + p.symbol + '</span>'
+                                + '<span class="pip-status">' + p.status + '</span>'
+                                + '<span class="pip-dur">' + dur + '</span>'
+                                + '<div class="pip-tasks">' + tasks + '</div>'
+                                + '</div>';
+                        }).join('');
+                    }
+                }
+            })
+            .catch(function() {});
+    }
+
+    function setText(id, val) {
+        var el = document.getElementById(id);
+        if (el) el.textContent = val;
+    }
+
+    function formatNum(n) {
+        if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+        if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
+        return n;
+    }
+
+    refreshAgentStatus();
+    setInterval(refreshAgentStatus, 5000);
+})();
+</script>
 {{end}}

--- a/internal/server/templates/news.html
+++ b/internal/server/templates/news.html
@@ -2,6 +2,7 @@
 {{define "content"}}
 <div class="page-header">
     <h1>News <span id="news-spinner" class="spinner hidden"></span></h1>
+    <div id="company-panel" class="company-panel"></div>
 </div>
 <div class="news-tabs" id="news-tabs">
     <button class="news-tab active" data-category="press-releases"><span class="tab-key">1</span> Press Releases</button>

--- a/internal/server/templates/security.html
+++ b/internal/server/templates/security.html
@@ -1,13 +1,8 @@
 {{template "layout" .}}
 {{define "content"}}
-<div class="info-header">
-    <div class="info-title">
-        <h1>{{.Symbol}}</h1>
-        <span id="info-company-name" class="info-company-name"></span>
-        <span id="info-price" class="info-price"></span>
-        <span id="info-change" class="info-change"></span>
-    </div>
-    <div id="info-sparkline" class="info-sparkline"></div>
+<div class="page-header">
+    <h1>{{.Symbol}}</h1>
+    <div id="company-panel" class="company-panel"></div>
 </div>
 <span id="help-indicator" class="help-indicator hidden">? help on</span>
 <div class="info-tabs" id="info-tabs">

--- a/internal/server/templates/security.html
+++ b/internal/server/templates/security.html
@@ -15,6 +15,7 @@
     <button class="info-tab" data-tab="financials"><span class="tab-key">2</span> Financials</button>
     <button class="info-tab" data-tab="estimates"><span class="tab-key">3</span> Estimates</button>
     <button class="info-tab" data-tab="news"><span class="tab-key">4</span> News</button>
+    <button class="info-tab" data-tab="ai"><span class="tab-key">5</span> AI Analysis</button>
 </div>
 <div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
     <p class="empty-state">Loading...</p>

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,0 +1,226 @@
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// CompanyIntelligence holds AI-generated analysis for a security.
+type CompanyIntelligence struct {
+	Symbol        string          `json:"symbol"`
+	CompanyName   string          `json:"companyName"`
+	Sector        string          `json:"sector"`
+	Analysis      json.RawMessage `json:"analysis,omitempty"`
+	Sentiment     float64         `json:"sentiment"`
+	RiskScore     float64         `json:"riskScore"`
+	Summary       string          `json:"summary"`
+	KeyRisks      []string        `json:"keyRisks"`
+	Opportunities []string        `json:"opportunities"`
+	Competitors   []string        `json:"competitors"`
+	Sources       []string        `json:"sources"`
+	GeneratedAt   time.Time       `json:"generatedAt"`
+	ModelVersion  string          `json:"modelVersion"`
+	Confidence    float64         `json:"confidence"`
+}
+
+// TrainingPair holds a prompt/completion pair for fine-tuning.
+type TrainingPair struct {
+	ID           int64     `json:"id"`
+	Symbol       string    `json:"symbol"`
+	Prompt       string    `json:"prompt"`
+	Completion   string    `json:"completion"`
+	Source       string    `json:"source"`
+	CreatedAt    time.Time `json:"createdAt"`
+	QualityScore float64   `json:"qualityScore"`
+}
+
+// Store manages the SQLite database for company intelligence.
+type Store struct {
+	db *sql.DB
+}
+
+func New(dbPath string) (*Store, error) {
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL")
+	if err != nil {
+		return nil, fmt.Errorf("open db: %w", err)
+	}
+
+	s := &Store{db: db}
+	if err := s.migrate(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("migrate: %w", err)
+	}
+
+	return s, nil
+}
+
+func (s *Store) Close() error {
+	return s.db.Close()
+}
+
+func (s *Store) migrate() error {
+	_, err := s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS company_intelligence (
+			symbol TEXT PRIMARY KEY,
+			company_name TEXT,
+			sector TEXT,
+			analysis JSON,
+			sentiment REAL DEFAULT 0,
+			risk_score REAL DEFAULT 0,
+			summary TEXT DEFAULT '',
+			key_risks JSON DEFAULT '[]',
+			opportunities JSON DEFAULT '[]',
+			competitors JSON DEFAULT '[]',
+			sources JSON DEFAULT '[]',
+			generated_at DATETIME,
+			model_version TEXT DEFAULT '',
+			confidence REAL DEFAULT 0,
+			raw_data JSON DEFAULT '{}'
+		);
+
+		CREATE TABLE IF NOT EXISTS training_data (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			symbol TEXT,
+			prompt TEXT,
+			completion TEXT,
+			source TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			quality_score REAL DEFAULT 0
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_training_symbol ON training_data(symbol);
+	`)
+	return err
+}
+
+// Get returns the cached intelligence for a symbol, or nil if not found.
+func (s *Store) Get(symbol string) (*CompanyIntelligence, error) {
+	row := s.db.QueryRow(`
+		SELECT symbol, company_name, sector, analysis, sentiment, risk_score,
+		       summary, key_risks, opportunities, competitors, sources,
+		       generated_at, model_version, confidence
+		FROM company_intelligence WHERE symbol = ?`, symbol)
+
+	var ci CompanyIntelligence
+	var keyRisks, opportunities, competitors, sources []byte
+	var generatedAt string
+
+	err := row.Scan(&ci.Symbol, &ci.CompanyName, &ci.Sector, &ci.Analysis,
+		&ci.Sentiment, &ci.RiskScore, &ci.Summary,
+		&keyRisks, &opportunities, &competitors, &sources,
+		&generatedAt, &ci.ModelVersion, &ci.Confidence)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	json.Unmarshal(keyRisks, &ci.KeyRisks)
+	json.Unmarshal(opportunities, &ci.Opportunities)
+	json.Unmarshal(competitors, &ci.Competitors)
+	json.Unmarshal(sources, &ci.Sources)
+	ci.GeneratedAt, _ = time.Parse("2006-01-02 15:04:05Z", generatedAt+"Z")
+
+	return &ci, nil
+}
+
+// Put upserts company intelligence.
+func (s *Store) Put(ci *CompanyIntelligence) error {
+	keyRisks, _ := json.Marshal(ci.KeyRisks)
+	opportunities, _ := json.Marshal(ci.Opportunities)
+	competitors, _ := json.Marshal(ci.Competitors)
+	sources, _ := json.Marshal(ci.Sources)
+
+	_, err := s.db.Exec(`
+		INSERT INTO company_intelligence
+			(symbol, company_name, sector, analysis, sentiment, risk_score,
+			 summary, key_risks, opportunities, competitors, sources,
+			 generated_at, model_version, confidence)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(symbol) DO UPDATE SET
+			company_name = excluded.company_name,
+			sector = excluded.sector,
+			analysis = excluded.analysis,
+			sentiment = excluded.sentiment,
+			risk_score = excluded.risk_score,
+			summary = excluded.summary,
+			key_risks = excluded.key_risks,
+			opportunities = excluded.opportunities,
+			competitors = excluded.competitors,
+			sources = excluded.sources,
+			generated_at = excluded.generated_at,
+			model_version = excluded.model_version,
+			confidence = excluded.confidence`,
+		ci.Symbol, ci.CompanyName, ci.Sector, ci.Analysis,
+		ci.Sentiment, ci.RiskScore, ci.Summary,
+		keyRisks, opportunities, competitors, sources,
+		ci.GeneratedAt.UTC().Format("2006-01-02 15:04:05"),
+		ci.ModelVersion, ci.Confidence)
+
+	return err
+}
+
+// IsFresh returns true if the analysis is younger than maxAge.
+func (s *Store) IsFresh(symbol string, maxAge time.Duration) bool {
+	ci, err := s.Get(symbol)
+	if err != nil || ci == nil {
+		return false
+	}
+	return time.Since(ci.GeneratedAt) < maxAge
+}
+
+// Rename clones a company record under a new symbol.
+func (s *Store) Rename(oldSymbol, newSymbol string) error {
+	ci, err := s.Get(oldSymbol)
+	if err != nil || ci == nil {
+		return fmt.Errorf("source not found: %s", oldSymbol)
+	}
+	ci.Symbol = newSymbol
+	return s.Put(ci)
+}
+
+// AddTrainingPair stores a prompt/completion pair for fine-tuning.
+func (s *Store) AddTrainingPair(symbol, prompt, completion, source string, quality float64) error {
+	_, err := s.db.Exec(`
+		INSERT INTO training_data (symbol, prompt, completion, source, quality_score)
+		VALUES (?, ?, ?, ?, ?)`, symbol, prompt, completion, source, quality)
+	return err
+}
+
+// ExportTrainingData returns all training pairs as JSONL-ready structs.
+func (s *Store) ExportTrainingData(minQuality float64) ([]TrainingPair, error) {
+	rows, err := s.db.Query(`
+		SELECT id, symbol, prompt, completion, source, created_at, quality_score
+		FROM training_data WHERE quality_score >= ? ORDER BY created_at`, minQuality)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var pairs []TrainingPair
+	for rows.Next() {
+		var tp TrainingPair
+		var createdAt string
+		err := rows.Scan(&tp.ID, &tp.Symbol, &tp.Prompt, &tp.Completion,
+			&tp.Source, &createdAt, &tp.QualityScore)
+		if err != nil {
+			return nil, err
+		}
+		tp.CreatedAt, _ = time.Parse("2006-01-02 15:04:05", createdAt)
+		pairs = append(pairs, tp)
+	}
+	return pairs, nil
+}
+
+// TrainingDataCount returns the number of training pairs.
+func (s *Store) TrainingDataCount() (int, error) {
+	var count int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM training_data`).Scan(&count)
+	return count, err
+}

--- a/scripts/setup-ollama.sh
+++ b/scripts/setup-ollama.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+set -e
+
+echo "=== Stocktopus Ollama Setup ==="
+
+# Check if Ollama is already installed
+if command -v ollama &> /dev/null; then
+    echo "Ollama already installed: $(ollama --version)"
+else
+    echo "Installing Ollama..."
+    if [[ "$(uname)" == "Darwin" ]]; then
+        TMPDIR=$(mktemp -d)
+        echo "Downloading Ollama for macOS..."
+        curl -fsSL -o "$TMPDIR/Ollama.zip" "https://ollama.com/download/Ollama-darwin.zip"
+        echo "Extracting..."
+        unzip -q "$TMPDIR/Ollama.zip" -d "$TMPDIR"
+        echo "Installing to /Applications..."
+        cp -R "$TMPDIR/Ollama.app" /Applications/
+        rm -rf "$TMPDIR"
+        echo "Starting Ollama..."
+        open /Applications/Ollama.app
+        echo "Waiting for Ollama to start..."
+        for i in {1..30}; do
+            if curl -s http://localhost:11434/api/tags > /dev/null 2>&1; then
+                echo "Ollama is running."
+                break
+            fi
+            sleep 1
+        done
+    else
+        curl -fsSL https://ollama.ai/install.sh | sh
+    fi
+fi
+
+# Verify Ollama is running
+if ! curl -s http://localhost:11434/api/tags > /dev/null 2>&1; then
+    echo "Ollama is not running. Please start it:"
+    echo "  macOS: open /Applications/Ollama.app"
+    echo "  Linux: ollama serve"
+    exit 1
+fi
+
+MODEL="${OLLAMA_MODEL:-gemma4}"
+METHOD="${1:-auto}"
+
+if [[ "$METHOD" == "huggingface" ]] || [[ "$METHOD" == "hf" ]]; then
+    echo ""
+    echo "=== Downloading GGUF from HuggingFace (faster) ==="
+    echo ""
+    echo "Choose a model variant:"
+    echo "  1) gemma-4-26B-A4B (recommended: 26B total, 4B active — fast + smart)"
+    echo "  2) gemma-4-E4B (4B — smallest, fastest)"
+    echo "  3) gemma-4-31B (31B — largest, most capable)"
+    echo ""
+    read -p "Choice [1]: " CHOICE
+    CHOICE="${CHOICE:-1}"
+
+    MODELS_DIR="$HOME/.ollama/models/blobs"
+    mkdir -p "$MODELS_DIR"
+
+    case "$CHOICE" in
+        1)
+            HF_REPO="unsloth/gemma-4-26B-A4B-it-GGUF"
+            GGUF_FILE="gemma-4-26B-A4B-it-Q4_K_M.gguf"
+            MODEL_NAME="gemma4-26b-a4b"
+            ;;
+        2)
+            HF_REPO="unsloth/gemma-4-E4B-it-GGUF"
+            GGUF_FILE="gemma-4-E4B-it-Q4_K_M.gguf"
+            MODEL_NAME="gemma4-e4b"
+            ;;
+        3)
+            HF_REPO="unsloth/gemma-4-31B-it-GGUF"
+            GGUF_FILE="gemma-4-31B-it-Q4_K_M.gguf"
+            MODEL_NAME="gemma4-31b"
+            ;;
+        *)
+            echo "Invalid choice"
+            exit 1
+            ;;
+    esac
+
+    DOWNLOAD_DIR="$(pwd)/.models"
+    mkdir -p "$DOWNLOAD_DIR"
+    GGUF_PATH="$DOWNLOAD_DIR/$GGUF_FILE"
+
+    if [[ -f "$GGUF_PATH" ]]; then
+        echo "GGUF already downloaded: $GGUF_PATH"
+    else
+        echo "Downloading $GGUF_FILE from HuggingFace..."
+        curl -L -o "$GGUF_PATH" \
+            "https://huggingface.co/$HF_REPO/resolve/main/$GGUF_FILE"
+    fi
+
+    echo "Creating Ollama model from GGUF..."
+    cat > "$DOWNLOAD_DIR/Modelfile" <<EOF
+FROM $GGUF_PATH
+
+PARAMETER temperature 0.3
+PARAMETER num_predict 4096
+
+SYSTEM """You are a financial analyst AI. Analyze companies using provided data and return structured JSON analysis."""
+EOF
+
+    ollama create "$MODEL_NAME" -f "$DOWNLOAD_DIR/Modelfile"
+    echo ""
+    echo "Model created: $MODEL_NAME"
+    echo "Set OLLAMA_MODEL=$MODEL_NAME in your environment"
+
+else
+    echo "Pulling $MODEL from Ollama registry..."
+    ollama pull "$MODEL"
+fi
+
+echo ""
+echo "=== Setup Complete ==="
+ollama list
+echo ""
+echo "Test with: ollama run ${MODEL_NAME:-$MODEL} 'Analyze AAPL stock briefly'"

--- a/tests/e2e/smoke_test.go
+++ b/tests/e2e/smoke_test.go
@@ -68,7 +68,7 @@ func TestMain(m *testing.M) {
 	debug := server.NewDebugBroadcaster()
 
 	// Server
-	srv, err := server.New(server.Config{Port: 0}, h, debug, poll, newsClient, logger)
+	srv, err := server.New(server.Config{Port: 0}, h, debug, poll, newsClient, nil, logger)
 	if err != nil {
 		panic("failed to create server: " + err.Error())
 	}


### PR DESCRIPTION
## Summary

- **Agent pipeline**: On-demand company analysis triggered when viewing the AI Analysis tab. Gemini 3.1 Pro orchestrates, Ollama Gemma 4 workers handle data gathering in parallel.
- **4 Python agents**: web search (DuckDuckGo), RSS news aggregation, SEC EDGAR filings, Bluesky social sentiment
- **SQLite storage**: `company_intelligence` table caches analysis (24h TTL), `training_data` table collects prompt/completion pairs for fine-tuning
- **Fine-tuning pipeline**: JSONL export + Ollama Modelfile generation for custom model creation
- **AI Analysis tab** (tab 5 on info page): executive summary, sentiment/risk/confidence gauges, key risks, opportunities, competitors, sector outlook, technical outlook, catalysts, sources
- **Background execution**: pipeline runs in detached goroutine with 5-min timeout, progress via WebSocket
- **UTC dates everywhere**: all stored timestamps in UTC

## New components
- `internal/agent/` — pipeline framework, orchestrator, worker pool, fine-tuner
- `internal/store/` — SQLite company intelligence store
- `agents/` — Python data gathering scripts
- `scripts/setup-ollama.sh` — Ollama + Gemma 4 setup script

## New endpoints
- `GET /api/security/{symbol}/intelligence` — cached analysis or trigger pipeline
- `GET /api/security/{symbol}/intelligence/status` — pipeline progress
- `POST /api/security/{symbol}/intelligence/refresh` — force re-analysis
- `GET /api/agent/status` — agent system health

## Test plan
- [ ] `make smoke` — all 17 tests pass
- [ ] `info AAPL` → tab 5 "AI Analysis" → triggers pipeline → shows analysis
- [ ] Cached results load instantly on revisit
- [ ] `./scripts/setup-ollama.sh huggingface` installs Gemma 4
- [ ] `make setup-agents` pulls model + installs Python deps