### PR TITLE
feat: wider chart view with lazy history loading

### DIFF
--- a/cmd/stocktopus/main.go
+++ b/cmd/stocktopus/main.go
@@ -136,7 +136,7 @@ func main() {
 		slog.Info("agent pipeline ready", "ollamaModel", ollamaModel, "cacheTTL", cacheTTL)
 	}
 
-	srv, err := server.New(server.Config{Port: 8080, Host: "localhost"}, h, debug, poll, newsClient, pipeline, logger)
+	srv, err := server.New(server.Config{Port: 8080, Host: "localhost"}, h, debug, poll, newsClient, pipeline, st, logger)
 	if err != nil {
 		slog.Error("failed to create server", "error", err)
 		os.Exit(1)

--- a/internal/news/news.go
+++ b/internal/news/news.go
@@ -22,6 +22,9 @@ type SearchResult struct {
 	Exchange string `json:"exchange"`
 }
 
+// APIKey returns the FMP API key.
+func (c *Client) APIKey() string { return c.apiKey }
+
 // SetGeminiKey sets the Gemini API key for AI-assisted search fallback.
 func (c *Client) SetGeminiKey(key string) {
 	c.geminiKey = key

--- a/internal/news/news.go
+++ b/internal/news/news.go
@@ -306,6 +306,69 @@ func (c *Client) GetAnalystEstimates(ctx context.Context, symbol string, limit i
 	return c.fetchJSON(ctx, "/stable/analyst-estimates", params)
 }
 
+// GetIntradayChart fetches intraday OHLCV data for a symbol.
+// interval: "1min", "5min", "15min", "30min", "1hour", "4hour"
+func (c *Client) GetIntradayChart(ctx context.Context, symbol, interval, from, to string) ([]model.OHLCV, error) {
+	params := url.Values{}
+	params.Set("symbol", symbol)
+	params.Set("apikey", c.apiKey)
+	if from != "" {
+		params.Set("from", from)
+	}
+	if to != "" {
+		params.Set("to", to)
+	}
+
+	reqURL := c.baseURL + "/stable/historical-chart/" + interval + "?" + params.Encode()
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("intraday request: %w", err)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("intraday fetch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("intraday read: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("intraday API %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Response has float volumes and datetime strings
+	var raw []struct {
+		Date   string  `json:"date"`
+		Open   float64 `json:"open"`
+		High   float64 `json:"high"`
+		Low    float64 `json:"low"`
+		Close  float64 `json:"close"`
+		Volume float64 `json:"volume"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("intraday parse: %w", err)
+	}
+
+	// Reverse to chronological order (API returns newest-first)
+	items := make([]model.OHLCV, len(raw))
+	for i, r := range raw {
+		items[len(raw)-1-i] = model.OHLCV{
+			Date:   r.Date,
+			Open:   r.Open,
+			High:   r.High,
+			Low:    r.Low,
+			Close:  r.Close,
+			Volume: int64(r.Volume),
+		}
+	}
+
+	return items, nil
+}
+
 // Category represents a news feed type.
 type Category string
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -124,6 +124,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/news/{category}", s.handleNewsAPI)
 	mux.HandleFunc("GET /api/search", s.handleSearch)
 	mux.HandleFunc("GET /api/chart/eod/{symbol}", s.handleChartEOD)
+	mux.HandleFunc("GET /api/chart/intraday/{interval}/{symbol}", s.handleChartIntraday)
 	mux.HandleFunc("GET /api/security/{symbol}/profile", s.handleSecurityProfile)
 	mux.HandleFunc("GET /api/security/{symbol}/metrics", s.handleSecurityMetrics)
 	mux.HandleFunc("GET /api/security/{symbol}/financials", s.handleSecurityFinancials)
@@ -510,6 +511,34 @@ func (s *Server) handleChartEOD(w http.ResponseWriter, r *http.Request) {
 	items, err := s.news.GetHistoricalEOD(r.Context(), symbol, from, to)
 	if err != nil {
 		s.logger.Error("chart eod failed", "symbol", symbol, "error", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(items)
+}
+
+func (s *Server) handleChartIntraday(w http.ResponseWriter, r *http.Request) {
+	interval := r.PathValue("interval")
+	symbol := r.PathValue("symbol")
+	from := r.URL.Query().Get("from")
+	to := r.URL.Query().Get("to")
+
+	// Validate interval
+	valid := map[string]bool{"1min": true, "5min": true, "15min": true, "30min": true, "1hour": true, "4hour": true}
+	if !valid[interval] {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "invalid interval: " + interval})
+		return
+	}
+
+	items, err := s.news.GetIntradayChart(r.Context(), symbol, interval, from, to)
+	if err != nil {
+		s.logger.Error("chart intraday failed", "symbol", symbol, "interval", interval, "error", err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadGateway)
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,15 +5,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"stocktopus/internal/agent"
 	"stocktopus/internal/hub"
 	"stocktopus/internal/news"
+	"stocktopus/internal/store"
 )
 
 type Config struct {
@@ -48,9 +52,10 @@ type Server struct {
 	symbols    SymbolLister
 	news       *news.Client
 	pipeline   *agent.Pipeline
+	store      *store.Store
 }
 
-func New(cfg Config, h *hub.Hub, debug *DebugBroadcaster, symbols SymbolLister, newsClient *news.Client, pipeline *agent.Pipeline, logger *slog.Logger) (*Server, error) {
+func New(cfg Config, h *hub.Hub, debug *DebugBroadcaster, symbols SymbolLister, newsClient *news.Client, pipeline *agent.Pipeline, st *store.Store, logger *slog.Logger) (*Server, error) {
 	s := &Server{
 		config:   cfg,
 		logger:   logger,
@@ -58,6 +63,7 @@ func New(cfg Config, h *hub.Hub, debug *DebugBroadcaster, symbols SymbolLister, 
 		debug:    debug,
 		symbols:  symbols,
 		pipeline: pipeline,
+		store:    st,
 		news:    newsClient,
 	}
 
@@ -133,6 +139,11 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/security/{symbol}/intelligence/status", s.handleIntelligenceStatus)
 	mux.HandleFunc("POST /api/security/{symbol}/intelligence/refresh", s.handleIntelligenceRefresh)
 	mux.HandleFunc("GET /api/agent/status", s.handleAgentStatus)
+	mux.HandleFunc("GET /api/watchlists", s.handleGetWatchlists)
+	mux.HandleFunc("POST /api/watchlists", s.handleCreateWatchlist)
+	mux.HandleFunc("POST /api/watchlists/{id}/symbols", s.handleAddToWatchlist)
+	mux.HandleFunc("DELETE /api/watchlists/{id}/symbols/{symbol}", s.handleRemoveFromWatchlist)
+	mux.HandleFunc("GET /api/watchlists/quotes", s.handleWatchlistQuotes)
 	mux.HandleFunc("GET /api/security/{symbol}/competitors", s.handleCompetitors)
 
 	// WebSocket
@@ -465,6 +476,119 @@ func (s *Server) handleCompetitors(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(results)
+}
+
+func (s *Server) handleGetWatchlists(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.store == nil {
+		json.NewEncoder(w).Encode([]any{})
+		return
+	}
+	lists, err := s.store.GetWatchlists()
+	if err != nil {
+		s.logger.Error("get watchlists failed", "error", err)
+		json.NewEncoder(w).Encode([]any{})
+		return
+	}
+	json.NewEncoder(w).Encode(lists)
+}
+
+func (s *Server) handleCreateWatchlist(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.store == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(map[string]string{"error": "store not available"})
+		return
+	}
+	var req struct {
+		Name string `json:"name"`
+	}
+	json.NewDecoder(r.Body).Decode(&req)
+	if req.Name == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "name required"})
+		return
+	}
+	wl, err := s.store.CreateWatchlist(req.Name)
+	if err != nil {
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	json.NewEncoder(w).Encode(wl)
+}
+
+func (s *Server) handleAddToWatchlist(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.store == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+	id, _ := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	var req struct {
+		Symbol string `json:"symbol"`
+	}
+	json.NewDecoder(r.Body).Decode(&req)
+	if req.Symbol == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "symbol required"})
+		return
+	}
+	err := s.store.AddToWatchlist(id, req.Symbol)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]string{"status": "added", "symbol": req.Symbol})
+}
+
+func (s *Server) handleRemoveFromWatchlist(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.store == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+	id, _ := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	symbol := r.PathValue("symbol")
+	s.store.RemoveFromWatchlist(id, symbol)
+	json.NewEncoder(w).Encode(map[string]string{"status": "removed"})
+}
+
+func (s *Server) handleWatchlistQuotes(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.store == nil {
+		json.NewEncoder(w).Encode([]any{})
+		return
+	}
+
+	symbols, err := s.store.GetAllWatchedSymbols()
+	if err != nil || len(symbols) == 0 {
+		json.NewEncoder(w).Encode([]any{})
+		return
+	}
+
+	// Batch fetch from FMP
+	params := url.Values{}
+	params.Set("symbols", strings.Join(symbols, ","))
+	params.Set("apikey", s.news.APIKey())
+
+	reqURL := "https://financialmodelingprep.com/stable/batch-quote?" + params.Encode()
+	req, err := http.NewRequestWithContext(r.Context(), "GET", reqURL, nil)
+	if err != nil {
+		json.NewEncoder(w).Encode([]any{})
+		return
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		json.NewEncoder(w).Encode([]any{})
+		return
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	w.Write(body)
 }
 
 // gatherFMPData collects all available FMP data for a symbol as JSON context.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -15,7 +15,7 @@ func testServer(t *testing.T) (*Server, *http.ServeMux) {
 	logger := slog.Default()
 	h := hub.New(logger)
 	debug := NewDebugBroadcaster()
-	srv, err := New(Config{Port: 0}, h, debug, nil, nil, nil, logger)
+	srv, err := New(Config{Port: 0}, h, debug, nil, nil, nil, nil, logger)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -1,4 +1,4 @@
-// Stocktopus Chart — EOD candlestick with volume and lazy history loading
+// Stocktopus Chart — EOD + intraday candlestick with volume and lazy history loading
 
 (function () {
     'use strict';
@@ -14,18 +14,35 @@
     var RANGE_KEY = 'stocktopus-chart-range';
     var defaultRange = localStorage.getItem(RANGE_KEY) || '1M';
 
-    // How much data to fetch initially (wider than the selected period)
-    var FETCH_SPANS = {
-        '1W': { fetch: 30, view: 7 },    // fetch 1 month, show last week
-        '1M': { fetch: 90, view: 30 },   // fetch 3 months, show last month
-        '3M': { fetch: 180, view: 90 },  // fetch 6 months, show last 3 months
-        '6M': { fetch: 365, view: 180 }, // fetch 1 year, show last 6 months
+    // ── Range Config ──
+
+    // EOD ranges: fetch more than shown, with lazy scroll-back
+    var EOD_RANGES = {
+        '1W': { fetch: 30, view: 7 },
+        '1M': { fetch: 90, view: 30 },
+        '3M': { fetch: 180, view: 90 },
+        '6M': { fetch: 365, view: 180 },
     };
 
-    // Track loaded data boundaries for lazy loading
-    var loadedFrom = null;   // earliest date loaded
-    var currentRange = null; // current range key
+    // Intraday ranges: interval name for API, how many days to fetch/show
+    var INTRADAY_RANGES = {
+        '1m':  { interval: '1min',  fetchDays: 1,  viewDays: 1,  scrollDays: 1 },
+        '5m':  { interval: '5min',  fetchDays: 3,  viewDays: 1,  scrollDays: 2 },
+        '15m': { interval: '15min', fetchDays: 5,  viewDays: 2,  scrollDays: 5 },
+        '30m': { interval: '30min', fetchDays: 10, viewDays: 3,  scrollDays: 7 },
+        '1h':  { interval: '1hour', fetchDays: 20, viewDays: 5,  scrollDays: 10 },
+        '4h':  { interval: '4hour', fetchDays: 60, viewDays: 15, scrollDays: 30 },
+    };
+
+    var currentRange = null;
+    var isIntraday = false;
+    var loadedFrom = null;
     var isLoadingMore = false;
+
+    // ── All loaded data ──
+
+    var allCandles = [];
+    var allVolumes = [];
 
     // ── Create Chart ──
 
@@ -51,17 +68,17 @@
         },
         timeScale: {
             borderColor: '#2a2a2a',
-            timeVisible: false,
+            timeVisible: true,
+            secondsVisible: false,
             rightOffset: 5,
         },
         handleScroll: true,
         handleScale: true,
     });
 
-    // Expose chart for vim keybindings
     window._stocktopusChart = chart;
 
-    // ── Candlestick Series ──
+    // ── Series ──
 
     var candleSeries = chart.addSeries(LightweightCharts.CandlestickSeries, {
         upColor: '#00cc66',
@@ -70,8 +87,6 @@
         wickDownColor: '#ff4444',
         borderVisible: false,
     });
-
-    // ── Volume Series ──
 
     var volumeSeries = chart.addSeries(LightweightCharts.HistogramSeries, {
         priceFormat: { type: 'volume' },
@@ -82,11 +97,6 @@
         scaleMargins: { top: 0.8, bottom: 0 },
         drawTicks: false,
     });
-
-    // ── All loaded data (sorted chronologically) ──
-
-    var allCandles = [];
-    var allVolumes = [];
 
     // ── Range Buttons ──
 
@@ -107,7 +117,7 @@
         });
     }
 
-    // ── Set Range (callable from vim : commands) ──
+    // ── Set Range ──
 
     function setRange(range) {
         localStorage.setItem(RANGE_KEY, range);
@@ -116,85 +126,136 @@
         allCandles = [];
         allVolumes = [];
         loadedFrom = null;
-        loadRange(range);
+        isIntraday = !!INTRADAY_RANGES[range];
+
+        // Toggle time visibility based on type
+        chart.timeScale().applyOptions({
+            timeVisible: isIntraday,
+        });
+
+        if (isIntraday) {
+            loadIntraday(range);
+        } else {
+            loadEOD(range);
+        }
     }
 
-    // Expose for vim : commands
     window._stocktopusSetRange = setRange;
 
-    // ── Data Loading ──
+    // ── EOD Loading ──
 
-    function loadRange(range) {
-        var span = FETCH_SPANS[range] || { fetch: 30, view: 7 };
+    function loadEOD(range) {
+        var span = EOD_RANGES[range] || { fetch: 30, view: 7 };
         var to = new Date();
         var from = new Date();
         from.setDate(from.getDate() - span.fetch);
 
-        fetchAndRender(formatDate(from), formatDate(to), true, span.view);
+        fetchEODAndRender(formatDate(from), formatDate(to), span.view);
     }
 
-    function fetchAndRender(fromStr, toStr, fitToView, viewDays) {
+    function fetchEODAndRender(fromStr, toStr, viewDays) {
         fetch('/api/chart/eod/' + symbol + '?from=' + fromStr + '&to=' + toStr)
             .then(function (r) { return r.json(); })
             .then(function (data) {
                 if (!data || data.length === 0) return;
 
-                var newCandles = data.map(function (d) {
+                mergeData(data.map(function (d) {
                     return { time: d.date, open: d.open, high: d.high, low: d.low, close: d.close };
-                });
-                var newVolumes = data.map(function (d) {
-                    var color = d.close >= d.open ? 'rgba(0, 204, 102, 0.3)' : 'rgba(255, 68, 68, 0.3)';
-                    return { time: d.date, value: d.volume, color: color };
-                });
+                }), data.map(function (d) {
+                    return { time: d.date, value: d.volume, color: d.close >= d.open ? 'rgba(0, 204, 102, 0.3)' : 'rgba(255, 68, 68, 0.3)' };
+                }));
 
-                // Merge with existing data, avoiding duplicates
-                var existingDates = {};
-                allCandles.forEach(function (c) { existingDates[c.time] = true; });
-
-                newCandles.forEach(function (c, i) {
-                    if (!existingDates[c.time]) {
-                        allCandles.push(c);
-                        allVolumes.push(newVolumes[i]);
-                    }
-                });
-
-                // Sort chronologically
-                allCandles.sort(function (a, b) { return a.time < b.time ? -1 : 1; });
-                allVolumes.sort(function (a, b) { return a.time < b.time ? -1 : 1; });
-
-                // Update loaded boundary
+                setChartData();
                 loadedFrom = allCandles[0].time;
 
-                // Set data
-                candleSeries.setData(allCandles);
-                volumeSeries.setData(allVolumes);
-
-                if (fitToView && viewDays) {
-                    // Scroll to show only the view period at the right edge
-                    chart.timeScale().fitContent();
-                    // Set visible range to the last N days
+                if (viewDays) {
                     var viewFrom = new Date();
                     viewFrom.setDate(viewFrom.getDate() - viewDays);
-                    chart.timeScale().setVisibleRange({
-                        from: formatDate(viewFrom),
-                        to: formatDate(new Date()),
-                    });
+                    chart.timeScale().setVisibleRange({ from: formatDate(viewFrom), to: formatDate(new Date()) });
                 }
 
                 isLoadingMore = false;
             })
-            .catch(function (err) {
-                console.error('Chart data error:', err);
+            .catch(function (err) { console.error('EOD error:', err); isLoadingMore = false; });
+    }
+
+    // ── Intraday Loading ──
+
+    function loadIntraday(range) {
+        var cfg = INTRADAY_RANGES[range];
+        if (!cfg) return;
+
+        var to = new Date();
+        var from = new Date();
+        from.setDate(from.getDate() - cfg.fetchDays);
+
+        fetchIntradayAndRender(cfg.interval, formatDate(from), formatDate(to), cfg.viewDays);
+    }
+
+    function fetchIntradayAndRender(interval, fromStr, toStr, viewDays) {
+        fetch('/api/chart/intraday/' + interval + '/' + symbol + '?from=' + fromStr + '&to=' + toStr)
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (!data || data.length === 0) return;
+
+                mergeData(data.map(function (d) {
+                    return { time: parseIntradayTime(d.date), open: d.open, high: d.high, low: d.low, close: d.close };
+                }), data.map(function (d) {
+                    return { time: parseIntradayTime(d.date), value: d.volume, color: d.close >= d.open ? 'rgba(0, 204, 102, 0.3)' : 'rgba(255, 68, 68, 0.3)' };
+                }));
+
+                setChartData();
+                if (allCandles.length > 0) loadedFrom = allCandles[0].time;
+
+                if (viewDays) {
+                    chart.timeScale().fitContent();
+                }
+
                 isLoadingMore = false;
-            });
+            })
+            .catch(function (err) { console.error('Intraday error:', err); isLoadingMore = false; });
+    }
+
+    // Parse "2026-04-21 13:55:00" to Unix timestamp for Lightweight Charts
+    function parseIntradayTime(dateStr) {
+        var d = new Date(dateStr.replace(' ', 'T') + 'Z');
+        return Math.floor(d.getTime() / 1000);
+    }
+
+    // ── Data Merge ──
+
+    function mergeData(newCandles, newVolumes) {
+        var existing = {};
+        allCandles.forEach(function (c) { existing[JSON.stringify(c.time)] = true; });
+
+        newCandles.forEach(function (c, i) {
+            var key = JSON.stringify(c.time);
+            if (!existing[key]) {
+                allCandles.push(c);
+                allVolumes.push(newVolumes[i]);
+                existing[key] = true;
+            }
+        });
+
+        // Sort
+        var timeSort = function (a, b) {
+            var ta = typeof a.time === 'number' ? a.time : a.time;
+            var tb = typeof b.time === 'number' ? b.time : b.time;
+            return ta < tb ? -1 : ta > tb ? 1 : 0;
+        };
+        allCandles.sort(timeSort);
+        allVolumes.sort(timeSort);
+    }
+
+    function setChartData() {
+        candleSeries.setData(allCandles);
+        volumeSeries.setData(allVolumes);
     }
 
     // ── Lazy Loading on Scroll Left ──
 
     chart.timeScale().subscribeVisibleLogicalRangeChange(function (logicalRange) {
         if (!logicalRange || isLoadingMore || !loadedFrom) return;
-
-        // If the user has scrolled to show data near the left edge, load more
         if (logicalRange.from < 5) {
             loadMoreHistory();
         }
@@ -204,14 +265,26 @@
         if (isLoadingMore || !loadedFrom) return;
         isLoadingMore = true;
 
-        var span = FETCH_SPANS[currentRange] || { fetch: 30 };
-        var to = new Date(loadedFrom);
-        to.setDate(to.getDate() - 1); // day before current earliest
-        var from = new Date(to);
-        from.setDate(from.getDate() - span.fetch);
-
-        fetchAndRender(formatDate(from), formatDate(to), false, 0);
+        if (isIntraday) {
+            var cfg = INTRADAY_RANGES[currentRange];
+            if (!cfg) { isLoadingMore = false; return; }
+            // loadedFrom is a unix timestamp for intraday
+            var toDate = new Date(loadedFrom * 1000);
+            toDate.setDate(toDate.getDate() - 1);
+            var fromDate = new Date(toDate);
+            fromDate.setDate(fromDate.getDate() - cfg.scrollDays);
+            fetchIntradayAndRender(cfg.interval, formatDate(fromDate), formatDate(toDate), 0);
+        } else {
+            var span = EOD_RANGES[currentRange] || { fetch: 30 };
+            var to = new Date(loadedFrom);
+            to.setDate(to.getDate() - 1);
+            var from = new Date(to);
+            from.setDate(from.getDate() - span.fetch);
+            fetchEODAndRender(formatDate(from), formatDate(to), 0);
+        }
     }
+
+    // ── Helpers ──
 
     function formatDate(d) {
         var y = d.getFullYear();
@@ -220,8 +293,6 @@
         return y + '-' + m + '-' + day;
     }
 
-    // ── Resize ──
-
     function resizeChart() {
         chart.resize(container.clientWidth, container.clientHeight);
     }
@@ -229,9 +300,15 @@
     window.addEventListener('resize', resizeChart);
     resizeChart();
 
-    // ── Default Load (from persisted range) ──
+    // ── Default Load ──
 
     setActiveRangeBtn(defaultRange);
     currentRange = defaultRange;
-    loadRange(defaultRange);
+    isIntraday = !!INTRADAY_RANGES[defaultRange];
+    if (isIntraday) {
+        chart.timeScale().applyOptions({ timeVisible: true });
+        loadIntraday(defaultRange);
+    } else {
+        loadEOD(defaultRange);
+    }
 })();

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -38,6 +38,11 @@
     var isIntraday = false;
     var loadedFrom = null;
     var isLoadingMore = false;
+    var autoRefresh = true;
+    var autoRefreshTimer = null;
+
+    // Intervals under 1 hour that support auto-refresh
+    var AUTO_REFRESH_INTERVALS = { '1m': 60, '5m': 300, '15m': 900, '30m': 1800 };
 
     // ── All loaded data ──
 
@@ -117,6 +122,79 @@
         });
     }
 
+    // ── Auto-Refresh Button ──
+
+    var autoRefreshBtn = document.getElementById('chart-auto-refresh');
+    if (autoRefreshBtn) {
+        autoRefreshBtn.onclick = function () {
+            autoRefresh = !autoRefresh;
+            autoRefreshBtn.classList.toggle('active', autoRefresh);
+            if (autoRefresh) {
+                scheduleAutoRefresh();
+            } else {
+                clearAutoRefresh();
+            }
+        };
+    }
+
+    function updateAutoRefreshVisibility() {
+        if (autoRefreshBtn) {
+            autoRefreshBtn.style.display = AUTO_REFRESH_INTERVALS[currentRange] ? '' : 'none';
+        }
+    }
+
+    function scheduleAutoRefresh() {
+        clearAutoRefresh();
+        if (!autoRefresh || !currentRange) return;
+
+        var intervalSecs = AUTO_REFRESH_INTERVALS[currentRange];
+        if (!intervalSecs) return;
+
+        // Calculate ms until the next clock boundary + 3s buffer
+        var now = new Date();
+        var epochSecs = Math.floor(now.getTime() / 1000);
+        var remainder = epochSecs % intervalSecs;
+        var delayMs = ((intervalSecs - remainder) * 1000) + 3000;
+
+        console.log('Auto-refresh scheduled in', Math.round(delayMs / 1000) + 's for', currentRange);
+
+        autoRefreshTimer = setTimeout(function () {
+            console.log('Auto-refreshing', symbol, currentRange);
+            refreshLatest();
+            scheduleAutoRefresh();
+        }, delayMs);
+    }
+
+    function clearAutoRefresh() {
+        if (autoRefreshTimer) {
+            clearTimeout(autoRefreshTimer);
+            autoRefreshTimer = null;
+        }
+    }
+
+    function refreshLatest() {
+        if (!isIntraday || !currentRange) return;
+        var cfg = INTRADAY_RANGES[currentRange];
+        if (!cfg) return;
+
+        // Fetch just today's data and merge
+        var today = formatDate(new Date());
+        fetch('/api/chart/intraday/' + cfg.interval + '/' + symbol + '?from=' + today + '&to=' + today)
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (!data || data.length === 0) return;
+
+                mergeData(data.map(function (d) {
+                    return { time: parseIntradayTime(d.date), open: d.open, high: d.high, low: d.low, close: d.close };
+                }), data.map(function (d) {
+                    return { time: parseIntradayTime(d.date), value: d.volume, color: d.close >= d.open ? 'rgba(0, 204, 102, 0.3)' : 'rgba(255, 68, 68, 0.3)' };
+                }));
+
+                setChartData();
+            })
+            .catch(function (err) { console.error('Auto-refresh error:', err); });
+    }
+
     // ── Set Range ──
 
     function setRange(range) {
@@ -133,8 +211,12 @@
             timeVisible: isIntraday,
         });
 
+        updateAutoRefreshVisibility();
+        clearAutoRefresh();
+
         if (isIntraday) {
             loadIntraday(range);
+            if (autoRefresh) scheduleAutoRefresh();
         } else {
             loadEOD(range);
         }
@@ -225,15 +307,21 @@
     // ── Data Merge ──
 
     function mergeData(newCandles, newVolumes) {
-        var existing = {};
-        allCandles.forEach(function (c) { existing[JSON.stringify(c.time)] = true; });
+        // Build index of existing data by time
+        var existingIdx = {};
+        allCandles.forEach(function (c, i) { existingIdx[JSON.stringify(c.time)] = i; });
 
         newCandles.forEach(function (c, i) {
             var key = JSON.stringify(c.time);
-            if (!existing[key]) {
+            if (key in existingIdx) {
+                // Update existing candle (e.g. current minute updating)
+                var idx = existingIdx[key];
+                allCandles[idx] = c;
+                allVolumes[idx] = newVolumes[i];
+            } else {
                 allCandles.push(c);
                 allVolumes.push(newVolumes[i]);
-                existing[key] = true;
+                existingIdx[key] = allCandles.length - 1;
             }
         });
 
@@ -305,9 +393,11 @@
     setActiveRangeBtn(defaultRange);
     currentRange = defaultRange;
     isIntraday = !!INTRADAY_RANGES[defaultRange];
+    updateAutoRefreshVisibility();
     if (isIntraday) {
         chart.timeScale().applyOptions({ timeVisible: true });
         loadIntraday(defaultRange);
+        if (autoRefresh) scheduleAutoRefresh();
     } else {
         loadEOD(defaultRange);
     }

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -1,4 +1,4 @@
-// Stocktopus Chart — EOD candlestick with volume
+// Stocktopus Chart — EOD candlestick with volume and lazy history loading
 
 (function () {
     'use strict';
@@ -13,6 +13,19 @@
 
     var RANGE_KEY = 'stocktopus-chart-range';
     var defaultRange = localStorage.getItem(RANGE_KEY) || '1M';
+
+    // How much data to fetch initially (wider than the selected period)
+    var FETCH_SPANS = {
+        '1W': { fetch: 30, view: 7 },    // fetch 1 month, show last week
+        '1M': { fetch: 90, view: 30 },   // fetch 3 months, show last month
+        '3M': { fetch: 180, view: 90 },  // fetch 6 months, show last 3 months
+        '6M': { fetch: 365, view: 180 }, // fetch 1 year, show last 6 months
+    };
+
+    // Track loaded data boundaries for lazy loading
+    var loadedFrom = null;   // earliest date loaded
+    var currentRange = null; // current range key
+    var isLoadingMore = false;
 
     // ── Create Chart ──
 
@@ -70,6 +83,11 @@
         drawTicks: false,
     });
 
+    // ── All loaded data (sorted chronologically) ──
+
+    var allCandles = [];
+    var allVolumes = [];
+
     // ── Range Buttons ──
 
     function setActiveRangeBtn(range) {
@@ -94,6 +112,10 @@
     function setRange(range) {
         localStorage.setItem(RANGE_KEY, range);
         setActiveRangeBtn(range);
+        currentRange = range;
+        allCandles = [];
+        allVolumes = [];
+        loadedFrom = null;
         loadRange(range);
     }
 
@@ -103,40 +125,92 @@
     // ── Data Loading ──
 
     function loadRange(range) {
+        var span = FETCH_SPANS[range] || { fetch: 30, view: 7 };
         var to = new Date();
         var from = new Date();
+        from.setDate(from.getDate() - span.fetch);
 
-        switch (range) {
-            case '1W': from.setDate(from.getDate() - 7); break;
-            case '1M': from.setMonth(from.getMonth() - 1); break;
-            case '3M': from.setMonth(from.getMonth() - 3); break;
-            case '6M': from.setMonth(from.getMonth() - 6); break;
-        }
+        fetchAndRender(formatDate(from), formatDate(to), true, span.view);
+    }
 
-        var fromStr = formatDate(from);
-        var toStr = formatDate(to);
-
+    function fetchAndRender(fromStr, toStr, fitToView, viewDays) {
         fetch('/api/chart/eod/' + symbol + '?from=' + fromStr + '&to=' + toStr)
             .then(function (r) { return r.json(); })
             .then(function (data) {
                 if (!data || data.length === 0) return;
 
-                var candles = data.map(function (d) {
+                var newCandles = data.map(function (d) {
                     return { time: d.date, open: d.open, high: d.high, low: d.low, close: d.close };
                 });
-
-                var volumes = data.map(function (d) {
+                var newVolumes = data.map(function (d) {
                     var color = d.close >= d.open ? 'rgba(0, 204, 102, 0.3)' : 'rgba(255, 68, 68, 0.3)';
                     return { time: d.date, value: d.volume, color: color };
                 });
 
-                candleSeries.setData(candles);
-                volumeSeries.setData(volumes);
-                chart.timeScale().fitContent();
+                // Merge with existing data, avoiding duplicates
+                var existingDates = {};
+                allCandles.forEach(function (c) { existingDates[c.time] = true; });
+
+                newCandles.forEach(function (c, i) {
+                    if (!existingDates[c.time]) {
+                        allCandles.push(c);
+                        allVolumes.push(newVolumes[i]);
+                    }
+                });
+
+                // Sort chronologically
+                allCandles.sort(function (a, b) { return a.time < b.time ? -1 : 1; });
+                allVolumes.sort(function (a, b) { return a.time < b.time ? -1 : 1; });
+
+                // Update loaded boundary
+                loadedFrom = allCandles[0].time;
+
+                // Set data
+                candleSeries.setData(allCandles);
+                volumeSeries.setData(allVolumes);
+
+                if (fitToView && viewDays) {
+                    // Scroll to show only the view period at the right edge
+                    chart.timeScale().fitContent();
+                    // Set visible range to the last N days
+                    var viewFrom = new Date();
+                    viewFrom.setDate(viewFrom.getDate() - viewDays);
+                    chart.timeScale().setVisibleRange({
+                        from: formatDate(viewFrom),
+                        to: formatDate(new Date()),
+                    });
+                }
+
+                isLoadingMore = false;
             })
             .catch(function (err) {
                 console.error('Chart data error:', err);
+                isLoadingMore = false;
             });
+    }
+
+    // ── Lazy Loading on Scroll Left ──
+
+    chart.timeScale().subscribeVisibleLogicalRangeChange(function (logicalRange) {
+        if (!logicalRange || isLoadingMore || !loadedFrom) return;
+
+        // If the user has scrolled to show data near the left edge, load more
+        if (logicalRange.from < 5) {
+            loadMoreHistory();
+        }
+    });
+
+    function loadMoreHistory() {
+        if (isLoadingMore || !loadedFrom) return;
+        isLoadingMore = true;
+
+        var span = FETCH_SPANS[currentRange] || { fetch: 30 };
+        var to = new Date(loadedFrom);
+        to.setDate(to.getDate() - 1); // day before current earliest
+        var from = new Date(to);
+        from.setDate(from.getDate() - span.fetch);
+
+        fetchAndRender(formatDate(from), formatDate(to), false, 0);
     }
 
     function formatDate(d) {
@@ -158,5 +232,6 @@
     // ── Default Load (from persisted range) ──
 
     setActiveRangeBtn(defaultRange);
+    currentRange = defaultRange;
     loadRange(defaultRange);
 })();

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -1077,6 +1077,12 @@ body {
     background: var(--bg-tertiary);
 }
 
+.chart-range-sep {
+    color: var(--border);
+    font-size: 14px;
+    line-height: 1;
+}
+
 .chart-range-btn.active {
     color: var(--orange);
     border-color: var(--orange);

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -365,6 +365,43 @@ body {
 .price-down { color: var(--red); }
 .price-flat { color: var(--text-secondary); }
 
+.watchlist-picker {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    padding: 3px 8px;
+    border: 1px solid var(--orange);
+    border-radius: 4px;
+    color: var(--orange);
+    cursor: default;
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+
+.watchlist-tabs {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 8px;
+}
+
+.wl-tab {
+    font-size: 11px;
+    padding: 3px 10px;
+    border: 1px solid;
+    border-radius: 4px;
+    cursor: pointer;
+    opacity: 0.6;
+}
+
+.wl-tab:hover {
+    opacity: 0.8;
+}
+
+.wl-tab-active {
+    opacity: 1;
+    font-weight: 700;
+}
+
 /* ── Add Security Form (Watchlist) ── */
 
 .add-security-form {
@@ -1075,6 +1112,38 @@ body {
 .chart-range-btn:hover {
     color: var(--text-primary);
     background: var(--bg-tertiary);
+}
+
+.chart-symbol {
+    font-weight: 700;
+    font-size: 13px;
+    color: var(--blue);
+    margin-right: 4px;
+}
+
+.chart-auto-refresh {
+    background: transparent;
+    border: 1px solid var(--green);
+    border-radius: 4px;
+    color: var(--green);
+    font-size: 14px;
+    padding: 2px 6px;
+    cursor: pointer;
+    line-height: 1;
+}
+
+.chart-auto-refresh:hover {
+    background: rgba(0, 204, 102, 0.15);
+}
+
+.chart-auto-refresh.active {
+    background: rgba(0, 204, 102, 0.15);
+    color: var(--green);
+}
+
+.chart-auto-refresh:not(.active) {
+    border-color: var(--border);
+    color: var(--text-muted);
 }
 
 .chart-range-sep {

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -702,7 +702,13 @@ window.onerror = function (msg, src, line, col, err) {
                 // Handle : chart commands (e.g. :1w, :1m, :3m, :6m)
                 if (raw.charAt(0) === ':') {
                     var chartCmd = raw.substring(1).toLowerCase();
-                    var rangeMap = { '1w': '1W', '1m': '1M', '3m': '3M', '6m': '6M' };
+                    var rangeMap = {
+                        // Intraday: :1, :5, :15, :30, :1h, :4h
+                        '1': '1m', '5': '5m', '15': '15m', '30': '30m',
+                        '1h': '1h', '4h': '4h',
+                        // EOD: :1w, :1m, :3m, :6m
+                        '1w': '1W', '1m': '1M', '3m': '3M', '6m': '6M',
+                    };
                     if (rangeMap[chartCmd] && window._stocktopusSetRange) {
                         window._stocktopusSetRange(rangeMap[chartCmd]);
                     }

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -148,6 +148,8 @@ window.onerror = function (msg, src, line, col, err) {
             subscribedSecurities.forEach(function (sym) {
                 ws.send(JSON.stringify({ type: 'subscribe', topic: 'quote:' + sym }));
             });
+            // Resubscribe watchlist symbols
+            resubscribeWatchlists();
             // Resubscribe to active news topic
             if (newsCurrentTopic) {
                 ws.send(JSON.stringify({ type: 'subscribe', topic: newsCurrentTopic }));
@@ -185,6 +187,9 @@ window.onerror = function (msg, src, line, col, err) {
 
     // ── Watchlist ──
 
+    var watchlistData = []; // cached watchlist data
+    var activeWatchlistId = parseInt(localStorage.getItem('stocktopus-watchlist-id') || '0');
+
     function initWatchlist() {
         const form = document.getElementById('add-security-form');
         if (form) {
@@ -192,21 +197,204 @@ window.onerror = function (msg, src, line, col, err) {
                 e.preventDefault();
                 const input = document.getElementById('wl-security-input');
                 const sec = input.value.trim().toUpperCase();
-                if (!sec || subscribedSecurities.has(sec)) {
+                if (!sec) {
                     input.value = '';
                     return;
                 }
                 subscribeSecurity(sec);
+                addToWatchlist(getActiveWatchlistId(), sec);
                 input.value = '';
             };
         }
 
-        // Resubscribe existing securities so rows repopulate
-        subscribedSecurities.forEach(function (sym) {
-            if (ws && ws.readyState === WebSocket.OPEN) {
-                ws.send(JSON.stringify({ type: 'subscribe', topic: 'quote:' + sym }));
-            }
+        // Fetch batch quotes immediately
+        fetchWatchlistQuotes();
+    }
+
+    function fetchWatchlistQuotes() {
+        fetch('/api/watchlists/quotes')
+            .then(function (r) { return r.json(); })
+            .then(function (quotes) {
+                if (!quotes || quotes.length === 0) return;
+                var tbody = document.getElementById('quote-body');
+                if (!tbody) return;
+
+                var empty = document.getElementById('empty-state');
+                if (empty) empty.style.display = 'none';
+
+                quotes.forEach(function (q) {
+                    var chgClass = q.change >= 0 ? 'price-up' : 'price-down';
+                    var chgPct = q.changePercentage ? q.changePercentage.toFixed(2) + '%' : '';
+                    var chg = q.change ? (q.change >= 0 ? '+' : '') + q.change.toFixed(2) : '';
+                    var vol = q.volume ? formatWatchlistVolume(q.volume) : '';
+                    var updated = '';
+
+                    var existing = document.getElementById('quote-' + q.symbol);
+                    var html = '<tr id="quote-' + q.symbol + '">'
+                        + '<td><span class="sym-link" data-symbol="' + q.symbol + '">' + q.symbol + '</span></td>'
+                        + '<td class="' + chgClass + '">' + (q.price ? q.price.toFixed(2) : '') + '</td>'
+                        + '<td class="' + chgClass + '">' + chg + '</td>'
+                        + '<td class="' + chgClass + '">' + chgPct + '</td>'
+                        + '<td>' + vol + '</td>'
+                        + '<td>' + updated + '</td>'
+                        + '</tr>';
+
+                    if (existing) {
+                        existing.outerHTML = html;
+                    } else {
+                        tbody.insertAdjacentHTML('beforeend', html);
+                    }
+
+                    // Subscribe for live updates
+                    subscribeSecurity(q.symbol);
+                });
+
+                // Wire up clicks
+                tbody.querySelectorAll('[data-symbol]').forEach(function (el) {
+                    el.onclick = function (e) {
+                        e.preventDefault();
+                        navigate('graph', el.dataset.symbol);
+                    };
+                });
+
+                // Add watchlist colors
+                tbody.querySelectorAll('tr').forEach(function (row) {
+                    var sym = row.querySelector('[data-symbol]');
+                    if (sym) {
+                        var colors = getWatchlistColors(sym.dataset.symbol);
+                        if (colors.length > 0) {
+                            row.style.borderLeft = '3px solid ' + colors[0];
+                        }
+                    }
+                });
+
+                // Filter to active watchlist
+                filterWatchlistView();
+            })
+            .catch(function (err) { console.error('Watchlist quotes error:', err); });
+    }
+
+    function formatWatchlistVolume(v) {
+        if (v >= 1e9) return (v / 1e9).toFixed(1) + 'B';
+        if (v >= 1e6) return (v / 1e6).toFixed(1) + 'M';
+        if (v >= 1e3) return (v / 1e3).toFixed(1) + 'K';
+        return v;
+    }
+
+    function loadWatchlists() {
+        fetch('/api/watchlists')
+            .then(function (r) { return r.json(); })
+            .then(function (lists) {
+                watchlistData = lists || [];
+                if (!activeWatchlistId && watchlistData.length > 0) {
+                    activeWatchlistId = watchlistData[0].id;
+                }
+                watchlistData.forEach(function (wl) {
+                    (wl.symbols || []).forEach(function (sym) {
+                        subscribeSecurity(sym);
+                    });
+                });
+                renderWatchlistTabs();
+                renderWatchlistPicker();
+            })
+            .catch(function () {});
+    }
+
+    function resubscribeWatchlists() {
+        if (watchlistData.length > 0) {
+            watchlistData.forEach(function (wl) {
+                (wl.symbols || []).forEach(function (sym) {
+                    if (ws && ws.readyState === WebSocket.OPEN) {
+                        ws.send(JSON.stringify({ type: 'subscribe', topic: 'quote:' + sym }));
+                    }
+                });
+            });
+        }
+    }
+
+    function renderWatchlistTabs() {
+        var tabContainer = document.getElementById('watchlist-tabs');
+        if (!tabContainer) return;
+
+        tabContainer.innerHTML = watchlistData.map(function (wl) {
+            var active = wl.id === activeWatchlistId ? ' wl-tab-active' : '';
+            return '<span class="wl-tab' + active + '" data-id="' + wl.id + '" style="border-color:' + wl.color + ';color:' + wl.color + '">' + escapeHtml(wl.name) + ' (' + (wl.symbols ? wl.symbols.length : 0) + ')</span>';
+        }).join('');
+
+        tabContainer.querySelectorAll('.wl-tab').forEach(function (tab) {
+            tab.onclick = function () {
+                activeWatchlistId = parseInt(tab.dataset.id);
+                localStorage.setItem('stocktopus-watchlist-id', activeWatchlistId);
+                renderWatchlistTabs();
+                renderWatchlistPicker();
+                filterWatchlistView();
+            };
         });
+    }
+
+    function renderWatchlistPicker() {
+        var picker = document.getElementById('watchlist-picker');
+        if (!picker) return;
+        var active = watchlistData.find(function (wl) { return wl.id === activeWatchlistId; });
+        if (active) {
+            picker.textContent = active.name;
+            picker.style.borderColor = active.color;
+            picker.style.color = active.color;
+        } else if (watchlistData.length > 0) {
+            picker.textContent = watchlistData[0].name;
+            picker.style.borderColor = watchlistData[0].color;
+            picker.style.color = watchlistData[0].color;
+        }
+    }
+
+    function filterWatchlistView() {
+        var tbody = document.getElementById('quote-body');
+        var empty = document.getElementById('empty-state');
+        if (!tbody) return;
+
+        var activeWl = watchlistData.find(function (wl) { return wl.id === activeWatchlistId; });
+        var activeSymbols = activeWl && activeWl.symbols ? activeWl.symbols : [];
+
+        // Show/hide rows based on active watchlist
+        var visibleCount = 0;
+        tbody.querySelectorAll('tr').forEach(function (row) {
+            var sym = row.querySelector('[data-symbol]');
+            var symbol = sym ? sym.dataset.symbol : '';
+            var inList = activeSymbols.indexOf(symbol) >= 0;
+            row.style.display = inList ? '' : 'none';
+            if (inList) visibleCount++;
+        });
+
+        if (empty) {
+            empty.style.display = visibleCount > 0 ? 'none' : '';
+            empty.textContent = visibleCount > 0 ? '' : 'No securities in this watchlist — use :watch to add';
+        }
+    }
+
+    function getActiveWatchlistId() {
+        return activeWatchlistId || (watchlistData.length > 0 ? watchlistData[0].id : 1);
+    }
+
+    function addToWatchlist(watchlistId, symbol) {
+        fetch('/api/watchlists/' + (watchlistId || getActiveWatchlistId()) + '/symbols', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ symbol: symbol }),
+        }).then(function () {
+            loadWatchlists(); // refresh
+        }).catch(function (err) { console.error('Watch error:', err); });
+    }
+
+    function createWatchlist(name) {
+        fetch('/api/watchlists', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: name }),
+        }).then(function (r) { return r.json(); })
+        .then(function (wl) {
+            loadWatchlists();
+            flashError('Watchlist "' + name + '" created');
+        }).catch(function (err) { console.error('Create watchlist error:', err); });
     }
 
     function subscribeSecurity(sec) {
@@ -245,6 +433,26 @@ window.onerror = function (msg, src, line, col, err) {
                 navigate('graph', el.dataset.symbol);
             };
         });
+
+        // Add watchlist color badge
+        var sym = row.querySelector('[data-symbol]');
+        if (sym) {
+            var symName = sym.dataset.symbol;
+            var colors = getWatchlistColors(symName);
+            if (colors.length > 0) {
+                row.style.borderLeft = '3px solid ' + colors[0];
+            }
+        }
+    }
+
+    function getWatchlistColors(symbol) {
+        var colors = [];
+        watchlistData.forEach(function (wl) {
+            if ((wl.symbols || []).indexOf(symbol) >= 0) {
+                colors.push(wl.color);
+            }
+        });
+        return colors;
     }
 
     // ── Debug Console ──
@@ -699,19 +907,49 @@ window.onerror = function (msg, src, line, col, err) {
                 const raw = input.value.trim();
                 if (!raw) return;
 
-                // Handle : chart commands (e.g. :1w, :1m, :3m, :6m)
+                // Handle : commands
                 if (raw.charAt(0) === ':') {
-                    var chartCmd = raw.substring(1).toLowerCase();
+                    var colonCmd = raw.substring(1);
+                    var colonLower = colonCmd.toLowerCase();
+
+                    // Chart range: :1, :5, :15, :30, :1h, :4h, :1w, :1m, :3m, :6m
                     var rangeMap = {
-                        // Intraday: :1, :5, :15, :30, :1h, :4h
                         '1': '1m', '5': '5m', '15': '15m', '30': '30m',
                         '1h': '1h', '4h': '4h',
-                        // EOD: :1w, :1m, :3m, :6m
                         '1w': '1W', '1m': '1M', '3m': '3M', '6m': '6M',
                     };
-                    if (rangeMap[chartCmd] && window._stocktopusSetRange) {
-                        window._stocktopusSetRange(rangeMap[chartCmd]);
+                    if (rangeMap[colonLower] && window._stocktopusSetRange) {
+                        window._stocktopusSetRange(rangeMap[colonLower]);
+                        input.value = '';
+                        enterNormalMode();
+                        return;
                     }
+
+                    // :watch or :watch SYMBOL — add to watchlist
+                    if (colonLower === 'watch' || colonLower.startsWith('watch ')) {
+                        var watchArg = colonCmd.substring(5).trim().toUpperCase();
+                        var watchSym = watchArg || selectedSecurity;
+                        if (watchSym) {
+                            addToWatchlist(getActiveWatchlistId(), watchSym);
+                            subscribeSecurity(watchSym);
+                            flashError('Added ' + watchSym + ' to watchlist');
+                        } else {
+                            flashError('Select a security first (s key)');
+                        }
+                        input.value = '';
+                        enterNormalMode();
+                        return;
+                    }
+
+                    // :watchlist "Name" — create new watchlist
+                    if (colonLower.startsWith('watchlist ')) {
+                        var wlName = colonCmd.substring(10).trim().replace(/^["']|["']$/g, '');
+                        if (wlName) createWatchlist(wlName);
+                        input.value = '';
+                        enterNormalMode();
+                        return;
+                    }
+
                     input.value = '';
                     enterNormalMode();
                     return;
@@ -920,8 +1158,25 @@ window.onerror = function (msg, src, line, col, err) {
 
     var vimHandlers = {
         watchlist: {
-            getItems: function () { return document.querySelectorAll('#quote-body tr'); },
+            getItems: function () {
+                // Only visible rows (filtered by active watchlist)
+                return document.querySelectorAll('#quote-body tr[style=""], #quote-body tr:not([style])');
+            },
             move: function (dir) {
+                if (dir === 'h' || dir === 'l') {
+                    // Switch between watchlists
+                    if (watchlistData.length <= 1) return;
+                    var idx = watchlistData.findIndex(function (wl) { return wl.id === activeWatchlistId; });
+                    if (dir === 'l') idx = Math.min(idx + 1, watchlistData.length - 1);
+                    else idx = Math.max(idx - 1, 0);
+                    activeWatchlistId = watchlistData[idx].id;
+                    localStorage.setItem('stocktopus-watchlist-id', activeWatchlistId);
+                    renderWatchlistTabs();
+                    renderWatchlistPicker();
+                    filterWatchlistView();
+                    clearVimSelection();
+                    return;
+                }
                 var items = this.getItems();
                 if (items.length === 0) return;
                 if (dir === 'j') vimSelectedIndex = Math.min(vimSelectedIndex + 1, items.length - 1);
@@ -1377,6 +1632,7 @@ window.onerror = function (msg, src, line, col, err) {
     function init() {
         initCommandBar();
         initSecuritySelector();
+        loadWatchlists(); // load persisted watchlists early
         connectWS();
         onViewEnter(currentView);
         updateClock();

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -1160,7 +1160,10 @@ window.onerror = function (msg, src, line, col, err) {
         watchlist: {
             getItems: function () {
                 // Only visible rows (filtered by active watchlist)
-                return document.querySelectorAll('#quote-body tr[style=""], #quote-body tr:not([style])');
+                var all = document.querySelectorAll('#quote-body tr');
+                return Array.from(all).filter(function (row) {
+                    return row.style.display !== 'none';
+                });
             },
             move: function (dir) {
                 if (dir === 'h' || dir === 'l') {

--- a/internal/server/templates/layout.html
+++ b/internal/server/templates/layout.html
@@ -11,13 +11,14 @@
         <span class="brand">STOCKTOPUS</span>
         <div class="cmd-bar">
             <span class="cmd-prompt">&gt;</span>
-            <input id="cmd-input" class="cmd-input" type="text" placeholder="enter command..." autocomplete="off" spellcheck="false" autofocus>
+            <input id="cmd-input" class="cmd-input" type="text" placeholder="enter command..." autocomplete="off" spellcheck="false">
             <div id="cmd-dropdown" class="cmd-dropdown hidden"></div>
         </div>
         <div class="security-selector">
             <input id="security-input" class="security-input" type="text" placeholder="SYM" autocomplete="off" spellcheck="false">
             <div id="security-dropdown" class="security-dropdown hidden"></div>
         </div>
+        <span id="watchlist-picker" class="watchlist-picker" title="Active watchlist">Default</span>
         <div id="conn-status" class="conn-status">DISCONNECTED</div>
     </header>
     <main id="view-container" class="terminal-content" data-view="{{.Active}}">

--- a/internal/server/templates/stock.html
+++ b/internal/server/templates/stock.html
@@ -3,10 +3,17 @@
 <div class="page-header">
     <h1>{{.Symbol}}</h1>
     <div class="chart-range-bar" id="chart-range-bar">
-        <button class="chart-range-btn" data-range="1W">1W</button>
-        <button class="chart-range-btn active" data-range="1M">1M</button>
-        <button class="chart-range-btn" data-range="3M">3M</button>
-        <button class="chart-range-btn" data-range="6M">6M</button>
+        <button class="chart-range-btn chart-intraday-btn" data-range="1m" data-interval="1min">1m</button>
+        <button class="chart-range-btn chart-intraday-btn" data-range="5m" data-interval="5min">5m</button>
+        <button class="chart-range-btn chart-intraday-btn" data-range="15m" data-interval="15min">15m</button>
+        <button class="chart-range-btn chart-intraday-btn" data-range="30m" data-interval="30min">30m</button>
+        <button class="chart-range-btn chart-intraday-btn" data-range="1h" data-interval="1hour">1h</button>
+        <button class="chart-range-btn chart-intraday-btn" data-range="4h" data-interval="4hour">4h</button>
+        <span class="chart-range-sep">|</span>
+        <button class="chart-range-btn chart-eod-btn active" data-range="1W">1W</button>
+        <button class="chart-range-btn chart-eod-btn" data-range="1M">1M</button>
+        <button class="chart-range-btn chart-eod-btn" data-range="3M">3M</button>
+        <button class="chart-range-btn chart-eod-btn" data-range="6M">6M</button>
     </div>
 </div>
 <div id="chart-container" class="chart-container" data-symbol="{{.Symbol}}"></div>

--- a/internal/server/templates/stock.html
+++ b/internal/server/templates/stock.html
@@ -3,12 +3,14 @@
 <div class="page-header">
     <h1>{{.Symbol}}</h1>
     <div class="chart-range-bar" id="chart-range-bar">
+        <span class="chart-symbol">{{.Symbol}}</span>
         <button class="chart-range-btn chart-intraday-btn" data-range="1m" data-interval="1min">1m</button>
         <button class="chart-range-btn chart-intraday-btn" data-range="5m" data-interval="5min">5m</button>
         <button class="chart-range-btn chart-intraday-btn" data-range="15m" data-interval="15min">15m</button>
         <button class="chart-range-btn chart-intraday-btn" data-range="30m" data-interval="30min">30m</button>
         <button class="chart-range-btn chart-intraday-btn" data-range="1h" data-interval="1hour">1h</button>
         <button class="chart-range-btn chart-intraday-btn" data-range="4h" data-interval="4hour">4h</button>
+        <button class="chart-auto-refresh active" id="chart-auto-refresh" title="Auto-refresh">&#8635;</button>
         <span class="chart-range-sep">|</span>
         <button class="chart-range-btn chart-eod-btn active" data-range="1W">1W</button>
         <button class="chart-range-btn chart-eod-btn" data-range="1M">1M</button>

--- a/internal/server/templates/watchlist.html
+++ b/internal/server/templates/watchlist.html
@@ -7,6 +7,7 @@
         <button type="submit">+</button>
     </form>
 </div>
+<div id="watchlist-tabs" class="watchlist-tabs"></div>
 <div class="watchlist">
     <table class="quote-table">
         <thead>

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -93,6 +93,23 @@ func (s *Store) migrate() error {
 		);
 
 		CREATE INDEX IF NOT EXISTS idx_training_symbol ON training_data(symbol);
+
+		CREATE TABLE IF NOT EXISTS watchlists (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL UNIQUE,
+			color TEXT NOT NULL DEFAULT '#ff8800',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
+
+		CREATE TABLE IF NOT EXISTS watchlist_symbols (
+			watchlist_id INTEGER NOT NULL,
+			symbol TEXT NOT NULL,
+			added_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (watchlist_id, symbol),
+			FOREIGN KEY (watchlist_id) REFERENCES watchlists(id) ON DELETE CASCADE
+		);
+
+		INSERT OR IGNORE INTO watchlists (name, color) VALUES ('Default', '#ff8800');
 	`)
 	return err
 }
@@ -223,4 +240,123 @@ func (s *Store) TrainingDataCount() (int, error) {
 	var count int
 	err := s.db.QueryRow(`SELECT COUNT(*) FROM training_data`).Scan(&count)
 	return count, err
+}
+
+// ── Watchlists ──
+
+// Watchlist represents a named watchlist with a color.
+type Watchlist struct {
+	ID      int64    `json:"id"`
+	Name    string   `json:"name"`
+	Color   string   `json:"color"`
+	Symbols []string `json:"symbols"`
+}
+
+// Preset colors for new watchlists
+var watchlistColors = []string{
+	"#ff8800", "#4499ff", "#00cc66", "#ff4444",
+	"#cc66ff", "#ffcc00", "#00cccc", "#ff6699",
+}
+
+// GetWatchlists returns all watchlists with their symbols.
+func (s *Store) GetWatchlists() ([]Watchlist, error) {
+	rows, err := s.db.Query(`SELECT id, name, color FROM watchlists ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var lists []Watchlist
+	for rows.Next() {
+		var w Watchlist
+		if err := rows.Scan(&w.ID, &w.Name, &w.Color); err != nil {
+			return nil, err
+		}
+		lists = append(lists, w)
+	}
+
+	// Load symbols for each
+	for i := range lists {
+		symRows, err := s.db.Query(`SELECT symbol FROM watchlist_symbols WHERE watchlist_id = ? ORDER BY added_at`, lists[i].ID)
+		if err != nil {
+			continue
+		}
+		for symRows.Next() {
+			var sym string
+			symRows.Scan(&sym)
+			lists[i].Symbols = append(lists[i].Symbols, sym)
+		}
+		symRows.Close()
+	}
+
+	return lists, nil
+}
+
+// CreateWatchlist creates a new watchlist with an auto-assigned color.
+func (s *Store) CreateWatchlist(name string) (*Watchlist, error) {
+	// Count existing for color assignment
+	var count int
+	s.db.QueryRow(`SELECT COUNT(*) FROM watchlists`).Scan(&count)
+	color := watchlistColors[count%len(watchlistColors)]
+
+	res, err := s.db.Exec(`INSERT INTO watchlists (name, color) VALUES (?, ?)`, name, color)
+	if err != nil {
+		return nil, err
+	}
+	id, _ := res.LastInsertId()
+	return &Watchlist{ID: id, Name: name, Color: color}, nil
+}
+
+// AddToWatchlist adds a symbol to a watchlist. Uses default watchlist if watchlistID is 0.
+func (s *Store) AddToWatchlist(watchlistID int64, symbol string) error {
+	if watchlistID == 0 {
+		s.db.QueryRow(`SELECT id FROM watchlists ORDER BY id LIMIT 1`).Scan(&watchlistID)
+	}
+	_, err := s.db.Exec(`INSERT OR IGNORE INTO watchlist_symbols (watchlist_id, symbol) VALUES (?, ?)`,
+		watchlistID, symbol)
+	return err
+}
+
+// RemoveFromWatchlist removes a symbol from a watchlist.
+func (s *Store) RemoveFromWatchlist(watchlistID int64, symbol string) error {
+	_, err := s.db.Exec(`DELETE FROM watchlist_symbols WHERE watchlist_id = ? AND symbol = ?`,
+		watchlistID, symbol)
+	return err
+}
+
+// GetSymbolWatchlists returns which watchlists a symbol belongs to.
+func (s *Store) GetSymbolWatchlists(symbol string) ([]Watchlist, error) {
+	rows, err := s.db.Query(`
+		SELECT w.id, w.name, w.color FROM watchlists w
+		JOIN watchlist_symbols ws ON w.id = ws.watchlist_id
+		WHERE ws.symbol = ?`, symbol)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var lists []Watchlist
+	for rows.Next() {
+		var w Watchlist
+		rows.Scan(&w.ID, &w.Name, &w.Color)
+		lists = append(lists, w)
+	}
+	return lists, nil
+}
+
+// GetAllWatchedSymbols returns all unique symbols across all watchlists.
+func (s *Store) GetAllWatchedSymbols() ([]string, error) {
+	rows, err := s.db.Query(`SELECT DISTINCT symbol FROM watchlist_symbols ORDER BY symbol`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var symbols []string
+	for rows.Next() {
+		var sym string
+		rows.Scan(&sym)
+		symbols = append(symbols, sym)
+	}
+	return symbols, nil
 }

--- a/tests/e2e/smoke_test.go
+++ b/tests/e2e/smoke_test.go
@@ -68,7 +68,7 @@ func TestMain(m *testing.M) {
 	debug := server.NewDebugBroadcaster()
 
 	// Server
-	srv, err := server.New(server.Config{Port: 0}, h, debug, poll, newsClient, nil, logger)
+	srv, err := server.New(server.Config{Port: 0}, h, debug, poll, newsClient, nil, nil, logger)
 	if err != nil {
 		panic("failed to create server: " + err.Error())
 	}


### PR DESCRIPTION
## Summary

- **Wider initial view**: Each range period fetches more data than shown — 1W fetches 1M, 1M fetches 3M, 3M fetches 6M, 6M fetches 1Y. The visible range is set to the selected period at the right edge, with context available by scrolling left.
- **Lazy history loading**: Scrolling left near the chart edge automatically fetches the previous period's data and prepends it seamlessly. No gaps, no reload.
- **Data deduplication**: When loading more history, data is merged with existing candles, deduped by date, and sorted chronologically.

## How it works
| Range | Initial Fetch | Visible | Scroll loads |
|-------|--------------|---------|--------------|
| 1W | 30 days | Last 7 days | Previous 30 days |
| 1M | 90 days | Last 30 days | Previous 90 days |
| 3M | 180 days | Last 90 days | Previous 180 days |
| 6M | 365 days | Last 180 days | Previous 365 days |

## Test plan
- [ ] `make smoke` — all 17 tests pass
- [ ] `graph AAPL` → 1W shows candles with scrollable history to the left
- [ ] Scroll left → more data loads seamlessly
- [ ] Switch ranges → resets and loads fresh
- [ ] `h` key scrolls left, triggers lazy load