### PR TITLE
feat: chart indicators — SMA, EMA, MACD, RSI, news markers, tooltip

### DIFF
--- a/agents/fetch_article.py
+++ b/agents/fetch_article.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Fetches a URL and extracts readable article content."""
+import json
+import sys
+import requests
+from bs4 import BeautifulSoup
+
+def extract_article(url):
+    try:
+        headers = {"User-Agent": "Mozilla/5.0 (Stocktopus Reader)"}
+        resp = requests.get(url, headers=headers, timeout=10)
+        soup = BeautifulSoup(resp.text, "html.parser")
+
+        # Remove scripts, styles, nav, footer
+        for tag in soup(["script", "style", "nav", "footer", "header", "aside", "iframe", "form"]):
+            tag.decompose()
+
+        # Try common article selectors
+        article = None
+        for selector in ["article", '[role="main"]', ".post-content", ".article-body", ".entry-content", ".story-body", "main"]:
+            article = soup.select_one(selector)
+            if article:
+                break
+
+        if not article:
+            article = soup.body or soup
+
+        # Extract paragraphs
+        paragraphs = []
+        for p in article.find_all(["p", "h1", "h2", "h3", "h4", "blockquote", "li"]):
+            text = p.get_text(strip=True)
+            if len(text) > 20:
+                tag = p.name
+                paragraphs.append({"tag": tag, "text": text})
+
+        # Get title
+        title = ""
+        title_tag = soup.find("title")
+        if title_tag:
+            title = title_tag.get_text(strip=True)
+        h1 = soup.find("h1")
+        if h1:
+            title = h1.get_text(strip=True)
+
+        return {
+            "title": title,
+            "paragraphs": paragraphs[:50],
+            "url": url,
+            "wordCount": sum(len(p["text"].split()) for p in paragraphs),
+        }
+    except Exception as e:
+        return {"error": str(e), "url": url}
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(json.dumps({"error": "no URL provided"}))
+        sys.exit(1)
+    print(json.dumps(extract_article(sys.argv[1])))

--- a/internal/news/news.go
+++ b/internal/news/news.go
@@ -406,7 +406,16 @@ func New(apiKey, baseURL string) *Client {
 }
 
 // GetNews fetches news for the given category. Symbol is used for press-releases filtering.
+// GetNewsWithDates fetches news with optional date range filtering.
+func (c *Client) GetNewsWithDates(ctx context.Context, cat Category, symbol string, page, limit int, from, to string) ([]model.NewsItem, error) {
+	return c.getNewsInternal(ctx, cat, symbol, page, limit, from, to)
+}
+
 func (c *Client) GetNews(ctx context.Context, cat Category, symbol string, page, limit int) ([]model.NewsItem, error) {
+	return c.getNewsInternal(ctx, cat, symbol, page, limit, "", "")
+}
+
+func (c *Client) getNewsInternal(ctx context.Context, cat Category, symbol string, page, limit int, from, to string) ([]model.NewsItem, error) {
 	if limit <= 0 {
 		limit = 20
 	}
@@ -454,6 +463,13 @@ func (c *Client) GetNews(ctx context.Context, cat Category, symbol string, page,
 		endpoint = "/stable/fmp-articles"
 	default:
 		return nil, fmt.Errorf("unknown news category: %s", cat)
+	}
+
+	if from != "" {
+		params.Set("from", from)
+	}
+	if to != "" {
+		params.Set("to", to)
 	}
 
 	reqURL := c.baseURL + endpoint + "?" + params.Encode()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -130,6 +132,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/news/{category}", s.handleNewsAPI)
 	mux.HandleFunc("GET /api/search", s.handleSearch)
 	mux.HandleFunc("GET /api/chart/eod/{symbol}", s.handleChartEOD)
+	mux.HandleFunc("GET /api/article", s.handleArticle)
 	mux.HandleFunc("GET /api/chart/intraday/{interval}/{symbol}", s.handleChartIntraday)
 	mux.HandleFunc("GET /api/security/{symbol}/profile", s.handleSecurityProfile)
 	mux.HandleFunc("GET /api/security/{symbol}/metrics", s.handleSecurityMetrics)
@@ -645,6 +648,42 @@ func (s *Server) handleChartEOD(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(items)
+}
+
+func (s *Server) handleArticle(w http.ResponseWriter, r *http.Request) {
+	articleURL := r.URL.Query().Get("url")
+	if articleURL == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "url required"})
+		return
+	}
+
+	// Use Python script to fetch and extract
+	venvPython := "agents/../.venv/bin/python3"
+	pythonCmd := "python3"
+	if _, err := exec.LookPath(venvPython); err == nil {
+		pythonCmd = venvPython
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, pythonCmd, "agents/fetch_article.py", articleURL)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		s.logger.Error("article fetch failed", "url", articleURL, "error", err, "stderr", stderr.String())
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(map[string]string{"error": "failed to fetch article"})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(stdout.Bytes())
 }
 
 func (s *Server) handleChartIntraday(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -235,7 +235,9 @@ func (s *Server) handleNewsAPI(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	items, err := s.news.GetNews(r.Context(), cat, symbol, page, limit)
+	from := r.URL.Query().Get("from")
+	to := r.URL.Query().Get("to")
+	items, err := s.news.GetNewsWithDates(r.Context(), cat, symbol, page, limit, from, to)
 	if err != nil {
 		s.logger.Error("news fetch failed", "category", cat, "error", err)
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -229,6 +229,10 @@
         // News markers
         if (isOn('news')) {
             loadNewsMarkers();
+        } else {
+            if (newsMarkers) { try { newsMarkers.detach(); } catch (e) {} newsMarkers = null; }
+            var panel = document.getElementById('chart-news-panel');
+            if (panel) panel.remove();
         }
     }
 

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -319,46 +319,19 @@
             container.parentNode.insertBefore(panel, container.nextSibling);
         }
 
-        var html = '<div class="cnp-header"><span>News for ' + date + '</span><button class="cnp-close" onclick="document.getElementById(\'chart-news-panel\').remove()">&#10005;</button></div>';
+        var html = '<div class="cnp-header"><span>News for ' + date + ' (' + articles.length + ')</span><button class="cnp-close" onclick="document.getElementById(\'chart-news-panel\').remove();window._closeReader()">&#10005;</button></div>';
         html += '<div class="cnp-list">';
-        articles.forEach(function (a, i) {
-            html += '<div class="cnp-item" data-url="' + encodeURIComponent(a.url || '') + '" onclick="window._openArticle(this.dataset.url)">'
-                + '<span class="cnp-title">' + (a.title || '').replace(/</g, '&lt;') + '</span>'
+        articles.forEach(function (a) {
+            var safeUrl = (a.url || '').replace(/'/g, '%27');
+            var safeTitle = (a.title || '').replace(/</g, '&lt;').replace(/'/g, '&#39;');
+            html += '<div class="cnp-item" onclick="window._openReader(\'' + safeUrl + '\',\'' + safeTitle + '\')">'
+                + '<span class="cnp-title">' + safeTitle + '</span>'
                 + '<span class="cnp-meta">' + (a.source || '') + '</span>'
                 + '</div>';
         });
         html += '</div>';
-        html += '<div id="cnp-reader" class="cnp-reader"></div>';
         panel.innerHTML = html;
     }
-
-    window._openArticle = function (encodedUrl) {
-        var url = decodeURIComponent(encodedUrl);
-        var reader = document.getElementById('cnp-reader');
-        if (!reader) return;
-        reader.innerHTML = '<p style="color:var(--text-muted)">Loading article...</p>';
-
-        fetch('/api/article?url=' + encodeURIComponent(url))
-            .then(function (r) { return r.json(); })
-            .then(function (data) {
-                if (data.error) {
-                    reader.innerHTML = '<p style="color:var(--red)">' + data.error + '</p><a href="' + url + '" target="_blank" style="color:var(--blue)">Open in browser</a>';
-                    return;
-                }
-                var html = '<h2 class="cnp-article-title">' + (data.title || '').replace(/</g, '&lt;') + '</h2>';
-                html += '<div class="cnp-article-meta">' + (data.wordCount || 0) + ' words</div>';
-                html += '<div class="cnp-article-body">';
-                (data.paragraphs || []).forEach(function (p) {
-                    var tag = p.tag === 'h1' || p.tag === 'h2' || p.tag === 'h3' ? p.tag : 'p';
-                    html += '<' + tag + '>' + p.text.replace(/</g, '&lt;') + '</' + tag + '>';
-                });
-                html += '</div>';
-                reader.innerHTML = html;
-            })
-            .catch(function () {
-                reader.innerHTML = '<p style="color:var(--red)">Failed to load</p><a href="' + url + '" target="_blank" style="color:var(--blue)">Open in browser</a>';
-            });
-    };
 
     // ── Crosshair Tooltip ──
     var tooltipEl = document.getElementById('chart-tooltip');

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -232,11 +232,12 @@
         }
     }
 
-    // ── News Markers ──
+    // ── News Markers + Reader ──
+    var newsDataByDate = {}; // date -> array of news items
+
     function loadNewsMarkers() {
         if (allCandles.length < 2) return;
 
-        // Get date range from loaded candles
         var firstDate = typeof allCandles[0].time === 'string'
             ? allCandles[0].time
             : new Date(allCandles[0].time * 1000).toISOString().slice(0, 10);
@@ -244,44 +245,42 @@
             ? allCandles[allCandles.length - 1].time
             : new Date(allCandles[allCandles.length - 1].time * 1000).toISOString().slice(0, 10);
 
-        // Build candle date index
         var candleDates = {};
         allCandles.forEach(function (c) {
             var dk = typeof c.time === 'string' ? c.time : new Date(c.time * 1000).toISOString().slice(0, 10);
-            if (!candleDates[dk]) candleDates[dk] = c.time; // first candle on that date
+            if (!candleDates[dk]) candleDates[dk] = c.time;
         });
 
-        // Fetch news for the chart's date range
         fetch('/api/news/stock?symbol=' + symbol + '&limit=100&from=' + firstDate + '&to=' + lastDate)
             .then(function (r) { return r.json(); })
             .then(function (news) {
                 if (!news || news.length === 0) return;
 
-                // Count news per date for marker sizing
-                var dateCounts = {};
+                newsDataByDate = {};
                 news.forEach(function (n) {
                     var dk = (n.date || '').slice(0, 10);
-                    dateCounts[dk] = (dateCounts[dk] || 0) + 1;
+                    if (!newsDataByDate[dk]) newsDataByDate[dk] = [];
+                    newsDataByDate[dk].push(n);
                 });
 
                 var markers = [];
                 var seen = {};
-                Object.keys(dateCounts).forEach(function (dk) {
+                Object.keys(newsDataByDate).forEach(function (dk) {
                     if (candleDates[dk] && !seen[dk]) {
                         seen[dk] = true;
+                        var count = newsDataByDate[dk].length;
                         markers.push({
                             time: candleDates[dk],
                             position: 'aboveBar',
                             color: '#ffcc00',
                             shape: 'circle',
-                            text: dateCounts[dk] + ' article' + (dateCounts[dk] > 1 ? 's' : ''),
+                            text: count + ' article' + (count > 1 ? 's' : ''),
                         });
                     }
                 });
 
                 if (markers.length > 0) {
                     markers.sort(function (a, b) { return a.time < b.time ? -1 : 1; });
-                    console.log('News markers:', markers.length, 'first:', markers[0]);
                     if (newsMarkers) { try { newsMarkers.detach(); } catch (e) {} }
                     try {
                         newsMarkers = LightweightCharts.createSeriesMarkers(candleSeries, markers);
@@ -292,6 +291,70 @@
             })
             .catch(function () {});
     }
+
+    // Click on chart → check if near a news marker date → show news list
+    chart.subscribeCrosshairMove(function (param) {
+        // handled in tooltip section
+    });
+
+    chart.subscribeClick(function (param) {
+        if (!param || !param.time || !isOn('news')) return;
+        var dk = typeof param.time === 'string' ? param.time : new Date(param.time * 1000).toISOString().slice(0, 10);
+        var articles = newsDataByDate[dk];
+        if (articles && articles.length > 0) {
+            showNewsPanel(articles, dk);
+        }
+    });
+
+    function showNewsPanel(articles, date) {
+        var panel = document.getElementById('chart-news-panel');
+        if (!panel) {
+            panel = document.createElement('div');
+            panel.id = 'chart-news-panel';
+            panel.className = 'chart-news-panel';
+            container.parentNode.insertBefore(panel, container.nextSibling);
+        }
+
+        var html = '<div class="cnp-header"><span>News for ' + date + '</span><button class="cnp-close" onclick="document.getElementById(\'chart-news-panel\').remove()">&#10005;</button></div>';
+        html += '<div class="cnp-list">';
+        articles.forEach(function (a, i) {
+            html += '<div class="cnp-item" data-url="' + encodeURIComponent(a.url || '') + '" onclick="window._openArticle(this.dataset.url)">'
+                + '<span class="cnp-title">' + (a.title || '').replace(/</g, '&lt;') + '</span>'
+                + '<span class="cnp-meta">' + (a.source || '') + '</span>'
+                + '</div>';
+        });
+        html += '</div>';
+        html += '<div id="cnp-reader" class="cnp-reader"></div>';
+        panel.innerHTML = html;
+    }
+
+    window._openArticle = function (encodedUrl) {
+        var url = decodeURIComponent(encodedUrl);
+        var reader = document.getElementById('cnp-reader');
+        if (!reader) return;
+        reader.innerHTML = '<p style="color:var(--text-muted)">Loading article...</p>';
+
+        fetch('/api/article?url=' + encodeURIComponent(url))
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (data.error) {
+                    reader.innerHTML = '<p style="color:var(--red)">' + data.error + '</p><a href="' + url + '" target="_blank" style="color:var(--blue)">Open in browser</a>';
+                    return;
+                }
+                var html = '<h2 class="cnp-article-title">' + (data.title || '').replace(/</g, '&lt;') + '</h2>';
+                html += '<div class="cnp-article-meta">' + (data.wordCount || 0) + ' words</div>';
+                html += '<div class="cnp-article-body">';
+                (data.paragraphs || []).forEach(function (p) {
+                    var tag = p.tag === 'h1' || p.tag === 'h2' || p.tag === 'h3' ? p.tag : 'p';
+                    html += '<' + tag + '>' + p.text.replace(/</g, '&lt;') + '</' + tag + '>';
+                });
+                html += '</div>';
+                reader.innerHTML = html;
+            })
+            .catch(function () {
+                reader.innerHTML = '<p style="color:var(--red)">Failed to load</p><a href="' + url + '" target="_blank" style="color:var(--blue)">Open in browser</a>';
+            });
+    };
 
     // ── Crosshair Tooltip ──
     var tooltipEl = document.getElementById('chart-tooltip');

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -311,26 +311,57 @@
     });
 
     function showNewsPanel(articles, date) {
-        var panel = document.getElementById('chart-news-panel');
-        if (!panel) {
-            panel = document.createElement('div');
-            panel.id = 'chart-news-panel';
-            panel.className = 'chart-news-panel';
-            container.parentNode.insertBefore(panel, container.nextSibling);
-        }
+        // Show article list in the shared reader panel
+        var reader = document.getElementById('article-reader');
+        var readerTitle = document.getElementById('reader-title');
+        var readerBody = document.getElementById('reader-body');
+        if (!reader || !readerBody) return;
 
-        var html = '<div class="cnp-header"><span>News for ' + date + ' (' + articles.length + ')</span><button class="cnp-close" onclick="document.getElementById(\'chart-news-panel\').remove();window._closeReader()">&#10005;</button></div>';
-        html += '<div class="cnp-list">';
+        reader.classList.remove('hidden');
+        if (readerTitle) readerTitle.textContent = 'News for ' + date + ' (' + articles.length + ')';
+
+        var html = '<div class="cnp-list">';
         articles.forEach(function (a) {
-            var safeUrl = (a.url || '').replace(/'/g, '%27');
-            var safeTitle = (a.title || '').replace(/</g, '&lt;').replace(/'/g, '&#39;');
-            html += '<div class="cnp-item" onclick="window._openReader(\'' + safeUrl + '\',\'' + safeTitle + '\')">'
+            var safeUrl = encodeURIComponent(a.url || '');
+            var safeTitle = (a.title || '').replace(/</g, '&lt;');
+            html += '<div class="cnp-item" data-url="' + safeUrl + '" data-title="' + safeTitle.replace(/"/g, '&quot;') + '">'
                 + '<span class="cnp-title">' + safeTitle + '</span>'
                 + '<span class="cnp-meta">' + (a.source || '') + '</span>'
                 + '</div>';
         });
         html += '</div>';
-        panel.innerHTML = html;
+        html += '<div id="cnp-article-content" class="reader-content" style="padding-top:12px"></div>';
+        readerBody.innerHTML = html;
+
+        // Wire up clicks
+        readerBody.querySelectorAll('.cnp-item').forEach(function (item) {
+            item.onclick = function () {
+                // Highlight active
+                readerBody.querySelectorAll('.cnp-item').forEach(function (i) { i.classList.remove('cnp-item-active'); });
+                item.classList.add('cnp-item-active');
+                // Load article content below the list
+                var contentEl = document.getElementById('cnp-article-content');
+                if (contentEl) {
+                    contentEl.innerHTML = '<p style="color:var(--text-muted)">Loading...</p>';
+                    var url = decodeURIComponent(item.dataset.url);
+                    fetch('/api/article?url=' + encodeURIComponent(url))
+                        .then(function (r) { return r.json(); })
+                        .then(function (data) {
+                            if (data.error) {
+                                contentEl.innerHTML = '<p style="color:var(--red)">' + data.error + '</p>';
+                                return;
+                            }
+                            var h = '';
+                            (data.paragraphs || []).forEach(function (p) {
+                                var tag = (p.tag === 'h1' || p.tag === 'h2' || p.tag === 'h3') ? p.tag : 'p';
+                                h += '<' + tag + '>' + p.text.replace(/</g, '&lt;') + '</' + tag + '>';
+                            });
+                            contentEl.innerHTML = '<div class="reader-meta">' + (data.wordCount || 0) + ' words</div>' + h;
+                        })
+                        .catch(function () { contentEl.innerHTML = '<p style="color:var(--red)">Failed to load</p>'; });
+                }
+            };
+        });
     }
 
     // ── Crosshair Tooltip ──

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -282,9 +282,9 @@
                 if (markers.length > 0) {
                     markers.sort(function (a, b) { return a.time < b.time ? -1 : 1; });
                     console.log('News markers:', markers.length, 'first:', markers[0]);
-                    if (newsMarkers) { try { chart.removeSeriesMarkers(newsMarkers); } catch (e) {} }
+                    if (newsMarkers) { try { newsMarkers.detach(); } catch (e) {} }
                     try {
-                        newsMarkers = chart.createSeriesMarkers(candleSeries, markers);
+                        newsMarkers = LightweightCharts.createSeriesMarkers(candleSeries, markers);
                     } catch (e) {
                         console.error('Marker error:', e);
                     }
@@ -362,7 +362,7 @@
         isIntraday = !!INTRADAY_RANGES[range];
         chart.timeScale().applyOptions({ timeVisible: isIntraday });
         updateAutoRefreshVisibility(); clearAutoRefresh();
-        if (newsMarkers) { chart.removeSeriesMarkers(newsMarkers); newsMarkers = null; }
+        if (newsMarkers) { try { newsMarkers.detach(); } catch (e) {} newsMarkers = null; }
         if (isIntraday) { loadIntraday(range); if (autoRefresh) scheduleAutoRefresh(); }
         else { loadEOD(range); }
     }

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -56,6 +56,7 @@
     var ema20Series = null, ema50Series = null;
     var macdLineSeries = null, macdSignalSeries = null, macdHistSeries = null;
     var rsiSeries = null, rsi70Line = null, rsi30Line = null;
+    var newsMarkers = null;
 
     // ── Indicator Calculations ──
     function calcSMA(data, period) {
@@ -268,7 +269,8 @@
 
                 if (markers.length > 0) {
                     markers.sort(function (a, b) { return a.time < b.time ? -1 : 1; });
-                    candleSeries.setMarkers(markers);
+                    if (newsMarkers) { chart.removeSeriesMarkers(newsMarkers); }
+                    newsMarkers = chart.createSeriesMarkers(candleSeries, markers);
                 }
             })
             .catch(function () {});
@@ -343,7 +345,7 @@
         isIntraday = !!INTRADAY_RANGES[range];
         chart.timeScale().applyOptions({ timeVisible: isIntraday });
         updateAutoRefreshVisibility(); clearAutoRefresh();
-        candleSeries.setMarkers([]); // clear markers on range change
+        if (newsMarkers) { chart.removeSeriesMarkers(newsMarkers); newsMarkers = null; }
         if (isIntraday) { loadIntraday(range); if (autoRefresh) scheduleAutoRefresh(); }
         else { loadEOD(range); }
     }

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -83,13 +83,17 @@
     }
 
     function calcMACD(data) {
+        if (data.length < 26) return { line: [], signal: [], hist: [] };
         var ema12 = calcEMAValues(data, 12);
         var ema26 = calcEMAValues(data, 26);
         if (ema12.length === 0 || ema26.length === 0) return { line: [], signal: [], hist: [] };
         var macdLine = [];
-        var offset = ema12.length - ema26.length;
+        // EMA12 starts at index 11, EMA26 starts at index 25
+        // Align: for each EMA26 value at index i, the matching EMA12 is at i + 14
         for (var i = 0; i < ema26.length; i++) {
-            macdLine.push({ time: data[offset + i + 25].time, value: ema12[offset + i] - ema26[i] });
+            var dataIdx = i + 25; // corresponding index in original data
+            if (dataIdx >= data.length) break;
+            macdLine.push({ time: data[dataIdx].time, value: ema12[i + 14] - ema26[i] });
         }
         // Signal line = 9-period EMA of MACD
         var signal = calcEMAFromValues(macdLine, 9);

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -1,404 +1,427 @@
-// Stocktopus Chart — EOD + intraday candlestick with volume and lazy history loading
+// Stocktopus Chart — candlestick + volume + SMA/EMA + MACD + RSI + news markers + tooltip
 
 (function () {
     'use strict';
 
     var container = document.getElementById('chart-container');
     if (!container) return;
-
     var symbol = container.dataset.symbol;
     if (!symbol) return;
 
-    // ── Persisted Range ──
-
+    // ── Persisted State ──
     var RANGE_KEY = 'stocktopus-chart-range';
     var defaultRange = localStorage.getItem(RANGE_KEY) || '1M';
+    var toggleState = JSON.parse(localStorage.getItem('stocktopus-chart-toggles') || '{}');
 
-    // ── Range Config ──
-
-    // EOD ranges: fetch more than shown, with lazy scroll-back
     var EOD_RANGES = {
-        '1W': { fetch: 30, view: 7 },
-        '1M': { fetch: 90, view: 30 },
-        '3M': { fetch: 180, view: 90 },
-        '6M': { fetch: 365, view: 180 },
+        '1W': { fetch: 30, view: 7 }, '1M': { fetch: 90, view: 30 },
+        '3M': { fetch: 180, view: 90 }, '6M': { fetch: 365, view: 180 },
     };
-
-    // Intraday ranges: interval name for API, how many days to fetch/show
     var INTRADAY_RANGES = {
-        '1m':  { interval: '1min',  fetchDays: 1,  viewDays: 1,  scrollDays: 1 },
-        '5m':  { interval: '5min',  fetchDays: 3,  viewDays: 1,  scrollDays: 2 },
-        '15m': { interval: '15min', fetchDays: 5,  viewDays: 2,  scrollDays: 5 },
-        '30m': { interval: '30min', fetchDays: 10, viewDays: 3,  scrollDays: 7 },
-        '1h':  { interval: '1hour', fetchDays: 20, viewDays: 5,  scrollDays: 10 },
-        '4h':  { interval: '4hour', fetchDays: 60, viewDays: 15, scrollDays: 30 },
+        '1m': { interval: '1min', fetchDays: 1, viewDays: 1, scrollDays: 1 },
+        '5m': { interval: '5min', fetchDays: 3, viewDays: 1, scrollDays: 2 },
+        '15m': { interval: '15min', fetchDays: 5, viewDays: 2, scrollDays: 5 },
+        '30m': { interval: '30min', fetchDays: 10, viewDays: 3, scrollDays: 7 },
+        '1h': { interval: '1hour', fetchDays: 20, viewDays: 5, scrollDays: 10 },
+        '4h': { interval: '4hour', fetchDays: 60, viewDays: 15, scrollDays: 30 },
     };
-
-    var currentRange = null;
-    var isIntraday = false;
-    var loadedFrom = null;
-    var isLoadingMore = false;
-    var autoRefresh = true;
-    var autoRefreshTimer = null;
-
-    // Intervals under 1 hour that support auto-refresh
     var AUTO_REFRESH_INTERVALS = { '1m': 60, '5m': 300, '15m': 900, '30m': 1800 };
 
-    // ── All loaded data ──
+    var currentRange = null, isIntraday = false, loadedFrom = null;
+    var isLoadingMore = false, autoRefresh = true, autoRefreshTimer = null;
+    var allCandles = [], allVolumes = [];
 
-    var allCandles = [];
-    var allVolumes = [];
-
-    // ── Create Chart ──
-
+    // ── Chart ──
     var chart = LightweightCharts.createChart(container, {
-        layout: {
-            background: { color: '#0a0a0a' },
-            textColor: '#888888',
-            fontFamily: "'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace",
-            fontSize: 11,
-        },
-        grid: {
-            vertLines: { color: '#1a1a1a' },
-            horzLines: { color: '#1a1a1a' },
-        },
-        crosshair: {
-            mode: LightweightCharts.CrosshairMode.Normal,
-            vertLine: { color: '#555555', style: LightweightCharts.LineStyle.Dashed },
-            horzLine: { color: '#555555', style: LightweightCharts.LineStyle.Dashed },
-        },
-        rightPriceScale: {
-            borderColor: '#2a2a2a',
-            scaleMargins: { top: 0.05, bottom: 0.25 },
-        },
-        timeScale: {
-            borderColor: '#2a2a2a',
-            timeVisible: true,
-            secondsVisible: false,
-            rightOffset: 5,
-        },
-        handleScroll: true,
-        handleScale: true,
+        layout: { background: { color: '#0a0a0a' }, textColor: '#888888', fontFamily: "'SF Mono','Consolas',monospace", fontSize: 11 },
+        grid: { vertLines: { color: '#1a1a1a' }, horzLines: { color: '#1a1a1a' } },
+        crosshair: { mode: LightweightCharts.CrosshairMode.Normal, vertLine: { color: '#555', style: 2 }, horzLine: { color: '#555', style: 2 } },
+        rightPriceScale: { borderColor: '#2a2a2a', scaleMargins: { top: 0.05, bottom: 0.25 } },
+        timeScale: { borderColor: '#2a2a2a', timeVisible: true, secondsVisible: false, rightOffset: 5 },
+        handleScroll: true, handleScale: true,
     });
-
     window._stocktopusChart = chart;
 
-    // ── Series ──
-
+    // ── Main Series ──
     var candleSeries = chart.addSeries(LightweightCharts.CandlestickSeries, {
-        upColor: '#00cc66',
-        downColor: '#ff4444',
-        wickUpColor: '#00cc66',
-        wickDownColor: '#ff4444',
-        borderVisible: false,
+        upColor: '#00cc66', downColor: '#ff4444', wickUpColor: '#00cc66', wickDownColor: '#ff4444', borderVisible: false,
     });
-
     var volumeSeries = chart.addSeries(LightweightCharts.HistogramSeries, {
-        priceFormat: { type: 'volume' },
-        priceScaleId: 'volume',
+        priceFormat: { type: 'volume' }, priceScaleId: 'volume',
+    });
+    chart.priceScale('volume').applyOptions({ scaleMargins: { top: 0.8, bottom: 0 }, drawTicks: false });
+
+    // ── Indicator Series (created lazily) ──
+    var sma20Series = null, sma50Series = null, sma200Series = null;
+    var ema20Series = null, ema50Series = null;
+    var macdLineSeries = null, macdSignalSeries = null, macdHistSeries = null;
+    var rsiSeries = null, rsi70Line = null, rsi30Line = null;
+
+    // ── Indicator Calculations ──
+    function calcSMA(data, period) {
+        var result = [];
+        for (var i = period - 1; i < data.length; i++) {
+            var sum = 0;
+            for (var j = i - period + 1; j <= i; j++) sum += data[j].close;
+            result.push({ time: data[i].time, value: sum / period });
+        }
+        return result;
+    }
+
+    function calcEMA(data, period) {
+        if (data.length < period) return [];
+        var k = 2 / (period + 1);
+        var sum = 0;
+        for (var i = 0; i < period; i++) sum += data[i].close;
+        var prev = sum / period;
+        var result = [{ time: data[period - 1].time, value: prev }];
+        for (var i = period; i < data.length; i++) {
+            prev = data[i].close * k + prev * (1 - k);
+            result.push({ time: data[i].time, value: prev });
+        }
+        return result;
+    }
+
+    function calcMACD(data) {
+        var ema12 = calcEMAValues(data, 12);
+        var ema26 = calcEMAValues(data, 26);
+        if (ema12.length === 0 || ema26.length === 0) return { line: [], signal: [], hist: [] };
+        var macdLine = [];
+        var offset = ema12.length - ema26.length;
+        for (var i = 0; i < ema26.length; i++) {
+            macdLine.push({ time: data[offset + i + 25].time, value: ema12[offset + i] - ema26[i] });
+        }
+        // Signal line = 9-period EMA of MACD
+        var signal = calcEMAFromValues(macdLine, 9);
+        var hist = [];
+        var sigOffset = macdLine.length - signal.length;
+        for (var i = 0; i < signal.length; i++) {
+            var val = macdLine[sigOffset + i].value - signal[i].value;
+            hist.push({ time: signal[i].time, value: val, color: val >= 0 ? 'rgba(0,204,102,0.5)' : 'rgba(255,68,68,0.5)' });
+        }
+        return { line: macdLine, signal: signal, hist: hist };
+    }
+
+    function calcRSI(data, period) {
+        if (data.length < period + 1) return [];
+        var gains = 0, losses = 0;
+        for (var i = 1; i <= period; i++) {
+            var diff = data[i].close - data[i - 1].close;
+            if (diff > 0) gains += diff; else losses -= diff;
+        }
+        var avgGain = gains / period, avgLoss = losses / period;
+        var result = [{ time: data[period].time, value: avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss) }];
+        for (var i = period + 1; i < data.length; i++) {
+            var diff = data[i].close - data[i - 1].close;
+            avgGain = (avgGain * (period - 1) + (diff > 0 ? diff : 0)) / period;
+            avgLoss = (avgLoss * (period - 1) + (diff < 0 ? -diff : 0)) / period;
+            result.push({ time: data[i].time, value: avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss) });
+        }
+        return result;
+    }
+
+    function calcEMAValues(data, period) {
+        if (data.length < period) return [];
+        var k = 2 / (period + 1);
+        var sum = 0;
+        for (var i = 0; i < period; i++) sum += data[i].close;
+        var prev = sum / period;
+        var result = [prev];
+        for (var i = period; i < data.length; i++) {
+            prev = data[i].close * k + prev * (1 - k);
+            result.push(prev);
+        }
+        return result;
+    }
+
+    function calcEMAFromValues(data, period) {
+        if (data.length < period) return [];
+        var k = 2 / (period + 1);
+        var sum = 0;
+        for (var i = 0; i < period; i++) sum += data[i].value;
+        var prev = sum / period;
+        var result = [{ time: data[period - 1].time, value: prev }];
+        for (var i = period; i < data.length; i++) {
+            prev = data[i].value * k + prev * (1 - k);
+            result.push({ time: data[i].time, value: prev });
+        }
+        return result;
+    }
+
+    // ── Indicator Toggle ──
+    function isOn(name) { return !!toggleState[name]; }
+
+    function toggle(name) {
+        toggleState[name] = !toggleState[name];
+        localStorage.setItem('stocktopus-chart-toggles', JSON.stringify(toggleState));
+        updateToggleButtons();
+        updateIndicators();
+    }
+
+    window._stocktopusToggle = toggle;
+
+    function updateToggleButtons() {
+        document.querySelectorAll('.chart-toggle').forEach(function (btn) {
+            btn.classList.toggle('active', isOn(btn.dataset.indicator));
+        });
+    }
+
+    document.querySelectorAll('.chart-toggle').forEach(function (btn) {
+        btn.onclick = function () { toggle(btn.dataset.indicator); };
     });
 
-    chart.priceScale('volume').applyOptions({
-        scaleMargins: { top: 0.8, bottom: 0 },
-        drawTicks: false,
+    function updateIndicators() {
+        // Remove old series
+        [sma20Series, sma50Series, sma200Series, ema20Series, ema50Series,
+         macdLineSeries, macdSignalSeries, macdHistSeries, rsiSeries].forEach(function (s) {
+            if (s) { try { chart.removeSeries(s); } catch (e) {} }
+        });
+        sma20Series = sma50Series = sma200Series = ema20Series = ema50Series = null;
+        macdLineSeries = macdSignalSeries = macdHistSeries = rsiSeries = null;
+
+        if (allCandles.length < 2) return;
+
+        // SMA
+        if (isOn('sma')) {
+            sma20Series = chart.addSeries(LightweightCharts.LineSeries, { color: '#ffcc00', lineWidth: 1, priceLineVisible: false, lastValueVisible: false, title: 'SMA20' });
+            sma50Series = chart.addSeries(LightweightCharts.LineSeries, { color: '#ff6699', lineWidth: 1, priceLineVisible: false, lastValueVisible: false, title: 'SMA50' });
+            sma200Series = chart.addSeries(LightweightCharts.LineSeries, { color: '#cc66ff', lineWidth: 1, priceLineVisible: false, lastValueVisible: false, title: 'SMA200' });
+            sma20Series.setData(calcSMA(allCandles, 20));
+            sma50Series.setData(calcSMA(allCandles, 50));
+            if (allCandles.length >= 200) sma200Series.setData(calcSMA(allCandles, 200));
+        }
+
+        // EMA
+        if (isOn('ema')) {
+            ema20Series = chart.addSeries(LightweightCharts.LineSeries, { color: '#00cccc', lineWidth: 1, priceLineVisible: false, lastValueVisible: false, title: 'EMA20' });
+            ema50Series = chart.addSeries(LightweightCharts.LineSeries, { color: '#4499ff', lineWidth: 1, priceLineVisible: false, lastValueVisible: false, title: 'EMA50' });
+            ema20Series.setData(calcEMA(allCandles, 20));
+            ema50Series.setData(calcEMA(allCandles, 50));
+        }
+
+        // MACD
+        if (isOn('macd')) {
+            var macd = calcMACD(allCandles);
+            macdHistSeries = chart.addSeries(LightweightCharts.HistogramSeries, { priceScaleId: 'macd', priceLineVisible: false, lastValueVisible: false, title: 'MACD' });
+            macdLineSeries = chart.addSeries(LightweightCharts.LineSeries, { color: '#4499ff', lineWidth: 1, priceScaleId: 'macd', priceLineVisible: false, lastValueVisible: false });
+            macdSignalSeries = chart.addSeries(LightweightCharts.LineSeries, { color: '#ff6699', lineWidth: 1, priceScaleId: 'macd', priceLineVisible: false, lastValueVisible: false });
+            chart.priceScale('macd').applyOptions({ scaleMargins: { top: 0.75, bottom: 0 }, drawTicks: false });
+            macdHistSeries.setData(macd.hist);
+            macdLineSeries.setData(macd.line);
+            macdSignalSeries.setData(macd.signal);
+        }
+
+        // RSI
+        if (isOn('rsi')) {
+            rsiSeries = chart.addSeries(LightweightCharts.LineSeries, { color: '#cc66ff', lineWidth: 1, priceScaleId: 'rsi', priceLineVisible: false, lastValueVisible: false, title: 'RSI' });
+            chart.priceScale('rsi').applyOptions({ scaleMargins: { top: 0.85, bottom: 0 }, drawTicks: false });
+            rsiSeries.setData(calcRSI(allCandles, 14));
+            // Add 70/30 lines
+            rsiSeries.createPriceLine({ price: 70, color: '#ff444466', lineWidth: 1, lineStyle: 2, axisLabelVisible: false });
+            rsiSeries.createPriceLine({ price: 30, color: '#00cc6666', lineWidth: 1, lineStyle: 2, axisLabelVisible: false });
+        }
+
+        // News markers
+        if (isOn('news')) {
+            loadNewsMarkers();
+        }
+    }
+
+    // ── News Markers ──
+    function loadNewsMarkers() {
+        fetch('/api/news/stock?symbols=' + symbol + '&limit=50')
+            .then(function (r) { return r.json(); })
+            .then(function (news) {
+                if (!news || news.length === 0) return;
+                var markers = [];
+                var candleDates = {};
+                allCandles.forEach(function (c) {
+                    var dateKey = typeof c.time === 'string' ? c.time : new Date(c.time * 1000).toISOString().slice(0, 10);
+                    candleDates[dateKey] = c.time;
+                });
+
+                news.forEach(function (n) {
+                    var dateKey = (n.date || '').slice(0, 10);
+                    if (candleDates[dateKey]) {
+                        markers.push({
+                            time: candleDates[dateKey],
+                            position: 'aboveBar',
+                            color: '#ffcc00',
+                            shape: 'circle',
+                            text: (n.title || '').substring(0, 30),
+                        });
+                    }
+                });
+
+                // Dedupe by time (one marker per candle)
+                var seen = {};
+                markers = markers.filter(function (m) {
+                    var key = JSON.stringify(m.time);
+                    if (seen[key]) return false;
+                    seen[key] = true;
+                    return true;
+                });
+
+                if (markers.length > 0) {
+                    markers.sort(function (a, b) { return a.time < b.time ? -1 : 1; });
+                    candleSeries.setMarkers(markers);
+                }
+            })
+            .catch(function () {});
+    }
+
+    // ── Crosshair Tooltip ──
+    var tooltipEl = document.getElementById('chart-tooltip');
+
+    chart.subscribeCrosshairMove(function (param) {
+        if (!tooltipEl) return;
+        if (!param || !param.time || param.seriesData.size === 0) {
+            tooltipEl.classList.add('hidden');
+            return;
+        }
+
+        var candle = param.seriesData.get(candleSeries);
+        if (!candle) { tooltipEl.classList.add('hidden'); return; }
+
+        var chgClass = candle.close >= candle.open ? 'price-up' : 'price-down';
+        tooltipEl.innerHTML = '<span class="tt-sym">' + symbol + '</span>'
+            + ' O:<span class="' + chgClass + '">' + candle.open.toFixed(2) + '</span>'
+            + ' H:<span class="' + chgClass + '">' + candle.high.toFixed(2) + '</span>'
+            + ' L:<span class="' + chgClass + '">' + candle.low.toFixed(2) + '</span>'
+            + ' C:<span class="' + chgClass + '">' + candle.close.toFixed(2) + '</span>';
+
+        tooltipEl.classList.remove('hidden');
     });
 
     // ── Range Buttons ──
-
     function setActiveRangeBtn(range) {
-        var rangeBar = document.getElementById('chart-range-bar');
-        if (!rangeBar) return;
-        rangeBar.querySelectorAll('.chart-range-btn').forEach(function (b) {
-            b.classList.toggle('active', b.dataset.range === range);
-        });
+        var bar = document.getElementById('chart-range-bar');
+        if (bar) bar.querySelectorAll('.chart-range-btn').forEach(function (b) { b.classList.toggle('active', b.dataset.range === range); });
     }
-
     var rangeBar = document.getElementById('chart-range-bar');
-    if (rangeBar) {
-        rangeBar.querySelectorAll('.chart-range-btn').forEach(function (btn) {
-            btn.onclick = function () {
-                setRange(btn.dataset.range);
-            };
-        });
-    }
+    if (rangeBar) rangeBar.querySelectorAll('.chart-range-btn').forEach(function (btn) { btn.onclick = function () { setRange(btn.dataset.range); }; });
 
-    // ── Auto-Refresh Button ──
-
+    // ── Auto-Refresh ──
     var autoRefreshBtn = document.getElementById('chart-auto-refresh');
     if (autoRefreshBtn) {
-        autoRefreshBtn.onclick = function () {
-            autoRefresh = !autoRefresh;
-            autoRefreshBtn.classList.toggle('active', autoRefresh);
-            if (autoRefresh) {
-                scheduleAutoRefresh();
-            } else {
-                clearAutoRefresh();
-            }
-        };
+        autoRefreshBtn.onclick = function () { autoRefresh = !autoRefresh; autoRefreshBtn.classList.toggle('active', autoRefresh); if (autoRefresh) scheduleAutoRefresh(); else clearAutoRefresh(); };
     }
-
-    function updateAutoRefreshVisibility() {
-        if (autoRefreshBtn) {
-            autoRefreshBtn.style.display = AUTO_REFRESH_INTERVALS[currentRange] ? '' : 'none';
-        }
-    }
-
+    function updateAutoRefreshVisibility() { if (autoRefreshBtn) autoRefreshBtn.style.display = AUTO_REFRESH_INTERVALS[currentRange] ? '' : 'none'; }
     function scheduleAutoRefresh() {
         clearAutoRefresh();
         if (!autoRefresh || !currentRange) return;
-
-        var intervalSecs = AUTO_REFRESH_INTERVALS[currentRange];
-        if (!intervalSecs) return;
-
-        // Calculate ms until the next clock boundary + 3s buffer
-        var now = new Date();
-        var epochSecs = Math.floor(now.getTime() / 1000);
-        var remainder = epochSecs % intervalSecs;
-        var delayMs = ((intervalSecs - remainder) * 1000) + 3000;
-
-        console.log('Auto-refresh scheduled in', Math.round(delayMs / 1000) + 's for', currentRange);
-
-        autoRefreshTimer = setTimeout(function () {
-            console.log('Auto-refreshing', symbol, currentRange);
-            refreshLatest();
-            scheduleAutoRefresh();
-        }, delayMs);
+        var secs = AUTO_REFRESH_INTERVALS[currentRange];
+        if (!secs) return;
+        var now = Math.floor(Date.now() / 1000);
+        var delay = ((secs - (now % secs)) * 1000) + 3000;
+        autoRefreshTimer = setTimeout(function () { refreshLatest(); scheduleAutoRefresh(); }, delay);
     }
-
-    function clearAutoRefresh() {
-        if (autoRefreshTimer) {
-            clearTimeout(autoRefreshTimer);
-            autoRefreshTimer = null;
-        }
-    }
-
+    function clearAutoRefresh() { if (autoRefreshTimer) { clearTimeout(autoRefreshTimer); autoRefreshTimer = null; } }
     function refreshLatest() {
         if (!isIntraday || !currentRange) return;
-        var cfg = INTRADAY_RANGES[currentRange];
-        if (!cfg) return;
-
-        // Fetch just today's data and merge
-        var today = formatDate(new Date());
+        var cfg = INTRADAY_RANGES[currentRange]; if (!cfg) return;
+        var today = fmtDate(new Date());
         fetch('/api/chart/intraday/' + cfg.interval + '/' + symbol + '?from=' + today + '&to=' + today)
             .then(function (r) { return r.json(); })
             .then(function (data) {
                 if (!data || data.length === 0) return;
-
-                mergeData(data.map(function (d) {
-                    return { time: parseIntradayTime(d.date), open: d.open, high: d.high, low: d.low, close: d.close };
-                }), data.map(function (d) {
-                    return { time: parseIntradayTime(d.date), value: d.volume, color: d.close >= d.open ? 'rgba(0, 204, 102, 0.3)' : 'rgba(255, 68, 68, 0.3)' };
-                }));
-
-                setChartData();
-            })
-            .catch(function (err) { console.error('Auto-refresh error:', err); });
+                mergeData(data.map(function (d) { return { time: parseTime(d.date), open: d.open, high: d.high, low: d.low, close: d.close }; }),
+                    data.map(function (d) { return { time: parseTime(d.date), value: d.volume, color: d.close >= d.open ? 'rgba(0,204,102,0.3)' : 'rgba(255,68,68,0.3)' }; }));
+                applyData();
+            }).catch(function () {});
     }
 
     // ── Set Range ──
-
     function setRange(range) {
         localStorage.setItem(RANGE_KEY, range);
         setActiveRangeBtn(range);
-        currentRange = range;
-        allCandles = [];
-        allVolumes = [];
-        loadedFrom = null;
+        currentRange = range; allCandles = []; allVolumes = []; loadedFrom = null;
         isIntraday = !!INTRADAY_RANGES[range];
-
-        // Toggle time visibility based on type
-        chart.timeScale().applyOptions({
-            timeVisible: isIntraday,
-        });
-
-        updateAutoRefreshVisibility();
-        clearAutoRefresh();
-
-        if (isIntraday) {
-            loadIntraday(range);
-            if (autoRefresh) scheduleAutoRefresh();
-        } else {
-            loadEOD(range);
-        }
+        chart.timeScale().applyOptions({ timeVisible: isIntraday });
+        updateAutoRefreshVisibility(); clearAutoRefresh();
+        candleSeries.setMarkers([]); // clear markers on range change
+        if (isIntraday) { loadIntraday(range); if (autoRefresh) scheduleAutoRefresh(); }
+        else { loadEOD(range); }
     }
-
     window._stocktopusSetRange = setRange;
 
-    // ── EOD Loading ──
-
+    // ── Data Loading ──
     function loadEOD(range) {
-        var span = EOD_RANGES[range] || { fetch: 30, view: 7 };
-        var to = new Date();
-        var from = new Date();
-        from.setDate(from.getDate() - span.fetch);
-
-        fetchEODAndRender(formatDate(from), formatDate(to), span.view);
+        var s = EOD_RANGES[range] || { fetch: 30, view: 7 };
+        var to = new Date(), from = new Date(); from.setDate(from.getDate() - s.fetch);
+        fetchData('/api/chart/eod/' + symbol + '?from=' + fmtDate(from) + '&to=' + fmtDate(to), false, s.view);
     }
-
-    function fetchEODAndRender(fromStr, toStr, viewDays) {
-        fetch('/api/chart/eod/' + symbol + '?from=' + fromStr + '&to=' + toStr)
-            .then(function (r) { return r.json(); })
-            .then(function (data) {
-                if (!data || data.length === 0) return;
-
-                mergeData(data.map(function (d) {
-                    return { time: d.date, open: d.open, high: d.high, low: d.low, close: d.close };
-                }), data.map(function (d) {
-                    return { time: d.date, value: d.volume, color: d.close >= d.open ? 'rgba(0, 204, 102, 0.3)' : 'rgba(255, 68, 68, 0.3)' };
-                }));
-
-                setChartData();
-                loadedFrom = allCandles[0].time;
-
-                if (viewDays) {
-                    var viewFrom = new Date();
-                    viewFrom.setDate(viewFrom.getDate() - viewDays);
-                    chart.timeScale().setVisibleRange({ from: formatDate(viewFrom), to: formatDate(new Date()) });
-                }
-
-                isLoadingMore = false;
-            })
-            .catch(function (err) { console.error('EOD error:', err); isLoadingMore = false; });
-    }
-
-    // ── Intraday Loading ──
-
     function loadIntraday(range) {
-        var cfg = INTRADAY_RANGES[range];
-        if (!cfg) return;
-
-        var to = new Date();
-        var from = new Date();
-        from.setDate(from.getDate() - cfg.fetchDays);
-
-        fetchIntradayAndRender(cfg.interval, formatDate(from), formatDate(to), cfg.viewDays);
+        var c = INTRADAY_RANGES[range]; if (!c) return;
+        var to = new Date(), from = new Date(); from.setDate(from.getDate() - c.fetchDays);
+        fetchData('/api/chart/intraday/' + c.interval + '/' + symbol + '?from=' + fmtDate(from) + '&to=' + fmtDate(to), true, c.viewDays);
     }
 
-    function fetchIntradayAndRender(interval, fromStr, toStr, viewDays) {
-        fetch('/api/chart/intraday/' + interval + '/' + symbol + '?from=' + fromStr + '&to=' + toStr)
-            .then(function (r) { return r.json(); })
-            .then(function (data) {
-                if (!data || data.length === 0) return;
-
-                mergeData(data.map(function (d) {
-                    return { time: parseIntradayTime(d.date), open: d.open, high: d.high, low: d.low, close: d.close };
-                }), data.map(function (d) {
-                    return { time: parseIntradayTime(d.date), value: d.volume, color: d.close >= d.open ? 'rgba(0, 204, 102, 0.3)' : 'rgba(255, 68, 68, 0.3)' };
-                }));
-
-                setChartData();
-                if (allCandles.length > 0) loadedFrom = allCandles[0].time;
-
-                if (viewDays) {
-                    chart.timeScale().fitContent();
+    function fetchData(url, intra, viewDays) {
+        fetch(url).then(function (r) { return r.json(); }).then(function (data) {
+            if (!data || data.length === 0) return;
+            mergeData(data.map(function (d) { return { time: intra ? parseTime(d.date) : d.date, open: d.open, high: d.high, low: d.low, close: d.close }; }),
+                data.map(function (d) { return { time: intra ? parseTime(d.date) : d.date, value: d.volume, color: d.close >= d.open ? 'rgba(0,204,102,0.3)' : 'rgba(255,68,68,0.3)' }; }));
+            applyData();
+            if (allCandles.length > 0) loadedFrom = allCandles[0].time;
+            if (viewDays) {
+                if (intra) { chart.timeScale().fitContent(); }
+                else {
+                    var vf = new Date(); vf.setDate(vf.getDate() - viewDays);
+                    chart.timeScale().setVisibleRange({ from: fmtDate(vf), to: fmtDate(new Date()) });
                 }
-
-                isLoadingMore = false;
-            })
-            .catch(function (err) { console.error('Intraday error:', err); isLoadingMore = false; });
+            }
+            isLoadingMore = false;
+        }).catch(function (e) { console.error('Chart error:', e); isLoadingMore = false; });
     }
 
-    // Parse "2026-04-21 13:55:00" to Unix timestamp for Lightweight Charts
-    function parseIntradayTime(dateStr) {
-        var d = new Date(dateStr.replace(' ', 'T') + 'Z');
-        return Math.floor(d.getTime() / 1000);
+    function applyData() {
+        candleSeries.setData(allCandles);
+        volumeSeries.setData(allVolumes);
+        updateIndicators();
     }
 
     // ── Data Merge ──
-
-    function mergeData(newCandles, newVolumes) {
-        // Build index of existing data by time
-        var existingIdx = {};
-        allCandles.forEach(function (c, i) { existingIdx[JSON.stringify(c.time)] = i; });
-
-        newCandles.forEach(function (c, i) {
-            var key = JSON.stringify(c.time);
-            if (key in existingIdx) {
-                // Update existing candle (e.g. current minute updating)
-                var idx = existingIdx[key];
-                allCandles[idx] = c;
-                allVolumes[idx] = newVolumes[i];
-            } else {
-                allCandles.push(c);
-                allVolumes.push(newVolumes[i]);
-                existingIdx[key] = allCandles.length - 1;
-            }
-        });
-
-        // Sort
-        var timeSort = function (a, b) {
-            var ta = typeof a.time === 'number' ? a.time : a.time;
-            var tb = typeof b.time === 'number' ? b.time : b.time;
-            return ta < tb ? -1 : ta > tb ? 1 : 0;
-        };
-        allCandles.sort(timeSort);
-        allVolumes.sort(timeSort);
+    function mergeData(nc, nv) {
+        var idx = {}; allCandles.forEach(function (c, i) { idx[JSON.stringify(c.time)] = i; });
+        nc.forEach(function (c, i) { var k = JSON.stringify(c.time); if (k in idx) { allCandles[idx[k]] = c; allVolumes[idx[k]] = nv[i]; } else { allCandles.push(c); allVolumes.push(nv[i]); idx[k] = allCandles.length - 1; } });
+        var ts = function (a, b) { return a.time < b.time ? -1 : a.time > b.time ? 1 : 0; };
+        allCandles.sort(ts); allVolumes.sort(ts);
     }
 
-    function setChartData() {
-        candleSeries.setData(allCandles);
-        volumeSeries.setData(allVolumes);
-    }
-
-    // ── Lazy Loading on Scroll Left ──
-
-    chart.timeScale().subscribeVisibleLogicalRangeChange(function (logicalRange) {
-        if (!logicalRange || isLoadingMore || !loadedFrom) return;
-        if (logicalRange.from < 5) {
-            loadMoreHistory();
-        }
+    // ── Lazy Scroll ──
+    chart.timeScale().subscribeVisibleLogicalRangeChange(function (lr) {
+        if (!lr || isLoadingMore || !loadedFrom) return;
+        if (lr.from < 5) loadMore();
     });
-
-    function loadMoreHistory() {
+    function loadMore() {
         if (isLoadingMore || !loadedFrom) return;
         isLoadingMore = true;
-
         if (isIntraday) {
-            var cfg = INTRADAY_RANGES[currentRange];
-            if (!cfg) { isLoadingMore = false; return; }
-            // loadedFrom is a unix timestamp for intraday
-            var toDate = new Date(loadedFrom * 1000);
-            toDate.setDate(toDate.getDate() - 1);
-            var fromDate = new Date(toDate);
-            fromDate.setDate(fromDate.getDate() - cfg.scrollDays);
-            fetchIntradayAndRender(cfg.interval, formatDate(fromDate), formatDate(toDate), 0);
+            var c = INTRADAY_RANGES[currentRange]; if (!c) { isLoadingMore = false; return; }
+            var to = new Date(loadedFrom * 1000); to.setDate(to.getDate() - 1);
+            var from = new Date(to); from.setDate(from.getDate() - c.scrollDays);
+            fetchData('/api/chart/intraday/' + c.interval + '/' + symbol + '?from=' + fmtDate(from) + '&to=' + fmtDate(to), true, 0);
         } else {
-            var span = EOD_RANGES[currentRange] || { fetch: 30 };
-            var to = new Date(loadedFrom);
-            to.setDate(to.getDate() - 1);
-            var from = new Date(to);
-            from.setDate(from.getDate() - span.fetch);
-            fetchEODAndRender(formatDate(from), formatDate(to), 0);
+            var s = EOD_RANGES[currentRange] || { fetch: 30 };
+            var to = new Date(loadedFrom); to.setDate(to.getDate() - 1);
+            var from = new Date(to); from.setDate(from.getDate() - s.fetch);
+            fetchData('/api/chart/eod/' + symbol + '?from=' + fmtDate(from) + '&to=' + fmtDate(to), false, 0);
         }
     }
 
     // ── Helpers ──
+    function fmtDate(d) { return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0'); }
+    function parseTime(s) { return Math.floor(new Date(s.replace(' ', 'T') + 'Z').getTime() / 1000); }
+    function resizeChart() { chart.resize(container.clientWidth, container.clientHeight); }
+    window.addEventListener('resize', resizeChart); resizeChart();
 
-    function formatDate(d) {
-        var y = d.getFullYear();
-        var m = String(d.getMonth() + 1).padStart(2, '0');
-        var day = String(d.getDate()).padStart(2, '0');
-        return y + '-' + m + '-' + day;
-    }
-
-    function resizeChart() {
-        chart.resize(container.clientWidth, container.clientHeight);
-    }
-
-    window.addEventListener('resize', resizeChart);
-    resizeChart();
-
-    // ── Default Load ──
-
+    // ── Init ──
+    updateToggleButtons();
     setActiveRangeBtn(defaultRange);
     currentRange = defaultRange;
     isIntraday = !!INTRADAY_RANGES[defaultRange];
     updateAutoRefreshVisibility();
-    if (isIntraday) {
-        chart.timeScale().applyOptions({ timeVisible: true });
-        loadIntraday(defaultRange);
-        if (autoRefresh) scheduleAutoRefresh();
-    } else {
-        loadEOD(defaultRange);
-    }
+    if (isIntraday) { chart.timeScale().applyOptions({ timeVisible: true }); loadIntraday(defaultRange); if (autoRefresh) scheduleAutoRefresh(); }
+    else { loadEOD(defaultRange); }
 })();

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -281,8 +281,13 @@
 
                 if (markers.length > 0) {
                     markers.sort(function (a, b) { return a.time < b.time ? -1 : 1; });
+                    console.log('News markers:', markers.length, 'first:', markers[0]);
                     if (newsMarkers) { try { chart.removeSeriesMarkers(newsMarkers); } catch (e) {} }
-                    newsMarkers = chart.createSeriesMarkers(candleSeries, markers);
+                    try {
+                        newsMarkers = chart.createSeriesMarkers(candleSeries, markers);
+                    } catch (e) {
+                        console.error('Marker error:', e);
+                    }
                 }
             })
             .catch(function () {});

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -234,42 +234,54 @@
 
     // ── News Markers ──
     function loadNewsMarkers() {
-        fetch('/api/news/stock?symbols=' + symbol + '&limit=50')
+        if (allCandles.length < 2) return;
+
+        // Get date range from loaded candles
+        var firstDate = typeof allCandles[0].time === 'string'
+            ? allCandles[0].time
+            : new Date(allCandles[0].time * 1000).toISOString().slice(0, 10);
+        var lastDate = typeof allCandles[allCandles.length - 1].time === 'string'
+            ? allCandles[allCandles.length - 1].time
+            : new Date(allCandles[allCandles.length - 1].time * 1000).toISOString().slice(0, 10);
+
+        // Build candle date index
+        var candleDates = {};
+        allCandles.forEach(function (c) {
+            var dk = typeof c.time === 'string' ? c.time : new Date(c.time * 1000).toISOString().slice(0, 10);
+            if (!candleDates[dk]) candleDates[dk] = c.time; // first candle on that date
+        });
+
+        // Fetch news for the chart's date range
+        fetch('/api/news/stock?symbol=' + symbol + '&limit=100&from=' + firstDate + '&to=' + lastDate)
             .then(function (r) { return r.json(); })
             .then(function (news) {
                 if (!news || news.length === 0) return;
-                var markers = [];
-                var candleDates = {};
-                allCandles.forEach(function (c) {
-                    var dateKey = typeof c.time === 'string' ? c.time : new Date(c.time * 1000).toISOString().slice(0, 10);
-                    candleDates[dateKey] = c.time;
+
+                // Count news per date for marker sizing
+                var dateCounts = {};
+                news.forEach(function (n) {
+                    var dk = (n.date || '').slice(0, 10);
+                    dateCounts[dk] = (dateCounts[dk] || 0) + 1;
                 });
 
-                news.forEach(function (n) {
-                    var dateKey = (n.date || '').slice(0, 10);
-                    if (candleDates[dateKey]) {
+                var markers = [];
+                var seen = {};
+                Object.keys(dateCounts).forEach(function (dk) {
+                    if (candleDates[dk] && !seen[dk]) {
+                        seen[dk] = true;
                         markers.push({
-                            time: candleDates[dateKey],
+                            time: candleDates[dk],
                             position: 'aboveBar',
                             color: '#ffcc00',
                             shape: 'circle',
-                            text: (n.title || '').substring(0, 30),
+                            text: dateCounts[dk] + ' article' + (dateCounts[dk] > 1 ? 's' : ''),
                         });
                     }
                 });
 
-                // Dedupe by time (one marker per candle)
-                var seen = {};
-                markers = markers.filter(function (m) {
-                    var key = JSON.stringify(m.time);
-                    if (seen[key]) return false;
-                    seen[key] = true;
-                    return true;
-                });
-
                 if (markers.length > 0) {
                     markers.sort(function (a, b) { return a.time < b.time ? -1 : 1; });
-                    if (newsMarkers) { chart.removeSeriesMarkers(newsMarkers); }
+                    if (newsMarkers) { try { chart.removeSeriesMarkers(newsMarkers); } catch (e) {} }
                     newsMarkers = chart.createSeriesMarkers(candleSeries, markers);
                 }
             })

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -1158,11 +1158,59 @@ body {
     background: var(--bg-tertiary);
 }
 
+.chart-toggle {
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    padding: 3px 6px;
+    cursor: pointer;
+}
+
+.chart-toggle:hover {
+    color: var(--text-primary);
+    border-color: var(--text-muted);
+}
+
+.chart-toggle.active {
+    color: var(--green);
+    border-color: var(--green);
+    background: rgba(0, 204, 102, 0.1);
+}
+
 .chart-container {
     width: 100%;
     height: calc(100vh - 140px);
     border-radius: 4px;
     overflow: hidden;
+    position: relative;
+}
+
+.chart-tooltip {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    background: rgba(10, 10, 10, 0.85);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 4px 8px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-primary);
+    z-index: 10;
+    pointer-events: none;
+}
+
+.chart-tooltip.hidden {
+    display: none;
+}
+
+.tt-sym {
+    color: var(--blue);
+    font-weight: 700;
+    margin-right: 6px;
 }
 
 /* ── Debug Panels ── */

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -1342,6 +1342,11 @@ body {
     background: var(--bg-tertiary);
 }
 
+.cnp-item-active {
+    background: var(--bg-tertiary);
+    border-left: 3px solid var(--orange);
+}
+
 .cnp-title {
     color: var(--text-primary);
     flex: 1;

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -1203,6 +1203,107 @@ body {
     pointer-events: none;
 }
 
+/* ── Chart News Panel ── */
+
+.chart-news-panel {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    margin-top: 8px;
+    max-height: 40vh;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+}
+
+.cnp-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--border);
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--text-secondary);
+    flex-shrink: 0;
+}
+
+.cnp-close {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 14px;
+}
+
+.cnp-list {
+    display: flex;
+    flex-direction: column;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+}
+
+.cnp-item {
+    display: flex;
+    justify-content: space-between;
+    padding: 6px 12px;
+    cursor: pointer;
+    border-bottom: 1px solid rgba(42, 42, 42, 0.3);
+    font-size: 12px;
+}
+
+.cnp-item:hover {
+    background: var(--bg-tertiary);
+}
+
+.cnp-title {
+    color: var(--text-primary);
+    flex: 1;
+}
+
+.cnp-meta {
+    color: var(--text-muted);
+    font-size: 10px;
+    margin-left: 12px;
+    flex-shrink: 0;
+}
+
+.cnp-reader {
+    padding: 12px 16px;
+    overflow-y: auto;
+    flex: 1;
+}
+
+.cnp-article-title {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin-bottom: 8px;
+    line-height: 1.4;
+}
+
+.cnp-article-meta {
+    font-size: 10px;
+    color: var(--text-muted);
+    margin-bottom: 12px;
+}
+
+.cnp-article-body {
+    font-size: 13px;
+    color: var(--text-secondary);
+    line-height: 1.7;
+}
+
+.cnp-article-body p {
+    margin-bottom: 10px;
+}
+
+.cnp-article-body h2, .cnp-article-body h3 {
+    color: var(--text-primary);
+    margin: 16px 0 8px;
+    font-size: 14px;
+}
+
 .chart-tooltip.hidden {
     display: none;
 }

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -237,6 +237,14 @@ body {
     border-color: var(--green);
 }
 
+/* ── Terminal Body (content + reader split) ── */
+
+.terminal-body {
+    flex: 1;
+    display: flex;
+    overflow: hidden;
+}
+
 /* ── Terminal Content ── */
 
 .terminal-content {
@@ -244,6 +252,84 @@ body {
     padding: 16px;
     overflow-y: auto;
     overflow-x: hidden;
+}
+
+/* ── Article Reader Panel ── */
+
+.article-reader {
+    width: 450px;
+    flex-shrink: 0;
+    background: var(--bg-secondary);
+    border-left: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.article-reader.hidden {
+    display: none;
+}
+
+.reader-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+}
+
+.reader-title {
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+}
+
+.reader-close {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 14px;
+    margin-left: 8px;
+    flex-shrink: 0;
+}
+
+.reader-close:hover {
+    color: var(--text-primary);
+}
+
+.reader-body {
+    flex: 1;
+    padding: 16px;
+    overflow-y: auto;
+    font-size: 13px;
+    color: var(--text-secondary);
+    line-height: 1.7;
+}
+
+.reader-body p {
+    margin-bottom: 12px;
+}
+
+.reader-body h1, .reader-body h2, .reader-body h3 {
+    color: var(--text-primary);
+    margin: 16px 0 8px;
+    font-size: 15px;
+}
+
+.reader-meta {
+    font-size: 10px;
+    color: var(--text-muted);
+    margin-bottom: 12px;
+}
+
+.reader-content {
+    font-size: 13px;
 }
 
 /* ── Terminal Footer ── */

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -925,6 +925,15 @@ window.onerror = function (msg, src, line, col, err) {
                         return;
                     }
 
+                    // Indicator toggles: :sma, :ema, :macd, :rsi, :sn
+                    var indicatorMap = { 'sma': 'sma', 'ema': 'ema', 'macd': 'macd', 'rsi': 'rsi', 'sn': 'news' };
+                    if (indicatorMap[colonLower] && window._stocktopusToggle) {
+                        window._stocktopusToggle(indicatorMap[colonLower]);
+                        input.value = '';
+                        enterNormalMode();
+                        return;
+                    }
+
                     // :watch or :watch SYMBOL — add to watchlist
                     if (colonLower === 'watch' || colonLower.startsWith('watch ')) {
                         var watchArg = colonCmd.substring(5).trim().toUpperCase();

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -717,7 +717,7 @@ window.onerror = function (msg, src, line, col, err) {
         var unreadClass = unread ? ' news-unread' : '';
 
         return '<div class="news-card' + unreadClass + '" data-url="' + escapeHtml(item.url) + '">'
-            + '<div class="news-card-title"><a href="' + escapeHtml(item.url) + '" target="_blank" rel="noopener">' + escapeHtml(item.title) + '</a></div>'
+            + '<div class="news-card-title"><a href="' + escapeHtml(item.url) + '" onclick="event.preventDefault();if(window._openReader)window._openReader(this.href,this.textContent)">' + escapeHtml(item.title) + '</a></div>'
             + '<div class="news-card-meta">'
             +   symbolBadge
             +   '<span>' + escapeHtml(item.source) + '</span>'
@@ -1267,7 +1267,9 @@ window.onerror = function (msg, src, line, col, err) {
                 var card = items[vimSelectedIndex];
                 markNewsRead(card);
                 var link = card.querySelector('.news-card-title a');
-                if (link) window.open(link.href, '_blank', 'noopener');
+                if (link && window._openReader) {
+                    window._openReader(link.href, link.textContent);
+                }
             }
         },
         info: {
@@ -1387,7 +1389,7 @@ window.onerror = function (msg, src, line, col, err) {
                     var cards = this.getNewsCards();
                     if (vimSelectedIndex >= 0 && vimSelectedIndex < cards.length) {
                         var link = cards[vimSelectedIndex].querySelector('.news-card-title a');
-                        if (link) window.open(link.href, '_blank', 'noopener');
+                        if (link && window._openReader) window._openReader(link.href, link.textContent);
                     }
                 }
             }
@@ -1429,7 +1431,12 @@ window.onerror = function (msg, src, line, col, err) {
                 }
                 enterNormalMode();
             } else {
-                // Normal mode: Escape focuses command bar (enter insert)
+                // Normal mode: close reader first, then focus command bar
+                var reader = document.getElementById('article-reader');
+                if (reader && !reader.classList.contains('hidden')) {
+                    reader.classList.add('hidden');
+                    return;
+                }
                 document.getElementById('cmd-input').focus();
             }
             return;
@@ -1502,6 +1509,47 @@ window.onerror = function (msg, src, line, col, err) {
                 return;
         }
     }, true); // capture phase — intercepts before Vimium and other extensions
+
+    // ── Shared Article Reader ──
+
+    window._openReader = function (url, title) {
+        var reader = document.getElementById('article-reader');
+        var readerBody = document.getElementById('reader-body');
+        var readerTitle = document.getElementById('reader-title');
+        if (!reader || !readerBody) return;
+
+        reader.classList.remove('hidden');
+        if (readerTitle) readerTitle.textContent = title || 'Loading...';
+        readerBody.innerHTML = '<p style="color:var(--text-muted)">Loading article...</p>';
+
+        fetch('/api/article?url=' + encodeURIComponent(url))
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (data.error) {
+                    readerBody.innerHTML = '<p style="color:var(--red)">' + escapeHtml(data.error) + '</p>'
+                        + '<a href="' + escapeHtml(url) + '" target="_blank" style="color:var(--blue)">Open in browser</a>';
+                    return;
+                }
+                if (readerTitle) readerTitle.textContent = data.title || title || '';
+                var html = '<div class="reader-meta">' + (data.wordCount || 0) + ' words</div>';
+                html += '<div class="reader-content">';
+                (data.paragraphs || []).forEach(function (p) {
+                    var tag = (p.tag === 'h1' || p.tag === 'h2' || p.tag === 'h3') ? p.tag : 'p';
+                    html += '<' + tag + '>' + escapeHtml(p.text) + '</' + tag + '>';
+                });
+                html += '</div>';
+                readerBody.innerHTML = html;
+            })
+            .catch(function () {
+                readerBody.innerHTML = '<p style="color:var(--red)">Failed to load</p>'
+                    + '<a href="' + escapeHtml(url) + '" target="_blank" style="color:var(--blue)">Open in browser</a>';
+            });
+    };
+
+    window._closeReader = function () {
+        var reader = document.getElementById('article-reader');
+        if (reader) reader.classList.add('hidden');
+    };
 
     // ── Browser History ──
 

--- a/internal/server/templates/layout.html
+++ b/internal/server/templates/layout.html
@@ -21,9 +21,18 @@
         <span id="watchlist-picker" class="watchlist-picker" title="Active watchlist">Default</span>
         <div id="conn-status" class="conn-status">DISCONNECTED</div>
     </header>
-    <main id="view-container" class="terminal-content" data-view="{{.Active}}">
-        {{template "content" .}}
-    </main>
+    <div class="terminal-body">
+        <main id="view-container" class="terminal-content" data-view="{{.Active}}">
+            {{template "content" .}}
+        </main>
+        <aside id="article-reader" class="article-reader hidden">
+            <div class="reader-header">
+                <span id="reader-title" class="reader-title">Article</span>
+                <button class="reader-close" onclick="window._closeReader()">&#10005;</button>
+            </div>
+            <div id="reader-body" class="reader-body"></div>
+        </aside>
+    </div>
     <footer class="terminal-footer">
         <span id="vim-mode" class="footer-mode">NORMAL</span>
         <span id="current-view" class="footer-view">{{.Active}}</span>

--- a/internal/server/templates/stock.html
+++ b/internal/server/templates/stock.html
@@ -16,9 +16,16 @@
         <button class="chart-range-btn chart-eod-btn" data-range="1M">1M</button>
         <button class="chart-range-btn chart-eod-btn" data-range="3M">3M</button>
         <button class="chart-range-btn chart-eod-btn" data-range="6M">6M</button>
+        <span class="chart-range-sep">|</span>
+        <button class="chart-toggle" id="toggle-sma" data-indicator="sma" title=":sma">SMA</button>
+        <button class="chart-toggle" id="toggle-ema" data-indicator="ema" title=":ema">EMA</button>
+        <button class="chart-toggle" id="toggle-macd" data-indicator="macd" title=":macd">MACD</button>
+        <button class="chart-toggle" id="toggle-rsi" data-indicator="rsi" title=":rsi">RSI</button>
+        <button class="chart-toggle" id="toggle-news" data-indicator="news" title=":sn">N</button>
     </div>
 </div>
 <div id="chart-container" class="chart-container" data-symbol="{{.Symbol}}"></div>
+<div id="chart-tooltip" class="chart-tooltip hidden"></div>
 <script src="/static/lightweight-charts.js"></script>
 <script src="/static/chart.js"></script>
 {{end}}

--- a/internal/server/templates/stock.html
+++ b/internal/server/templates/stock.html
@@ -21,7 +21,7 @@
         <button class="chart-toggle" id="toggle-ema" data-indicator="ema" title=":ema">EMA</button>
         <button class="chart-toggle" id="toggle-macd" data-indicator="macd" title=":macd">MACD</button>
         <button class="chart-toggle" id="toggle-rsi" data-indicator="rsi" title=":rsi">RSI</button>
-        <button class="chart-toggle" id="toggle-news" data-indicator="news" title=":sn">N</button>
+        <button class="chart-toggle" id="toggle-news" data-indicator="news" title=":sn">News</button>
     </div>
 </div>
 <div id="chart-container" class="chart-container" data-symbol="{{.Symbol}}"></div>


### PR DESCRIPTION
## Summary

- **SMA overlays** (20/50/200-day) — yellow, pink, purple lines on price chart
- **EMA overlays** (20/50-day) — cyan, blue lines
- **MACD** — histogram + MACD line + signal line in separate price pane
- **RSI** (14-period) — with 70/30 overbought/oversold reference lines
- **News markers** — yellow circles on candles where news events occurred, showing headline text
- **Crosshair tooltip** — OHLCV data overlay as you hover over the chart

## Toggles
All indicators toggleable via:
- UI buttons in the range bar (SMA, EMA, MACD, RSI, N)
- Command bar: `:sma`, `:ema`, `:macd`, `:rsi`, `:sn`
- State persisted in localStorage

## Technical details
- All indicators calculated client-side from loaded OHLCV data
- Recalculate on every data load (initial, lazy scroll, auto-refresh)
- MACD and RSI use separate price scales so they don't distort the main chart

## Test plan
- [ ] `make smoke` — all 17 tests pass
- [ ] `graph AAPL` → click SMA → 20/50/200 day lines appear
- [ ] `:macd` in command bar → MACD histogram appears below candles
- [ ] `:rsi` → RSI line with 70/30 bands
- [ ] `:sn` → yellow news markers on relevant candles
- [ ] Hover chart → tooltip shows O/H/L/C values
- [ ] Toggle states persist across page navigations