### PR TITLE
fix: article text spacing, reader entity updates, background context

### DIFF
--- a/agents/fetch_article.py
+++ b/agents/fetch_article.py
@@ -171,10 +171,12 @@ def extract_content(html):
             if title:
                 break
 
-    # Paragraphs
+    # Paragraphs — use separator=' ' to add spaces between inline elements
     paragraphs = []
     for p in article.find_all(["p", "h1", "h2", "h3", "h4", "h5", "blockquote", "li"]):
-        text = p.get_text(strip=True)
+        text = p.get_text(separator=' ')
+        # Clean up: collapse multiple spaces, strip edges
+        text = re.sub(r'\s+', ' ', text).strip()
         if len(text) > 15:
             paragraphs.append({"tag": p.name, "text": text})
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -783,7 +783,8 @@ func (s *Server) handleArticleEntities(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) runArticleScript(w http.ResponseWriter, r *http.Request, pythonCmd, articleURL string, onSuccess func([]byte), extraArgs ...string) {
 	args := append([]string{"agents/fetch_article.py", articleURL}, extraArgs...)
-	ctx, cancel := context.WithTimeout(r.Context(), 90*time.Second)
+	// Use background context — don't kill the script if client disconnects
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, pythonCmd, args...)

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -424,7 +424,7 @@
                         var text = item.text || '';
                         if (text.length > 200) text = text.substring(0, 200) + '...';
                         return '<div class="news-card news-unread">'
-                            + '<div class="news-card-title"><a href="' + esc(item.url) + '" target="_blank" rel="noopener">' + esc(item.title) + '</a></div>'
+                            + '<div class="news-card-title"><a href="' + esc(item.url) + '" onclick="event.preventDefault();if(window._openReader)window._openReader(this.href,this.textContent)">' + esc(item.title) + '</a></div>'
                             + '<div class="news-card-meta"><span>' + esc(item.source) + '</span><span>' + date + '</span></div>'
                             + '<div class="news-card-text">' + esc(text) + '</div>'
                             + '</div>';

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -394,6 +394,15 @@ body {
     white-space: nowrap;
 }
 
+.reader-llm-status {
+    font-size: 11px;
+    color: var(--text-muted);
+    padding: 4px 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
 .reader-content {
     font-size: 13px;
 }

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -1615,7 +1615,8 @@ window.onerror = function (msg, src, line, col, err) {
                 });
                 html += '</div>';
 
-                // Entity badges — populated async
+                // LLM status + entity badges — populated async
+                html += '<div class="reader-llm-status" id="reader-llm-status"><span class="spinner"></span> Analyzing with LLM...</div>';
                 html += '<div class="reader-entities" id="reader-entities"></div>';
 
                 // Related section
@@ -1730,14 +1731,37 @@ window.onerror = function (msg, src, line, col, err) {
             .then(function (r) { return r.json(); })
             .then(function (data) {
                 if (thisFetch.abort) return;
-                // Re-query DOM — original reference may be stale after 30s
+
+                var statusEl = document.getElementById('reader-llm-status');
                 var el = document.getElementById('reader-entities');
-                if (!el) return;
+
+                // Check if still pending (server returned "pending" status)
+                if (data.status === 'pending') {
+                    if (statusEl) statusEl.innerHTML = '<span class="spinner"></span> Waiting for LLM (another request in progress)...';
+                    // Retry in 5s
+                    setTimeout(function () {
+                        if (!thisFetch.abort) fetchArticleEntities(url);
+                    }, 5000);
+                    return;
+                }
+
                 var hasEntities = (data.tickers && data.tickers.length > 0) ||
                     (data.companies && data.companies.length > 0) ||
                     (data.people && data.people.length > 0);
 
-                if (!hasEntities) return;
+                if (statusEl) {
+                    if (hasEntities) {
+                        var count = (data.tickers || []).length + (data.companies || []).length +
+                            (data.people || []).length + (data.sectors || []).length;
+                        statusEl.innerHTML = '<span style="color:var(--green)">&#10003;</span> LLM found ' + count + ' entities';
+                        setTimeout(function () { if (statusEl) statusEl.style.display = 'none'; }, 3000);
+                    } else {
+                        statusEl.innerHTML = '<span style="color:var(--text-muted)">&#10003;</span> LLM analysis complete (no entities found)';
+                        setTimeout(function () { if (statusEl) statusEl.style.display = 'none'; }, 3000);
+                    }
+                }
+
+                if (!hasEntities || !el) return;
 
                 var html = '';
                 (data.tickers || []).forEach(function (t) {
@@ -1754,7 +1778,13 @@ window.onerror = function (msg, src, line, col, err) {
                 });
                 el.innerHTML = html;
             })
-            .catch(function () { /* LLM entities are optional */ });
+            .catch(function () {
+                var statusEl = document.getElementById('reader-llm-status');
+                if (statusEl) {
+                    statusEl.innerHTML = '<span style="color:var(--text-muted)">LLM unavailable</span>';
+                    setTimeout(function () { if (statusEl) statusEl.style.display = 'none'; }, 3000);
+                }
+            });
     }
 
     window._closeReader = function () {

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -1707,17 +1707,11 @@ window.onerror = function (msg, src, line, col, err) {
         });
     }
 
-    var activeEntityFetch = null; // prevent duplicate entity requests
+    var activeEntityURL = ''; // track which URL is being fetched
 
     function fetchArticleEntities(url) {
-        // Cancel any previous entity fetch
-        if (activeEntityFetch) {
-            activeEntityFetch.abort = true;
-        }
-        var thisFetch = { abort: false };
-        activeEntityFetch = thisFetch;
+        activeEntityURL = url;
 
-        var entitiesEl = document.getElementById('reader-entities');
         var relatedEl = document.getElementById('reader-related');
 
         // First: quick client-side FMP search from title
@@ -1730,17 +1724,16 @@ window.onerror = function (msg, src, line, col, err) {
         fetch('/api/article/entities?url=' + encodeURIComponent(url))
             .then(function (r) { return r.json(); })
             .then(function (data) {
-                if (thisFetch.abort) return;
+                // Ignore if user opened a different article
+                if (activeEntityURL !== url) return;
 
                 var statusEl = document.getElementById('reader-llm-status');
                 var el = document.getElementById('reader-entities');
 
-                // Check if still pending (server returned "pending" status)
                 if (data.status === 'pending') {
                     if (statusEl) statusEl.innerHTML = '<span class="spinner"></span> Waiting for LLM (another request in progress)...';
-                    // Retry in 5s
                     setTimeout(function () {
-                        if (!thisFetch.abort) fetchArticleEntities(url);
+                        if (activeEntityURL === url) fetchArticleEntities(url);
                     }, 5000);
                     return;
                 }
@@ -1748,6 +1741,8 @@ window.onerror = function (msg, src, line, col, err) {
                 var hasEntities = (data.tickers && data.tickers.length > 0) ||
                     (data.companies && data.companies.length > 0) ||
                     (data.people && data.people.length > 0);
+
+                console.log('LLM entities received:', data.tickers, data.companies, data.people, 'statusEl:', !!statusEl, 'entitiesEl:', !!el);
 
                 if (statusEl) {
                     if (hasEntities) {

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -1721,8 +1721,16 @@ window.onerror = function (msg, src, line, col, err) {
         }
 
         // Then: async LLM entity extraction (can take 30-60s)
-        fetch('/api/article/entities?url=' + encodeURIComponent(url))
-            .then(function (r) { return r.json(); })
+        var entityController = new AbortController();
+        setTimeout(function () { entityController.abort(); }, 120000); // 2 min timeout
+        fetch('/api/article/entities?url=' + encodeURIComponent(url), { signal: entityController.signal })
+            .then(function (r) {
+                if (!r.ok) {
+                    console.error('Entity fetch HTTP error:', r.status);
+                    throw new Error('HTTP ' + r.status);
+                }
+                return r.json();
+            })
             .then(function (data) {
                 // Ignore if user opened a different article
                 if (activeEntityURL !== url) return;
@@ -1773,11 +1781,12 @@ window.onerror = function (msg, src, line, col, err) {
                 });
                 el.innerHTML = html;
             })
-            .catch(function () {
+            .catch(function (err) {
+                console.error('Entity fetch error:', err);
                 var statusEl = document.getElementById('reader-llm-status');
                 if (statusEl) {
-                    statusEl.innerHTML = '<span style="color:var(--text-muted)">LLM unavailable</span>';
-                    setTimeout(function () { if (statusEl) statusEl.style.display = 'none'; }, 3000);
+                    statusEl.innerHTML = '<span style="color:var(--text-muted)">LLM unavailable: ' + (err.message || err) + '</span>';
+                    setTimeout(function () { if (statusEl) statusEl.style.display = 'none'; }, 5000);
                 }
             });
     }

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -1729,7 +1729,10 @@ window.onerror = function (msg, src, line, col, err) {
         fetch('/api/article/entities?url=' + encodeURIComponent(url))
             .then(function (r) { return r.json(); })
             .then(function (data) {
-                if (thisFetch.abort || !entitiesEl) return;
+                if (thisFetch.abort) return;
+                // Re-query DOM — original reference may be stale after 30s
+                var el = document.getElementById('reader-entities');
+                if (!el) return;
                 var hasEntities = (data.tickers && data.tickers.length > 0) ||
                     (data.companies && data.companies.length > 0) ||
                     (data.people && data.people.length > 0);
@@ -1749,7 +1752,7 @@ window.onerror = function (msg, src, line, col, err) {
                 (data.sectors || []).forEach(function (s) {
                     html += '<span class="reader-sector-badge">' + escapeHtml(s) + '</span>';
                 });
-                entitiesEl.innerHTML = html;
+                el.innerHTML = html;
             })
             .catch(function () { /* LLM entities are optional */ });
     }


### PR DESCRIPTION
## Summary

- **Article text spacing** — fix missing spaces between inline HTML elements (`<a>`, `<strong>`, `<b>`). Uses `get_text(separator=' ')` instead of `get_text(strip=True)`.
- **Info page news tab** — now opens articles in the reader panel (was opening new browser tabs)
- **LLM entity updates** — entities now populate live when they arrive. Fixed stale DOM reference and simplified abort logic.
- **LLM status indicator** — spinner + "Analyzing with LLM..." while processing, "✓ LLM found N entities" when complete
- **Background context** — article script uses `context.Background()` so the Python subprocess runs to completion even if the browser disconnects. Previously `r.Context()` was killing the script when the HTTP connection closed, causing "LLM unavailable" despite successful extraction.
- **Error logging** — entity fetch logs HTTP status and error details to browser console

## The background context bug
The entity extraction takes ~30s (Ollama NER). The browser's fetch kept the HTTP connection open, but if anything interrupted it (scroll, navigate, timeout), `r.Context()` cancelled, killing the Python subprocess mid-execution. The server logged success from stderr (buffered before kill) but stdout was lost. Fix: `context.Background()` with 90s timeout.

## Test plan
- [ ] `make smoke` — all 19 tests pass
- [ ] Open article → text appears instantly → "Analyzing with LLM..." spinner → entity badges appear after ~30s
- [ ] Article text has proper spacing between inline elements
- [ ] Same article second time → entities load from cache instantly