### PR TITLE
feat: equity indices page, /graph/ route, chart watermark

### DIFF
--- a/internal/news/news.go
+++ b/internal/news/news.go
@@ -377,6 +377,11 @@ func (c *Client) GetSICList(ctx context.Context) (json.RawMessage, error) {
 	return c.fetchJSON(ctx, "/stable/standard-industrial-classification-list", nil)
 }
 
+// GetIndexList fetches the list of all equity indices.
+func (c *Client) GetIndexList(ctx context.Context) (json.RawMessage, error) {
+	return c.fetchJSON(ctx, "/stable/index-list", nil)
+}
+
 // GetPeers returns sector peers for a symbol.
 func (c *Client) GetPeers(ctx context.Context, symbol string) (json.RawMessage, error) {
 	params := url.Values{"symbol": {symbol}}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -499,7 +499,7 @@ func (s *Server) handleCompetitors(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleIndicesPage(w http.ResponseWriter, r *http.Request) {
 	s.renderPage(w, r, "indices.html", map[string]any{
 		"Title":  "Equity Indices",
-		"Active": "indices",
+		"Active": "ei",
 	})
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -106,7 +106,7 @@ func (s *Server) loadTemplates() error {
 	layoutPath := filepath.Join(templatesDir(), "layout.html")
 	s.pages = make(map[string]*template.Template)
 
-	pageNames := []string{"watchlist", "stock", "security", "screener", "feed", "debug", "news"}
+	pageNames := []string{"watchlist", "stock", "security", "screener", "feed", "debug", "news", "indices"}
 	for _, page := range pageNames {
 		pagePath := filepath.Join(templatesDir(), page+".html")
 		t, err := template.ParseFiles(layoutPath, pagePath)
@@ -147,6 +147,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/security/{symbol}/intelligence/refresh", s.handleIntelligenceRefresh)
 	mux.HandleFunc("GET /api/agent/status", s.handleAgentStatus)
 	mux.HandleFunc("GET /api/sic", s.handleSICCodes)
+	mux.HandleFunc("GET /api/indices", s.handleIndices)
 	mux.HandleFunc("GET /api/watchlists", s.handleGetWatchlists)
 	mux.HandleFunc("POST /api/watchlists", s.handleCreateWatchlist)
 	mux.HandleFunc("POST /api/watchlists/{id}/symbols", s.handleAddToWatchlist)
@@ -166,6 +167,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /screener", s.handleScreener)
 	mux.HandleFunc("GET /feed", s.handleFeed)
 	mux.HandleFunc("GET /news", s.handleNews)
+	mux.HandleFunc("GET /indices", s.handleIndicesPage)
 	mux.HandleFunc("GET /debug", s.handleDebug)
 }
 
@@ -492,6 +494,24 @@ func (s *Server) handleCompetitors(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(results)
+}
+
+func (s *Server) handleIndicesPage(w http.ResponseWriter, r *http.Request) {
+	s.renderPage(w, r, "indices.html", map[string]any{
+		"Title":  "Equity Indices",
+		"Active": "indices",
+	})
+}
+
+func (s *Server) handleIndices(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	data, err := s.news.GetIndexList(r.Context())
+	if err != nil {
+		s.logger.Error("index list failed", "error", err)
+		json.NewEncoder(w).Encode([]any{})
+		return
+	}
+	w.Write(data)
 }
 
 func (s *Server) handleSICCodes(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -162,7 +162,8 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	// Pages
 	mux.HandleFunc("GET /{$}", s.handleIndex)
 	mux.HandleFunc("GET /watchlist", s.handleWatchlist)
-	mux.HandleFunc("GET /stock/{symbol}", s.handleStock)
+	mux.HandleFunc("GET /graph/{symbol}", s.handleStock)
+	mux.HandleFunc("GET /stock/{symbol}", s.handleStock) // legacy redirect
 	mux.HandleFunc("GET /security/{symbol}", s.handleSecurity)
 	mux.HandleFunc("GET /screener", s.handleScreener)
 	mux.HandleFunc("GET /feed", s.handleFeed)

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -518,6 +518,13 @@
     function resizeChart() { chart.resize(container.clientWidth, container.clientHeight); }
     window.addEventListener('resize', resizeChart); resizeChart();
 
+    // ── Watermark ──
+    try {
+        LightweightCharts.createTextWatermark(chart, {
+            lines: [{ text: symbol, color: 'rgba(255, 255, 255, 0.04)', fontSize: 80, fontFamily: "'SF Mono','Consolas',monospace", fontStyle: 'bold' }],
+        });
+    } catch (e) { /* watermark optional */ }
+
     // ── Init ──
     updateToggleButtons();
     setActiveRangeBtn(defaultRange);

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -14,7 +14,7 @@
     var toggleState = JSON.parse(localStorage.getItem('stocktopus-chart-toggles') || '{}');
 
     var EOD_RANGES = {
-        '1W': { fetch: 30, view: 7 }, '1M': { fetch: 90, view: 30 },
+        '1W': { fetch: 60, view: 30 }, '1M': { fetch: 90, view: 30 },
         '3M': { fetch: 180, view: 90 }, '6M': { fetch: 365, view: 180 },
     };
     var INTRADAY_RANGES = {

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -3,10 +3,18 @@
 (function () {
     'use strict';
 
+    function waitForChartLib(cb) {
+        if (window.LightweightCharts) { cb(); }
+        else { setTimeout(function () { waitForChartLib(cb); }, 100); }
+    }
+
     var container = document.getElementById('chart-container');
     if (!container) return;
     var symbol = container.dataset.symbol;
     if (!symbol) return;
+
+    waitForChartLib(initChart);
+    function initChart() {
 
     // ── Persisted State ──
     var RANGE_KEY = 'stocktopus-chart-range';
@@ -518,4 +526,5 @@
     updateAutoRefreshVisibility();
     if (isIntraday) { chart.timeScale().applyOptions({ timeVisible: true }); loadIntraday(defaultRange); if (autoRefresh) scheduleAutoRefresh(); }
     else { loadEOD(defaultRange); }
+    } // end initChart
 })();

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -520,10 +520,12 @@
 
     // ── Watermark ──
     try {
-        LightweightCharts.createTextWatermark(chart, {
-            lines: [{ text: symbol, color: 'rgba(255, 255, 255, 0.04)', fontSize: 80, fontFamily: "'SF Mono','Consolas',monospace", fontStyle: 'bold' }],
+        var panes = chart.panes();
+        var mainPane = panes && panes[0] ? panes[0] : chart;
+        LightweightCharts.createTextWatermark(mainPane, {
+            lines: [{ text: symbol, color: 'rgba(255, 255, 255, 0.07)', fontSize: 72, fontFamily: "'SF Mono','Consolas',monospace", fontStyle: 'bold' }],
         });
-    } catch (e) { /* watermark optional */ }
+    } catch (e) { console.log('watermark:', e.message); }
 
     // ── Init ──
     updateToggleButtons();

--- a/internal/server/static/indices.js
+++ b/internal/server/static/indices.js
@@ -103,11 +103,19 @@
         });
 
     function fetchIndexQuote(symbol) {
-        fetch('/api/security/' + encodeURIComponent(symbol) + '/profile')
+        // Use chart EOD for latest price — profile doesn't support indices
+        fetch('/api/chart/eod/' + encodeURIComponent(symbol) + '?from=' + new Date(Date.now() - 7*86400000).toISOString().slice(0,10) + '&to=' + new Date().toISOString().slice(0,10))
             .then(function (r) { return r.json(); })
             .then(function (data) {
-                if (!data || !data[0]) return;
-                var q = data[0];
+                if (!data || data.length < 1) return;
+                // Latest day's data
+                var latest = data[data.length - 1];
+                var prev = data.length > 1 ? data[data.length - 2] : latest;
+                var q = {
+                    price: latest.close,
+                    change: latest.close - prev.close,
+                    changePercentage: ((latest.close - prev.close) / prev.close) * 100,
+                };
                 var chgClass = q.change >= 0 ? 'price-up' : 'price-down';
                 var priceEl = document.getElementById('price-' + symbol);
                 var changeEl = document.getElementById('change-' + symbol);

--- a/internal/server/static/indices.js
+++ b/internal/server/static/indices.js
@@ -1,0 +1,171 @@
+// Stocktopus Equity Indices page
+
+(function () {
+    'use strict';
+
+    var container = document.getElementById('indices-container');
+    if (!container) return;
+
+    // Major indices to show by default (most important first)
+    var MAJOR_INDICES = [
+        '^GSPC', '^DJI', '^IXIC', '^VIX', '^RUT',           // US
+        '^FTSE', '^GDAXI', '^FCHI', '^STOXX50E',             // Europe
+        '^N225', '^HSI', '^AXJO', '^KS11', '^TWII', '^STI',  // Asia-Pacific
+        '^GSPTSE', '^BVSP', '^MXX',                           // Americas
+    ];
+
+    // Exchange → timezone mapping for local time
+    var EXCHANGE_TZ = {
+        'SNP': 'America/New_York', 'DJI': 'America/New_York', 'NASDAQ': 'America/New_York',
+        'NYQ': 'America/New_York', 'CBOE': 'America/Chicago',
+        'LSE': 'Europe/London', 'XETRA': 'Europe/Berlin', 'PAR': 'Europe/Paris',
+        'STO': 'Europe/Stockholm', 'AMS': 'Europe/Amsterdam',
+        'JPX': 'Asia/Tokyo', 'HKSE': 'Asia/Hong_Kong', 'KSC': 'Asia/Seoul',
+        'TAI': 'Asia/Taipei', 'ASX': 'Australia/Sydney', 'SGX': 'Asia/Singapore',
+        'TSX': 'America/Toronto', 'SAO': 'America/Sao_Paulo', 'MEX': 'America/Mexico_City',
+    };
+
+    // Market hours (approximate, local time)
+    var MARKET_HOURS = { open: 9, close: 16 };
+
+    function getLocalTime(exchange) {
+        var tz = EXCHANGE_TZ[exchange] || 'America/New_York';
+        try {
+            var now = new Date();
+            var timeStr = now.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', timeZone: tz, hour12: false });
+            var hour = parseInt(now.toLocaleString('en-GB', { hour: '2-digit', hour12: false, timeZone: tz }));
+            var day = now.toLocaleDateString('en-US', { weekday: 'short', timeZone: tz });
+            var isWeekend = day === 'Sat' || day === 'Sun';
+            var isOpen = !isWeekend && hour >= MARKET_HOURS.open && hour < MARKET_HOURS.close;
+            return { time: timeStr, open: isOpen };
+        } catch (e) {
+            return { time: '--:--', open: false };
+        }
+    }
+
+    function fmt(n) {
+        if (n == null || isNaN(n)) return '—';
+        if (Math.abs(n) >= 1e12) return (n / 1e12).toFixed(1) + 'T';
+        if (Math.abs(n) >= 1e9) return (n / 1e9).toFixed(1) + 'B';
+        if (Math.abs(n) >= 1e6) return (n / 1e6).toFixed(1) + 'M';
+        return n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+    }
+
+    function esc(s) { return (s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;'); }
+
+    // Load indices
+    fetch('/api/indices')
+        .then(function (r) { return r.json(); })
+        .then(function (allIndices) {
+            if (!allIndices || allIndices.length === 0) {
+                container.innerHTML = '<p class="empty-state">No indices available</p>';
+                return;
+            }
+
+            // Build lookup
+            var indexMap = {};
+            allIndices.forEach(function (idx) { indexMap[idx.symbol] = idx; });
+
+            // Filter to major indices that exist in the list
+            var indices = MAJOR_INDICES.filter(function (s) { return indexMap[s]; }).map(function (s) { return indexMap[s]; });
+
+            // Render table shell
+            var html = '<table class="fin-table indices-table" id="indices-table"><thead><tr>';
+            html += '<th>Index</th><th>2D</th><th>Price</th><th>Change</th><th>% Change</th><th>Local Time</th>';
+            html += '</tr></thead><tbody>';
+            indices.forEach(function (idx) {
+                var local = getLocalTime(idx.exchange);
+                var statusClass = local.open ? 'idx-open' : 'idx-closed';
+                var statusLabel = local.open ? 'O' : 'C';
+                html += '<tr class="idx-row" data-symbol="' + esc(idx.symbol) + '" data-exchange="' + esc(idx.exchange) + '">'
+                    + '<td class="idx-name"><span class="idx-sym">' + esc(idx.symbol) + '</span> <span class="idx-label">' + esc(idx.name) + '</span></td>'
+                    + '<td><div class="idx-spark" data-spark-sym="' + esc(idx.symbol) + '"></div></td>'
+                    + '<td class="idx-price" id="price-' + esc(idx.symbol) + '">—</td>'
+                    + '<td class="idx-change" id="change-' + esc(idx.symbol) + '">—</td>'
+                    + '<td class="idx-pct" id="pct-' + esc(idx.symbol) + '">—</td>'
+                    + '<td class="idx-time"><span class="' + statusClass + '">' + statusLabel + '</span> ' + local.time + '</td>'
+                    + '</tr>';
+            });
+            html += '</tbody></table>';
+            container.innerHTML = html;
+
+            // Fetch quotes for each index
+            indices.forEach(function (idx) { fetchIndexQuote(idx.symbol); });
+
+            // Load sparklines
+            loadIndexSparklines(indices);
+
+            // Update local times every minute
+            setInterval(function () { updateLocalTimes(indices); }, 60000);
+        })
+        .catch(function (err) {
+            container.innerHTML = '<p class="empty-state">Failed to load indices</p>';
+        });
+
+    function fetchIndexQuote(symbol) {
+        fetch('/api/security/' + encodeURIComponent(symbol) + '/profile')
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (!data || !data[0]) return;
+                var q = data[0];
+                var chgClass = q.change >= 0 ? 'price-up' : 'price-down';
+                var priceEl = document.getElementById('price-' + symbol);
+                var changeEl = document.getElementById('change-' + symbol);
+                var pctEl = document.getElementById('pct-' + symbol);
+                if (priceEl) priceEl.textContent = fmt(q.price);
+                if (priceEl) priceEl.className = 'idx-price ' + chgClass;
+                if (changeEl) { changeEl.textContent = (q.change >= 0 ? '+' : '') + q.change.toFixed(2); changeEl.className = 'idx-change ' + chgClass; }
+                if (pctEl) { pctEl.textContent = (q.changePercentage >= 0 ? '+' : '') + q.changePercentage.toFixed(2) + '%'; pctEl.className = 'idx-pct ' + chgClass; }
+            })
+            .catch(function () {});
+    }
+
+    function loadIndexSparklines(indices) {
+        function tryRender() {
+            if (!window.LightweightCharts) { setTimeout(tryRender, 200); return; }
+            var from = new Date(); from.setDate(from.getDate() - 2);
+            var fromStr = from.toISOString().slice(0, 10);
+            var toStr = new Date().toISOString().slice(0, 10);
+
+            document.querySelectorAll('.idx-spark').forEach(function (el) {
+                var sym = el.dataset.sparkSym;
+                if (!sym) return;
+                fetch('/api/chart/eod/' + encodeURIComponent(sym) + '?from=' + fromStr + '&to=' + toStr)
+                    .then(function (r) { return r.json(); })
+                    .then(function (data) {
+                        if (!data || data.length < 2) return;
+                        var first = data[0].close, last = data[data.length - 1].close;
+                        var color = last >= first ? '#00cc66' : '#ff4444';
+                        var chart = LightweightCharts.createChart(el, {
+                            width: 80, height: 24,
+                            layout: { background: { color: 'transparent' }, textColor: 'transparent' },
+                            grid: { vertLines: { visible: false }, horzLines: { visible: false } },
+                            rightPriceScale: { visible: false }, timeScale: { visible: false },
+                            handleScroll: false, handleScale: false,
+                            crosshair: { vertLine: { visible: false }, horzLine: { visible: false } },
+                        });
+                        var series = chart.addSeries(LightweightCharts.AreaSeries, {
+                            lineColor: color, topColor: color.replace(')', ',0.15)').replace('rgb', 'rgba'),
+                            bottomColor: 'transparent', lineWidth: 1,
+                            priceLineVisible: false, lastValueVisible: false,
+                        });
+                        series.setData(data.map(function (d) { return { time: d.date, value: d.close }; }));
+                        chart.timeScale().fitContent();
+                    }).catch(function () {});
+            });
+        }
+        tryRender();
+    }
+
+    function updateLocalTimes(indices) {
+        indices.forEach(function (idx) {
+            var row = document.querySelector('[data-symbol="' + idx.symbol + '"] .idx-time');
+            if (row) {
+                var local = getLocalTime(idx.exchange);
+                var statusClass = local.open ? 'idx-open' : 'idx-closed';
+                var statusLabel = local.open ? 'O' : 'C';
+                row.innerHTML = '<span class="' + statusClass + '">' + statusLabel + '</span> ' + local.time;
+            }
+        });
+    }
+})();

--- a/internal/server/static/indices.js
+++ b/internal/server/static/indices.js
@@ -7,11 +7,11 @@
     if (!container) return;
 
     // Major indices to show by default (most important first)
+    // Only indices available on our FMP plan (non-premium)
     var MAJOR_INDICES = [
         '^GSPC', '^DJI', '^IXIC', '^VIX', '^RUT',           // US
-        '^FTSE', '^GDAXI', '^FCHI', '^STOXX50E',             // Europe
-        '^N225', '^HSI', '^AXJO', '^KS11', '^TWII', '^STI',  // Asia-Pacific
-        '^GSPTSE', '^BVSP', '^MXX',                           // Americas
+        '^FTSE', '^STOXX50E',                                 // Europe
+        '^N225', '^HSI',                                       // Asia-Pacific
     ];
 
     // Exchange → timezone mapping for local time

--- a/internal/server/static/indices.js
+++ b/internal/server/static/indices.js
@@ -77,12 +77,13 @@
                 var local = getLocalTime(idx.exchange);
                 var statusClass = local.open ? 'idx-open' : 'idx-closed';
                 var statusLabel = local.open ? 'O' : 'C';
+                var safeId = idx.symbol.replace('^', '');
                 html += '<tr class="idx-row" data-symbol="' + esc(idx.symbol) + '" data-exchange="' + esc(idx.exchange) + '">'
                     + '<td class="idx-name"><span class="idx-sym">' + esc(idx.symbol) + '</span> <span class="idx-label">' + esc(idx.name) + '</span></td>'
                     + '<td><div class="idx-spark" data-spark-sym="' + esc(idx.symbol) + '"></div></td>'
-                    + '<td class="idx-price" id="price-' + esc(idx.symbol) + '">—</td>'
-                    + '<td class="idx-change" id="change-' + esc(idx.symbol) + '">—</td>'
-                    + '<td class="idx-pct" id="pct-' + esc(idx.symbol) + '">—</td>'
+                    + '<td class="idx-price" id="price-' + safeId + '">—</td>'
+                    + '<td class="idx-change" id="change-' + safeId + '">—</td>'
+                    + '<td class="idx-pct" id="pct-' + safeId + '">—</td>'
                     + '<td class="idx-time"><span class="' + statusClass + '">' + statusLabel + '</span> ' + local.time + '</td>'
                     + '</tr>';
             });
@@ -117,9 +118,10 @@
                     changePercentage: ((latest.close - prev.close) / prev.close) * 100,
                 };
                 var chgClass = q.change >= 0 ? 'price-up' : 'price-down';
-                var priceEl = document.getElementById('price-' + symbol);
-                var changeEl = document.getElementById('change-' + symbol);
-                var pctEl = document.getElementById('pct-' + symbol);
+                var safeId = symbol.replace('^', '');
+                var priceEl = document.getElementById('price-' + safeId);
+                var changeEl = document.getElementById('change-' + safeId);
+                var pctEl = document.getElementById('pct-' + safeId);
                 if (priceEl) priceEl.textContent = fmt(q.price);
                 if (priceEl) priceEl.className = 'idx-price ' + chgClass;
                 if (changeEl) { changeEl.textContent = (q.change >= 0 ? '+' : '') + q.change.toFixed(2); changeEl.className = 'idx-change ' + chgClass; }
@@ -131,7 +133,7 @@
     function loadIndexSparklines(indices) {
         function tryRender() {
             if (!window.LightweightCharts) { setTimeout(tryRender, 200); return; }
-            var from = new Date(); from.setDate(from.getDate() - 2);
+            var from = new Date(); from.setDate(from.getDate() - 5);
             var fromStr = from.toISOString().slice(0, 10);
             var toStr = new Date().toISOString().slice(0, 10);
 

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -1916,6 +1916,12 @@ body {
     height: 24px;
 }
 
+.idx-spark-selected {
+    outline: 1px solid var(--orange);
+    outline-offset: 1px;
+    border-radius: 3px;
+}
+
 .idx-spark a[href*="tradingview"] {
     display: none !important;
 }

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -1900,6 +1900,15 @@ body {
 
 .idx-name {
     min-width: 200px;
+    text-align: left !important;
+}
+
+.indices-table td {
+    text-align: left;
+}
+
+.indices-table th {
+    text-align: left !important;
 }
 
 .idx-spark {

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -1873,6 +1873,71 @@ body {
     outline-offset: -1px;
 }
 
+/* ── Equity Indices ── */
+
+.indices-table {
+    width: 100%;
+}
+
+.idx-row {
+    cursor: pointer;
+}
+
+.idx-row:hover {
+    background: var(--bg-secondary);
+}
+
+.idx-sym {
+    color: var(--blue);
+    font-weight: 700;
+    margin-right: 6px;
+}
+
+.idx-label {
+    color: var(--text-secondary);
+    font-size: 11px;
+}
+
+.idx-name {
+    min-width: 200px;
+}
+
+.idx-spark {
+    width: 80px;
+    height: 24px;
+}
+
+.idx-spark a[href*="tradingview"] {
+    display: none !important;
+}
+
+.idx-price {
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+
+.idx-change, .idx-pct {
+    font-variant-numeric: tabular-nums;
+}
+
+.idx-time {
+    font-size: 11px;
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+
+.idx-open {
+    color: var(--green);
+    font-weight: 700;
+    font-size: 10px;
+}
+
+.idx-closed {
+    color: var(--red);
+    font-weight: 700;
+    font-size: 10px;
+}
+
 /* ── Flash Animations ── */
 
 @keyframes flash-green {

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -31,6 +31,7 @@ window.onerror = function (msg, src, line, col, err) {
         graph:      { path: '/stock/{symbol}',  needsSecurity: true,  usage: 'graph <SECURITY>',    desc: 'show stock price chart for SECURITY' },
         info:       { path: '/security/{symbol}', needsSecurity: true, usage: 'info <SECURITY>',     desc: 'deep-dive company fundamentals for SECURITY' },
         news:       { path: '/news',            needsSecurity: false, usage: 'news [SECURITY]',     desc: 'market news — optionally filter by security', optionalSecurity: true },
+        ei:         { path: '/indices',          needsSecurity: false, usage: 'ei',                  desc: 'equity indices — global market overview' },
         screener:   { path: '/screener',        needsSecurity: false, usage: 'screener',            desc: 'filter and scan stocks by criteria' },
         debug:      { path: '/debug',           needsSecurity: false, usage: 'debug',               desc: 'live server log console' },
     };
@@ -1449,6 +1450,40 @@ window.onerror = function (msg, src, line, col, err) {
                 if (!sym) return;
                 if (action === 'info' && window._navigateToSecurity) window._navigateToSecurity(sym);
                 if (action === 'graph' && window._navigateToGraph) window._navigateToGraph(sym);
+            }
+        },
+        ei: {
+            _colFocus: 'row', // 'row' or 'spark'
+            getItems: function () {
+                return Array.from(document.querySelectorAll('.idx-row'));
+            },
+            move: function (dir) {
+                var items = this.getItems();
+                if (items.length === 0) return;
+                if (dir === 'j') vimSelectedIndex = Math.min(vimSelectedIndex + 1, items.length - 1);
+                else if (dir === 'k') vimSelectedIndex = Math.max(vimSelectedIndex - 1, 0);
+                else if (dir === 'h') this._colFocus = 'row';
+                else if (dir === 'l') this._colFocus = 'spark';
+                vimSelect(items, vimSelectedIndex);
+            },
+            activate: function () {
+                var items = this.getItems();
+                if (vimSelectedIndex < 0 || vimSelectedIndex >= items.length) return;
+                var sym = items[vimSelectedIndex].dataset.symbol;
+                if (!sym) return;
+                if (this._colFocus === 'spark') {
+                    // Open graph for this index
+                    if (window._navigateToGraph) {
+                        setSecurity(sym);
+                        window._navigateToGraph(sym);
+                    }
+                } else {
+                    // Navigate to index page (coming soon → graph for now)
+                    if (window._navigateToGraph) {
+                        setSecurity(sym);
+                        window._navigateToGraph(sym);
+                    }
+                }
             }
         },
         debug: {

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -217,6 +217,9 @@ window.onerror = function (msg, src, line, col, err) {
             };
         }
 
+        // Re-render tabs (DOM is fresh on SPA navigation)
+        renderWatchlistTabs();
+
         // Fetch batch quotes immediately
         fetchWatchlistQuotes();
     }

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -28,7 +28,7 @@ window.onerror = function (msg, src, line, col, err) {
 
     const COMMANDS = {
         watchlist:  { path: '/watchlist',       needsSecurity: false, usage: 'watchlist',           desc: 'real-time price table for tracked securities' },
-        graph:      { path: '/stock/{symbol}',  needsSecurity: true,  usage: 'graph <SECURITY>',    desc: 'show stock price chart for SECURITY' },
+        graph:      { path: '/graph/{symbol}',   needsSecurity: true,  usage: 'graph <SECURITY>',    desc: 'show price chart for any security' },
         info:       { path: '/security/{symbol}', needsSecurity: true, usage: 'info <SECURITY>',     desc: 'deep-dive company fundamentals for SECURITY' },
         news:       { path: '/news',            needsSecurity: false, usage: 'news [SECURITY]',     desc: 'market news — optionally filter by security', optionalSecurity: true },
         ei:         { path: '/indices',          needsSecurity: false, usage: 'ei',                  desc: 'equity indices — global market overview' },
@@ -1901,24 +1901,56 @@ window.onerror = function (msg, src, line, col, err) {
             });
         }
 
-        // Fetch profile
+        // Fetch profile — falls back to EOD data for indices
         fetch('/api/security/' + symbol + '/profile')
             .then(function (r) { return r.json(); })
             .then(function (data) {
-                if (!data || !data.length) return;
-                var p = data[0];
-                var nameEl = document.getElementById('cpanel-name');
-                var priceEl = document.getElementById('cpanel-price');
-                var changeEl = document.getElementById('cpanel-change');
-                if (nameEl) nameEl.textContent = p.companyName || '';
-                if (priceEl) priceEl.textContent = p.price ? p.price.toFixed(2) : '';
-                if (changeEl) {
-                    var chg = p.change || 0;
-                    var chgPct = p.changePercentage || 0;
-                    changeEl.textContent = (chg >= 0 ? '+' : '') + chg.toFixed(2) + ' (' + chgPct.toFixed(2) + '%)';
-                    changeEl.className = 'cpanel-change ' + (chg >= 0 ? 'price-up' : 'price-down');
+                if (data && data.length) {
+                    var p = data[0];
+                    setCpanelData(p.companyName || '', p.price, p.change, p.changePercentage);
+                } else {
+                    // Profile empty (index/crypto) — use EOD data
+                    fetchCpanelFromEOD(symbol);
                 }
-            });
+            })
+            .catch(function () { fetchCpanelFromEOD(symbol); });
+
+        function fetchCpanelFromEOD(sym) {
+            var from = new Date(Date.now() - 7 * 86400000).toISOString().slice(0, 10);
+            var to = new Date().toISOString().slice(0, 10);
+            fetch('/api/chart/eod/' + encodeURIComponent(sym) + '?from=' + from + '&to=' + to)
+                .then(function (r) { return r.json(); })
+                .then(function (eod) {
+                    if (!eod || eod.length < 1) return;
+                    var latest = eod[eod.length - 1];
+                    var prev = eod.length > 1 ? eod[eod.length - 2] : latest;
+                    var chg = latest.close - prev.close;
+                    var pct = (chg / prev.close) * 100;
+                    // Try to get name from index list
+                    fetch('/api/indices')
+                        .then(function (r) { return r.json(); })
+                        .then(function (indices) {
+                            var idx = (indices || []).find(function (i) { return i.symbol === sym; });
+                            setCpanelData(idx ? idx.name : sym, latest.close, chg, pct);
+                        })
+                        .catch(function () { setCpanelData(sym, latest.close, chg, pct); });
+                })
+                .catch(function () {});
+        }
+
+        function setCpanelData(name, price, change, changePct) {
+            var nameEl = document.getElementById('cpanel-name');
+            var priceEl = document.getElementById('cpanel-price');
+            var changeEl = document.getElementById('cpanel-change');
+            if (nameEl) nameEl.textContent = name;
+            if (priceEl) priceEl.textContent = price ? price.toLocaleString(undefined, { maximumFractionDigits: 2 }) : '';
+            if (changeEl) {
+                var chg = change || 0;
+                var chgPct = changePct || 0;
+                changeEl.textContent = (chg >= 0 ? '+' : '') + chg.toFixed(2) + ' (' + chgPct.toFixed(2) + '%)';
+                changeEl.className = 'cpanel-change ' + (chg >= 0 ? 'price-up' : 'price-down');
+            }
+        }
 
         // Skip sparkline if container has no-spark class
         if (!spark || el.classList.contains('no-spark')) return;

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -1465,6 +1465,17 @@ window.onerror = function (msg, src, line, col, err) {
                 else if (dir === 'h') this._colFocus = 'row';
                 else if (dir === 'l') this._colFocus = 'spark';
                 vimSelect(items, vimSelectedIndex);
+                this._updateColHighlight(items);
+            },
+            _updateColHighlight: function (items) {
+                // Remove all spark highlights
+                document.querySelectorAll('.idx-spark-selected').forEach(function (el) {
+                    el.classList.remove('idx-spark-selected');
+                });
+                if (this._colFocus === 'spark' && vimSelectedIndex >= 0 && items[vimSelectedIndex]) {
+                    var sparkCell = items[vimSelectedIndex].querySelector('.idx-spark');
+                    if (sparkCell) sparkCell.classList.add('idx-spark-selected');
+                }
             },
             activate: function () {
                 var items = this.getItems();

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -1472,17 +1472,13 @@ window.onerror = function (msg, src, line, col, err) {
                 var sym = items[vimSelectedIndex].dataset.symbol;
                 if (!sym) return;
                 if (this._colFocus === 'spark') {
-                    // Open graph for this index
-                    if (window._navigateToGraph) {
-                        setSecurity(sym);
-                        window._navigateToGraph(sym);
-                    }
+                    // Sparkline selected → open graph
+                    setSecurity(sym);
+                    if (window._navigateToGraph) window._navigateToGraph(sym);
                 } else {
-                    // Navigate to index page (coming soon → graph for now)
-                    if (window._navigateToGraph) {
-                        setSecurity(sym);
-                        window._navigateToGraph(sym);
-                    }
+                    // Row selected → open index info page
+                    setSecurity(sym);
+                    if (window._navigateToSecurity) window._navigateToSecurity(sym);
                 }
             }
         },

--- a/internal/server/templates/indices.html
+++ b/internal/server/templates/indices.html
@@ -1,0 +1,10 @@
+{{template "layout" .}}
+{{define "content"}}
+<div class="page-header">
+    <h2 class="view-title">Equity Indices</h2>
+</div>
+<div id="indices-container">
+    <p class="empty-state">Loading indices...</p>
+</div>
+<script src="/static/indices.js"></script>
+{{end}}


### PR DESCRIPTION
## Summary

### Equity Indices Page
- New `ei` command → `/indices` page showing 9 major world indices
- US: S&P 500, Dow Jones, Nasdaq, VIX, Russell 2000
- Europe: FTSE 100, Euro Stoxx 50
- Asia: Nikkei 225, Hang Seng
- Columns: name, 5-day sparkline, price, change, % change, local time (O/C)
- Prices from EOD data (profile API doesn't support indices)
- Vim: j/k rows, h/l toggle row↔sparkline (orange outline), Enter activates

### Graph Route Renamed
- `/stock/{symbol}` → `/graph/{symbol}` (type-agnostic)
- Old `/stock/` kept as legacy
- Works for stocks, indices, crypto — any chartable security

### Company Panel Adapts to Security Type
- Stocks: name, price, change from profile API
- Indices: name from index list, price/change from EOD fallback
- Graceful fallback chain: profile → EOD → symbol only

### Chart Watermark
- Symbol displayed as subtle background watermark (72px, 7% opacity)
- Uses v5 `createTextWatermark` on main pane

### Fixes
- Watchlist tabs render on SPA navigation (was blank on command bar nav)
- 1W chart shows 30 days of data (was 7)
- chart.js waits for LightweightCharts to load (fixes direct page load race)
- Sparkline column highlight visible on h/l selection

## Test plan
- [ ] `make smoke` — all 19 tests pass
- [ ] `ei` → indices with prices, sparklines, local times
- [ ] j/k selects, l highlights sparkline, Enter navigates
- [ ] `graph AAPL` → chart with AAPL watermark
- [ ] `graph ^GSPC` → chart with index name + price in header
- [ ] Watchlist tabs visible when navigating via command bar