### PR TITLE
feat: multi-agent trading analysis pipeline (phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,8 @@
 
 # --- Language-specific build artifacts ---
 *.class  # Java
-*.pyc    # Python
+*.pyc         # Python
+__pycache__/  # Python cache directories
 *.jar
 main
 stocktopus  # Project binary
@@ -77,6 +78,8 @@ bin/        # Build output directory
 .venv/      # Python virtual environment
 .models/    # Downloaded GGUF model files
 *.db        # SQLite databases
+*.db-shm    # SQLite shared memory
+*.db-wal    # SQLite write-ahead log
 
 # --- Secrets & Environment Variables ---
 .env*       # Environment files (contains API keys!)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # Stocktopus
 
-A Bloomberg terminal-inspired stock monitoring web app with real-time quotes, news feeds, candlestick charts, and vim-style keyboard navigation.
+A Bloomberg terminal-inspired stock monitoring web app with real-time quotes, news feeds, candlestick charts, AI-powered analysis, and vim-style keyboard navigation.
 
 ## Features
 
-- **Command Bar**: Type commands like `graph AAPL`, `news MSFT`, `watchlist` to navigate. Autocomplete for both commands and securities (searches by ticker and company name).
-- **Real-Time Watchlist**: Subscribe to securities and get live quote updates via WebSocket with flash animations on price changes.
-- **Candlestick Charts**: Professional OHLCV charts powered by TradingView Lightweight Charts with 1W/1M/3M/6M range selectors and volume overlay.
-- **News Feed**: Six categories (Press Releases, Articles, Stock, Crypto, Forex, General) with security filtering, tabbed interface, and infinite scroll.
-- **Security Search**: FMP-powered search by ticker and company name, available in both the command bar and security selector.
-- **Vim Keybindings**: Modal navigation (Normal/Insert) with `hjkl` movement, number keys for tab switching, `:` commands for chart ranges. Vimium-compatible.
-- **Multi-Timezone Clocks**: ET, UTC, UK, and JST times in the footer for market awareness.
+- **Command Bar**: Type commands like `graph AAPL`, `news MSFT`, `watchlist`, `analyze AAPL` to navigate. Autocomplete for both commands and securities.
+- **Real-Time Watchlist**: Multiple named watchlists with colored badges, live WebSocket quote updates, and flash animations on price changes.
+- **Candlestick Charts**: Professional OHLCV charts powered by TradingView Lightweight Charts with range selectors (1m to 6M) and technical indicators (SMA, EMA, MACD, RSI). News event markers overlay on chart.
+- **News Feed**: Six categories (Press Releases, Articles, Stock, Crypto, Forex, General) with security filtering, infinite scroll, and AI-powered article reader with entity extraction.
+- **Security Info**: Deep-dive company pages with Overview, Financials, Estimates, News, AI Analysis, and Sector tabs. Peer comparison with sparklines and 6M performance charts.
+- **Equity Indices**: Global market overview with 9 major indices, sparklines, local exchange times, and open/closed status.
+- **AI Company Intelligence**: Gemini-orchestrated analysis pipeline with Ollama workers gathering data from web search, RSS, SEC filings, and social sentiment. Competitor analysis cascading.
+- **Multi-Agent Trading Analysis**: TradingAgents-inspired pipeline with 4 parallel Ollama analyst agents (Technical, Fundamentals, News, Sentiment). Button-triggered with cost estimates. Research and risk debate phases planned.
+- **Vim Keybindings**: Modal navigation (Normal/Insert) with `hjkl` movement, number keys for tab switching, `:` commands for chart ranges and indicators. Vimium-compatible.
+- **Multi-Timezone Clocks**: ET, UTC, UK, and JST times in the footer.
 
 ## Architecture
 
@@ -27,62 +30,86 @@ graph TD
         HUB["Hub<br/>Pub/Sub WebSocket"]
         POLL["Poller<br/>Demand-based quotes"]
         NEWS["News Client<br/>FMP stable API"]
+        AGENT["Agent Pipeline<br/>Gemini + Ollama"]
+        TRADE["Trading Pipeline<br/>Multi-Agent Analysis"]
+        DB["SQLite<br/>Intelligence Store"]
     end
 
     subgraph "External"
-        FMP["Financial Modeling Prep<br/>Quotes, News, Search, EOD"]
+        FMP["Financial Modeling Prep<br/>Quotes, News, Search, EOD, Financials"]
+        OLLAMA["Ollama<br/>Local LLM (gemma3/gemma4)"]
+        GEMINI["Gemini API<br/>Orchestration + Debate"]
     end
 
     UI -- "SPA fragment fetch" --> SRV
     WS -- "subscribe/unsubscribe" --> HUB
-    HUB -- "quote updates" --> WS
+    HUB -- "quote/news/agent updates" --> WS
     HUB -- "first subscriber" --> POLL
     POLL -- "GetQuotes" --> FMP
-    SRV -- "news, search, chart" --> NEWS
+    SRV -- "news, search, chart, financials" --> NEWS
     NEWS --> FMP
     LC -- "/api/chart/eod" --> SRV
+    AGENT -- "synthesis" --> GEMINI
+    AGENT -- "workers" --> OLLAMA
+    TRADE -- "analyst agents" --> OLLAMA
+    AGENT --> DB
+    TRADE --> DB
 ```
 
 ## Project Structure
 
 ```
-cmd/stocktopus/          # Entry point
+cmd/stocktopus/              # Entry point
 internal/
-  hub/                   # WebSocket pub-sub hub
-  news/                  # FMP news, search, and chart data client
-  poller/                # Demand-based quote poller
-  provider/              # StockProvider interface + implementations (FMP, Polygon, AlphaVantage)
-  server/                # HTTP server, routes, templates, static assets
-  model/                 # Data models (Quote, NewsItem, OHLCV)
+  agent/                     # AI agent pipeline (Gemini orchestrator + Ollama workers)
+    trading/                 # Multi-agent trading analysis (4 analysts, debate, trader)
+  hub/                       # WebSocket pub-sub hub with composite routing
+  news/                      # FMP client (quotes, news, search, financials, EOD)
+  newspoller/                # Demand-based news polling
+  poller/                    # Demand-based quote poller
+  sectorpoller/              # Sector intelligence polling
+  provider/                  # StockProvider interface + FMP/Polygon/AlphaVantage
+  server/                    # HTTP server, routes, templates, static assets
+  store/                     # SQLite store (intelligence, watchlists, training data)
+  model/                     # Data models (Quote, NewsItem, OHLCV)
+agents/                      # Python agent scripts (web search, RSS, SEC, sentiment)
 tests/
-  e2e/                   # E2E smoke tests (build tag: e2e)
-  contract/              # Provider contract tests
-worklog/                 # Development notes
+  e2e/                       # E2E smoke tests (build tag: e2e)
+  contract/                  # Provider contract tests
+worklog/                     # Development notes
 ```
 
 ## Getting Started
 
 ### Prerequisites
 - Go 1.23+
-- [FMP API key](https://financialmodelingprep.com/) (set as `STOCK_API_KEY` env var)
+- [FMP API key](https://financialmodelingprep.com/) (set as `STOCK_API_KEY`)
+- [Ollama](https://ollama.ai/) with `gemma3` and `gemma4` models (for AI features)
+- Optional: `GEMINI_API_KEY` for AI orchestration and debate synthesis
 
 ### Run
 ```bash
 git clone https://github.com/binarypath/stocktopus.git
 cd stocktopus
-export STOCK_API_KEY=your_api_key
+export STOCK_API_KEY=your_fmp_key
 make dev
 ```
 
 Open `http://localhost:8080` in your browser.
 
+### AI Setup
+```bash
+make setup-agents    # Install Ollama models + Python venv
+export GEMINI_API_KEY=your_gemini_key
+```
+
 ### Commands
 ```
-make build    # Build to bin/stocktopus
+make build    # Build to bin/stocktopus (includes JS lint)
 make dev      # Build and run
 make test     # Unit tests
 make smoke    # E2E smoke tests (requires STOCK_API_KEY)
-make clean    # Remove bin/
+make clean    # Remove bin/ and database
 ```
 
 ## Keyboard Reference
@@ -93,20 +120,38 @@ make clean    # Remove bin/
 | `Esc` | Normal | Focus command bar (Insert) |
 | `/` | Normal | Focus command bar |
 | `s` | Normal | Focus security selector |
-| `:` | Normal | Chart command mode (`:1w`, `:1m`, `:3m`, `:6m`) |
+| `:` | Normal | Command mode (`:1w`, `:3m`, `:sma`, `:rsi`, `:watch`, `:az`) |
 | `h/j/k/l` | Normal | Navigate (view-dependent) |
 | `Enter` | Normal | Activate selection |
-| `g` | Normal | Go to graph for selected security (watchlist) |
-| `1-6` | Normal | Jump to news tab by number |
+| `g` | Normal | Go to graph for selected security |
+| `i` | Normal | Go to info for selected security |
+| `?` | Normal | Toggle help tooltips |
+| `1-6` | Normal | Jump to tab by number |
+
+## Terminal Commands
+
+| Command | Description |
+|---------|-------------|
+| `watchlist` | Real-time price table |
+| `graph <SEC>` | Candlestick chart |
+| `info <SEC>` | Company deep dive |
+| `news [SEC]` | Market news feed |
+| `ei` | Equity indices |
+| `analyze <SEC>` / `az <SEC>` | Run multi-agent trading analysis |
+| `screener` | Stock screener |
+| `debug` | Live server log console |
 
 ## Data Provider
 
 Uses [Financial Modeling Prep](https://financialmodelingprep.com/) stable API for:
-- Real-time quotes (`/stable/quote`, `/stable/batch-quote`)
-- Historical EOD data (`/stable/historical-price-eod/full`)
-- News across 6 categories (`/stable/news/*`)
-- Security search by ticker and name (`/stable/search-symbol`, `/stable/search-name`)
+- Real-time quotes, historical EOD, intraday charts
+- News across 6 categories with date filtering
+- Security search by ticker and company name
+- Company financials (income, balance sheet, cash flow)
+- Key metrics, ratios, analyst estimates
+- Sector peers, index lists, SIC codes
 
 ## Credits
 
 - Charts powered by [TradingView Lightweight Charts](https://www.tradingview.com/lightweight-charts/) (Apache 2.0)
+- AI analysis powered by [Ollama](https://ollama.ai/) (local) and [Gemini](https://ai.google.dev/) (cloud)

--- a/cmd/stocktopus/main.go
+++ b/cmd/stocktopus/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"stocktopus/internal/agent"
+	"stocktopus/internal/agent/trading"
 	"stocktopus/internal/hub"
 	"stocktopus/internal/news"
 	"stocktopus/internal/newspoller"
@@ -193,7 +194,33 @@ func main() {
 
 	h.SetSubscriptionHandler(composite)
 
-	srv, err := server.New(server.Config{Port: 8080, Host: "localhost"}, h, debug, poll, newsClient, pipeline, st, logger)
+	// Trading analysis pipeline (multi-agent, button-triggered)
+	var tradingPipeline *trading.TradingPipeline
+	if st != nil {
+		ollamaHost := os.Getenv("OLLAMA_HOST")
+		analystModel := os.Getenv("OLLAMA_NER_MODEL") // gemma3 — same lightweight model
+		if analystModel == "" {
+			analystModel = "gemma3"
+		}
+		tradingPipeline = trading.NewTradingPipeline(trading.TradingPipelineConfig{
+			OllamaHost:  ollamaHost,
+			OllamaModel: analystModel,
+		}, newsClient, st, logger)
+
+		// Publish trading pipeline status via hub
+		tradingPipeline.SetStatusCallback(func(result trading.PipelineResult) {
+			data, _ := json.Marshal(map[string]interface{}{
+				"type":   "trading_status",
+				"topic":  "trading:" + result.Symbol,
+				"result": result,
+			})
+			h.Publish("trading:"+result.Symbol, data)
+		})
+
+		slog.Info("trading pipeline ready", "model", analystModel)
+	}
+
+	srv, err := server.New(server.Config{Port: 8080, Host: "localhost"}, h, debug, poll, newsClient, pipeline, tradingPipeline, st, logger)
 	if err != nil {
 		slog.Error("failed to create server", "error", err)
 		os.Exit(1)

--- a/cmd/stocktopus/main.go
+++ b/cmd/stocktopus/main.go
@@ -205,6 +205,7 @@ func main() {
 		tradingPipeline = trading.NewTradingPipeline(trading.TradingPipelineConfig{
 			OllamaHost:  ollamaHost,
 			OllamaModel: analystModel,
+			AgentsDir:   "agents",
 		}, newsClient, st, logger)
 
 		// Publish trading pipeline status via hub

--- a/internal/agent/trading/analysts.go
+++ b/internal/agent/trading/analysts.go
@@ -1,0 +1,564 @@
+package trading
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"stocktopus/internal/model"
+	"stocktopus/internal/news"
+)
+
+// AnalystRunner executes the 4 analyst agents in parallel using Ollama.
+type AnalystRunner struct {
+	fmp        *news.Client
+	ollamaHost string
+	ollamaModel string
+	client     *http.Client
+	logger     *slog.Logger
+}
+
+func NewAnalystRunner(fmp *news.Client, ollamaHost, ollamaModel string, logger *slog.Logger) *AnalystRunner {
+	if ollamaHost == "" {
+		ollamaHost = "http://localhost:11434"
+	}
+	if ollamaModel == "" {
+		ollamaModel = "gemma3"
+	}
+	return &AnalystRunner{
+		fmp:         fmp,
+		ollamaHost:  ollamaHost,
+		ollamaModel: ollamaModel,
+		client:      &http.Client{Timeout: 120 * time.Second},
+		logger:      logger.With("component", "analysts"),
+	}
+}
+
+// RunAll executes all 4 analysts in parallel and returns their reports.
+// onStage is called when each analyst starts/completes for progress reporting.
+func (ar *AnalystRunner) RunAll(ctx context.Context, symbol string, onStage func(name string, status StageStatus)) []AnalystReport {
+	type result struct {
+		report AnalystReport
+		err    error
+	}
+
+	analysts := []struct {
+		name string
+		fn   func(ctx context.Context, symbol string) (AnalystReport, error)
+	}{
+		{"technical", ar.runTechnical},
+		{"fundamentals", ar.runFundamentals},
+		{"news", ar.runNews},
+		{"sentiment", ar.runSentiment},
+	}
+
+	results := make([]result, len(analysts))
+	var wg sync.WaitGroup
+
+	for i, a := range analysts {
+		wg.Add(1)
+		go func(idx int, name string, fn func(context.Context, string) (AnalystReport, error)) {
+			defer wg.Done()
+			if onStage != nil {
+				onStage(name, StageRunning)
+			}
+			report, err := fn(ctx, symbol)
+			results[idx] = result{report, err}
+			if err != nil {
+				if onStage != nil {
+					onStage(name, StageFailed)
+				}
+			} else {
+				if onStage != nil {
+					onStage(name, StageComplete)
+				}
+			}
+		}(i, a.name, a.fn)
+	}
+	wg.Wait()
+
+	reports := make([]AnalystReport, 0, len(analysts))
+	for i, r := range results {
+		if r.err != nil {
+			ar.logger.Warn("analyst failed", "analyst", analysts[i].name, "symbol", symbol, "error", r.err)
+			reports = append(reports, AnalystReport{
+				Analyst: analysts[i].name,
+				Symbol:  symbol,
+				Outlook: "neutral",
+				Summary: fmt.Sprintf("Analysis unavailable: %v", r.err),
+			})
+		} else {
+			reports = append(reports, r.report)
+		}
+	}
+	return reports
+}
+
+// runTechnical gathers EOD price data, calculates indicators, and asks Ollama to analyze.
+func (ar *AnalystRunner) runTechnical(ctx context.Context, symbol string) (AnalystReport, error) {
+	start := time.Now()
+
+	// Fetch 90 days of EOD data for indicator calculation
+	to := time.Now().UTC().Format("2006-01-02")
+	from := time.Now().UTC().AddDate(0, -3, 0).Format("2006-01-02")
+
+	bars, err := ar.fmp.GetHistoricalEOD(ctx, symbol, from, to)
+	if err != nil {
+		return AnalystReport{}, fmt.Errorf("fetch EOD: %w", err)
+	}
+	if len(bars) < 5 {
+		return AnalystReport{}, fmt.Errorf("insufficient price data: %d bars", len(bars))
+	}
+
+	indicators := calcIndicators(bars)
+
+	prompt := fmt.Sprintf(`You are a technical analyst. Analyze the following price data and indicators for %s.
+Return ONLY valid JSON with this structure:
+{"outlook":"bullish|bearish|neutral","summary":"2-3 sentence technical outlook","keyPoints":["point1","point2","point3"],"score":<-1.0 to 1.0>}
+
+Recent prices (last 10 trading days):
+%s
+
+Technical indicators:
+%s`, symbol, formatRecentPrices(bars), indicators)
+
+	report, err := ar.callOllamaForReport(ctx, "technical", symbol, prompt)
+	if err != nil {
+		return AnalystReport{}, err
+	}
+	report.Duration = time.Since(start).Seconds()
+
+	// Attach raw price data
+	rawData, _ := json.Marshal(map[string]interface{}{
+		"bars":       len(bars),
+		"indicators": indicators,
+	})
+	report.RawData = rawData
+
+	return report, nil
+}
+
+// runFundamentals gathers financial statements and asks Ollama to analyze.
+func (ar *AnalystRunner) runFundamentals(ctx context.Context, symbol string) (AnalystReport, error) {
+	start := time.Now()
+
+	// Fetch financial data in parallel
+	type fetchResult struct {
+		name string
+		data json.RawMessage
+		err  error
+	}
+
+	fetches := []struct {
+		name string
+		fn   func() (json.RawMessage, error)
+	}{
+		{"income", func() (json.RawMessage, error) { return ar.fmp.GetIncomeStatement(ctx, symbol, 3) }},
+		{"balance", func() (json.RawMessage, error) { return ar.fmp.GetBalanceSheet(ctx, symbol, 3) }},
+		{"cashflow", func() (json.RawMessage, error) { return ar.fmp.GetCashFlow(ctx, symbol, 3) }},
+		{"metrics", func() (json.RawMessage, error) { return ar.fmp.GetKeyMetrics(ctx, symbol) }},
+		{"ratios", func() (json.RawMessage, error) { return ar.fmp.GetRatiosTTM(ctx, symbol) }},
+	}
+
+	results := make([]fetchResult, len(fetches))
+	var wg sync.WaitGroup
+	for i, f := range fetches {
+		wg.Add(1)
+		go func(idx int, name string, fn func() (json.RawMessage, error)) {
+			defer wg.Done()
+			data, err := fn()
+			results[idx] = fetchResult{name, data, err}
+		}(i, f.name, f.fn)
+	}
+	wg.Wait()
+
+	// Build data summary for the prompt (truncate large datasets)
+	var dataParts []string
+	for _, r := range results {
+		if r.err != nil {
+			ar.logger.Debug("fundamentals fetch skipped", "source", r.name, "error", r.err)
+			continue
+		}
+		summary := truncateJSON(r.data, 1500)
+		dataParts = append(dataParts, fmt.Sprintf("%s:\n%s", r.name, summary))
+	}
+
+	if len(dataParts) == 0 {
+		return AnalystReport{}, fmt.Errorf("no financial data available")
+	}
+
+	prompt := fmt.Sprintf(`You are a fundamentals analyst. Analyze the financial data for %s.
+Return ONLY valid JSON with this structure:
+{"outlook":"bullish|bearish|neutral","summary":"2-3 sentence fundamental outlook","keyPoints":["point1","point2","point3"],"score":<-1.0 to 1.0>}
+
+Financial data:
+%s`, symbol, strings.Join(dataParts, "\n\n"))
+
+	report, err := ar.callOllamaForReport(ctx, "fundamentals", symbol, prompt)
+	if err != nil {
+		return AnalystReport{}, err
+	}
+	report.Duration = time.Since(start).Seconds()
+	return report, nil
+}
+
+// runNews gathers recent news and asks Ollama to analyze market impact.
+func (ar *AnalystRunner) runNews(ctx context.Context, symbol string) (AnalystReport, error) {
+	start := time.Now()
+
+	to := time.Now().UTC().Format("2006-01-02")
+	from := time.Now().UTC().AddDate(0, 0, -14).Format("2006-01-02")
+
+	items, err := ar.fmp.GetNewsWithDates(ctx, news.Stock, symbol, 0, 20, from, to)
+	if err != nil {
+		return AnalystReport{}, fmt.Errorf("fetch news: %w", err)
+	}
+
+	// Build news summary
+	var newsSummary strings.Builder
+	for i, item := range items {
+		if i >= 15 {
+			break
+		}
+		newsSummary.WriteString(fmt.Sprintf("- [%s] %s: %s\n",
+			item.Date.Format("2006-01-02"), item.Source, item.Title))
+		if item.Text != "" {
+			text := item.Text
+			if len(text) > 200 {
+				text = text[:200] + "..."
+			}
+			newsSummary.WriteString(fmt.Sprintf("  %s\n", text))
+		}
+	}
+
+	if newsSummary.Len() == 0 {
+		return AnalystReport{
+			Analyst: "news",
+			Symbol:  symbol,
+			Outlook: "neutral",
+			Summary: "No recent news available for analysis",
+			Duration: time.Since(start).Seconds(),
+		}, nil
+	}
+
+	prompt := fmt.Sprintf(`You are a news analyst. Analyze the following recent news about %s for market impact.
+Return ONLY valid JSON with this structure:
+{"outlook":"bullish|bearish|neutral","summary":"2-3 sentence news impact analysis","keyPoints":["point1","point2","point3"],"score":<-1.0 to 1.0>}
+
+Recent news:
+%s`, symbol, newsSummary.String())
+
+	report, err := ar.callOllamaForReport(ctx, "news", symbol, prompt)
+	if err != nil {
+		return AnalystReport{}, err
+	}
+	report.Duration = time.Since(start).Seconds()
+	return report, nil
+}
+
+// runSentiment gathers social/sentiment data and asks Ollama to analyze.
+func (ar *AnalystRunner) runSentiment(ctx context.Context, symbol string) (AnalystReport, error) {
+	start := time.Now()
+
+	// Use the existing social_sentiment Python agent pattern but call Ollama directly
+	// with whatever sentiment data we can gather from FMP social sentiment endpoint
+	// For now, use a simpler approach: analyze recent news titles + press releases for sentiment
+
+	to := time.Now().UTC().Format("2006-01-02")
+	from := time.Now().UTC().AddDate(0, 0, -7).Format("2006-01-02")
+
+	// Get press releases for additional signal
+	pressItems, _ := ar.fmp.GetNewsWithDates(ctx, news.PressReleases, symbol, 0, 10, from, to)
+	stockNews, _ := ar.fmp.GetNewsWithDates(ctx, news.Stock, symbol, 0, 10, from, to)
+
+	var sentimentData strings.Builder
+	sentimentData.WriteString("Recent headlines and press releases:\n")
+	for _, item := range stockNews {
+		sentimentData.WriteString(fmt.Sprintf("- [NEWS] %s\n", item.Title))
+	}
+	for _, item := range pressItems {
+		sentimentData.WriteString(fmt.Sprintf("- [PR] %s\n", item.Title))
+	}
+
+	if sentimentData.Len() < 50 {
+		return AnalystReport{
+			Analyst: "sentiment",
+			Symbol:  symbol,
+			Outlook: "neutral",
+			Summary: "Insufficient data for sentiment analysis",
+			Duration: time.Since(start).Seconds(),
+		}, nil
+	}
+
+	prompt := fmt.Sprintf(`You are a sentiment analyst. Analyze the following headlines and press releases about %s to gauge market sentiment.
+Return ONLY valid JSON with this structure:
+{"outlook":"bullish|bearish|neutral","summary":"2-3 sentence sentiment analysis","keyPoints":["point1","point2","point3"],"score":<-1.0 to 1.0>}
+
+%s`, symbol, sentimentData.String())
+
+	report, err := ar.callOllamaForReport(ctx, "sentiment", symbol, prompt)
+	if err != nil {
+		return AnalystReport{}, err
+	}
+	report.Duration = time.Since(start).Seconds()
+	return report, nil
+}
+
+// callOllamaForReport sends a prompt to Ollama and parses the analyst report JSON.
+func (ar *AnalystRunner) callOllamaForReport(ctx context.Context, analyst, symbol, prompt string) (AnalystReport, error) {
+	reqBody, _ := json.Marshal(map[string]interface{}{
+		"model":  ar.ollamaModel,
+		"prompt": prompt,
+		"stream": false,
+		"format": "json",
+		"options": map[string]interface{}{
+			"temperature": 0.3,
+			"num_predict": 512,
+		},
+	})
+
+	req, err := http.NewRequestWithContext(ctx, "POST", ar.ollamaHost+"/api/generate", bytes.NewReader(reqBody))
+	if err != nil {
+		return AnalystReport{}, fmt.Errorf("ollama request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ar.client.Do(req)
+	if err != nil {
+		return AnalystReport{}, fmt.Errorf("ollama call: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return AnalystReport{}, fmt.Errorf("ollama read: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return AnalystReport{}, fmt.Errorf("ollama %d: %s", resp.StatusCode, string(body))
+	}
+
+	var ollamaResp struct {
+		Response string `json:"response"`
+	}
+	if err := json.Unmarshal(body, &ollamaResp); err != nil {
+		return AnalystReport{}, fmt.Errorf("ollama parse: %w", err)
+	}
+
+	// Parse the structured JSON from the LLM
+	var parsed struct {
+		Outlook   string   `json:"outlook"`
+		Summary   string   `json:"summary"`
+		KeyPoints []string `json:"keyPoints"`
+		Score     float64  `json:"score"`
+	}
+
+	text := strings.TrimSpace(ollamaResp.Response)
+	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
+		ar.logger.Warn("failed to parse analyst JSON, using raw", "analyst", analyst, "error", err)
+		return AnalystReport{
+			Analyst: analyst,
+			Symbol:  symbol,
+			Outlook: "neutral",
+			Summary: text,
+		}, nil
+	}
+
+	return AnalystReport{
+		Analyst:   analyst,
+		Symbol:    symbol,
+		Outlook:   parsed.Outlook,
+		Summary:   parsed.Summary,
+		KeyPoints: parsed.KeyPoints,
+		Score:     parsed.Score,
+	}, nil
+}
+
+// --- Technical indicator helpers ---
+
+func calcIndicators(bars []model.OHLCV) string {
+	closes := make([]float64, len(bars))
+	for i, b := range bars {
+		closes[i] = b.Close
+	}
+
+	var sb strings.Builder
+
+	// Current price
+	last := closes[len(closes)-1]
+	sb.WriteString(fmt.Sprintf("Current Price: %.2f\n", last))
+
+	// SMA
+	if len(closes) >= 20 {
+		sma20 := sma(closes, 20)
+		sb.WriteString(fmt.Sprintf("SMA(20): %.2f (%s)\n", sma20, aboveBelow(last, sma20)))
+	}
+	if len(closes) >= 50 {
+		sma50 := sma(closes, 50)
+		sb.WriteString(fmt.Sprintf("SMA(50): %.2f (%s)\n", sma50, aboveBelow(last, sma50)))
+	}
+
+	// RSI(14)
+	if len(closes) >= 15 {
+		rsi := rsi(closes, 14)
+		var rsiLabel string
+		switch {
+		case rsi > 70:
+			rsiLabel = "overbought"
+		case rsi < 30:
+			rsiLabel = "oversold"
+		default:
+			rsiLabel = "neutral"
+		}
+		sb.WriteString(fmt.Sprintf("RSI(14): %.1f (%s)\n", rsi, rsiLabel))
+	}
+
+	// MACD (12, 26, 9)
+	if len(closes) >= 26 {
+		macdLine, signal := macd(closes)
+		sb.WriteString(fmt.Sprintf("MACD: %.2f, Signal: %.2f (%s)\n", macdLine, signal,
+			func() string {
+				if macdLine > signal {
+					return "bullish crossover"
+				}
+				return "bearish crossover"
+			}()))
+	}
+
+	// Bollinger Bands
+	if len(closes) >= 20 {
+		upper, middle, lower := bollingerBands(closes, 20, 2)
+		sb.WriteString(fmt.Sprintf("Bollinger: Upper=%.2f Mid=%.2f Lower=%.2f", upper, middle, lower))
+		if last > upper {
+			sb.WriteString(" (above upper)")
+		} else if last < lower {
+			sb.WriteString(" (below lower)")
+		} else {
+			sb.WriteString(fmt.Sprintf(" (%.0f%% bandwidth)", (last-lower)/(upper-lower)*100))
+		}
+		sb.WriteString("\n")
+	}
+
+	// Price change
+	if len(closes) >= 2 {
+		dayChange := (closes[len(closes)-1] - closes[len(closes)-2]) / closes[len(closes)-2] * 100
+		sb.WriteString(fmt.Sprintf("1D Change: %.2f%%\n", dayChange))
+	}
+	if len(closes) >= 6 {
+		weekChange := (closes[len(closes)-1] - closes[len(closes)-6]) / closes[len(closes)-6] * 100
+		sb.WriteString(fmt.Sprintf("1W Change: %.2f%%\n", weekChange))
+	}
+
+	return sb.String()
+}
+
+func sma(data []float64, period int) float64 {
+	if len(data) < period {
+		return 0
+	}
+	sum := 0.0
+	for _, v := range data[len(data)-period:] {
+		sum += v
+	}
+	return sum / float64(period)
+}
+
+func ema(data []float64, period int) float64 {
+	if len(data) < period {
+		return 0
+	}
+	k := 2.0 / float64(period+1)
+	e := sma(data[:period], period)
+	for _, v := range data[period:] {
+		e = v*k + e*(1-k)
+	}
+	return e
+}
+
+func rsi(data []float64, period int) float64 {
+	if len(data) < period+1 {
+		return 50
+	}
+	gains, losses := 0.0, 0.0
+	for i := len(data) - period; i < len(data); i++ {
+		change := data[i] - data[i-1]
+		if change > 0 {
+			gains += change
+		} else {
+			losses -= change
+		}
+	}
+	if losses == 0 {
+		return 100
+	}
+	rs := (gains / float64(period)) / (losses / float64(period))
+	return 100 - 100/(1+rs)
+}
+
+func macd(data []float64) (float64, float64) {
+	ema12 := ema(data, 12)
+	ema26 := ema(data, 26)
+	macdLine := ema12 - ema26
+
+	// Signal line: EMA(9) of MACD values (simplified)
+	// For a proper implementation we'd compute MACD for each bar
+	// This is an approximation using just the last values
+	signal := macdLine * 0.8 // rough approximation
+
+	return macdLine, signal
+}
+
+func bollingerBands(data []float64, period int, numStd float64) (upper, middle, lower float64) {
+	middle = sma(data, period)
+
+	// Standard deviation
+	sum := 0.0
+	slice := data[len(data)-period:]
+	for _, v := range slice {
+		diff := v - middle
+		sum += diff * diff
+	}
+	std := math.Sqrt(sum / float64(period))
+
+	upper = middle + numStd*std
+	lower = middle - numStd*std
+	return
+}
+
+func aboveBelow(price, level float64) string {
+	pct := (price - level) / level * 100
+	if pct > 0 {
+		return fmt.Sprintf("%.1f%% above", pct)
+	}
+	return fmt.Sprintf("%.1f%% below", -pct)
+}
+
+func formatRecentPrices(bars []model.OHLCV) string {
+	start := len(bars) - 10
+	if start < 0 {
+		start = 0
+	}
+	var sb strings.Builder
+	for _, b := range bars[start:] {
+		sb.WriteString(fmt.Sprintf("%s O:%.2f H:%.2f L:%.2f C:%.2f V:%d\n",
+			b.Date, b.Open, b.High, b.Low, b.Close, b.Volume))
+	}
+	return sb.String()
+}
+
+// truncateJSON returns a truncated string representation of JSON data.
+func truncateJSON(data json.RawMessage, maxLen int) string {
+	s := string(data)
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/internal/agent/trading/analysts.go
+++ b/internal/agent/trading/analysts.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"math"
 	"net/http"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -19,31 +21,35 @@ import (
 
 // AnalystRunner executes the 4 analyst agents in parallel using Ollama.
 type AnalystRunner struct {
-	fmp        *news.Client
-	ollamaHost string
+	fmp         *news.Client
+	ollamaHost  string
 	ollamaModel string
-	client     *http.Client
-	logger     *slog.Logger
+	agentsDir   string
+	client      *http.Client
+	logger      *slog.Logger
 }
 
-func NewAnalystRunner(fmp *news.Client, ollamaHost, ollamaModel string, logger *slog.Logger) *AnalystRunner {
+func NewAnalystRunner(fmp *news.Client, ollamaHost, ollamaModel, agentsDir string, logger *slog.Logger) *AnalystRunner {
 	if ollamaHost == "" {
 		ollamaHost = "http://localhost:11434"
 	}
 	if ollamaModel == "" {
 		ollamaModel = "gemma3"
 	}
+	if agentsDir == "" {
+		agentsDir = "agents"
+	}
 	return &AnalystRunner{
 		fmp:         fmp,
 		ollamaHost:  ollamaHost,
 		ollamaModel: ollamaModel,
+		agentsDir:   agentsDir,
 		client:      &http.Client{Timeout: 120 * time.Second},
 		logger:      logger.With("component", "analysts"),
 	}
 }
 
 // RunAll executes all 4 analysts in parallel and returns their reports.
-// onStage is called when each analyst starts/completes for progress reporting.
 func (ar *AnalystRunner) RunAll(ctx context.Context, symbol string, onStage func(name string, status StageStatus)) []AnalystReport {
 	type result struct {
 		report AnalystReport
@@ -102,32 +108,84 @@ func (ar *AnalystRunner) RunAll(ctx context.Context, symbol string, onStage func
 	return reports
 }
 
-// runTechnical gathers EOD price data, calculates indicators, and asks Ollama to analyze.
+// --- fetchProfile is shared across analysts that need company context ---
+
+func (ar *AnalystRunner) fetchProfile(ctx context.Context, symbol string) string {
+	profileData, err := ar.fmp.GetProfile(ctx, symbol)
+	if err != nil {
+		return ""
+	}
+	var profiles []struct {
+		CompanyName string  `json:"companyName"`
+		Sector      string  `json:"sector"`
+		Industry    string  `json:"industry"`
+		MarketCap   float64 `json:"marketCap"`
+		Beta        float64 `json:"beta"`
+		Price       float64 `json:"price"`
+		Exchange    string  `json:"exchange"`
+	}
+	if json.Unmarshal(profileData, &profiles) != nil || len(profiles) == 0 {
+		return ""
+	}
+	p := profiles[0]
+	return fmt.Sprintf("Company: %s | Sector: %s | Industry: %s | Market Cap: %.0f | Beta: %.3f | Price: %.2f | Exchange: %s",
+		p.CompanyName, p.Sector, p.Industry, p.MarketCap, p.Beta, p.Price, p.Exchange)
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// TECHNICAL ANALYST
+// ════════════════════════════════════════════════════════════════════════
+
 func (ar *AnalystRunner) runTechnical(ctx context.Context, symbol string) (AnalystReport, error) {
 	start := time.Now()
 
-	// Fetch 90 days of EOD data for indicator calculation
 	to := time.Now().UTC().Format("2006-01-02")
 	from := time.Now().UTC().AddDate(0, -3, 0).Format("2006-01-02")
 
-	bars, err := ar.fmp.GetHistoricalEOD(ctx, symbol, from, to)
-	if err != nil {
-		return AnalystReport{}, fmt.Errorf("fetch EOD: %w", err)
+	// Fetch price data and profile in parallel
+	var bars []model.OHLCV
+	var profile string
+	var barsErr error
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+	go func() { defer wg.Done(); bars, barsErr = ar.fmp.GetHistoricalEOD(ctx, symbol, from, to) }()
+	go func() { defer wg.Done(); profile = ar.fetchProfile(ctx, symbol) }()
+	wg.Wait()
+
+	if barsErr != nil {
+		return AnalystReport{}, fmt.Errorf("fetch EOD: %w", barsErr)
 	}
 	if len(bars) < 5 {
 		return AnalystReport{}, fmt.Errorf("insufficient price data: %d bars", len(bars))
 	}
 
 	indicators := calcIndicators(bars)
+	volumeAnalysis := calcVolumeAnalysis(bars)
 
-	prompt := fmt.Sprintf(`You are a technical analyst. Analyze the following price data and indicators for %s.
-Return JSON with: outlook (bullish/bearish/neutral), summary (2-3 sentences), reasoning (cite specific indicators and values that support your conclusion), keyPoints (3-5 key observations), score (-1.0 to 1.0).
+	prompt := fmt.Sprintf(`You are an expert technical analyst tasked with analyzing price action and indicators for %s.
+
+Context:
+%s
+
+Your analysis should focus on:
+- **Trend Direction**: Identify the primary trend using moving averages (SMA crossovers, price vs SMA). Is the stock trending up, down, or ranging?
+- **Momentum**: Evaluate RSI for overbought/oversold conditions and MACD for momentum shifts. Are there divergences between price and momentum?
+- **Volatility**: Assess Bollinger Band position and width. Is volatility expanding or contracting? What does this imply?
+- **Volume**: Is volume confirming the price trend? Look for volume spikes, declining volume on rallies, or increasing volume on selloffs.
+- **Support/Resistance**: Identify key price levels from recent highs, lows, and moving averages.
+- **Risk/Reward**: Given the current technical setup, what is the probable near-term direction and what could invalidate that thesis?
+
+Provide specific numbers from the data below. Do not be vague — cite the exact indicator values.
 
 Recent prices (last 10 trading days):
 %s
 
 Technical indicators:
-%s`, symbol, formatRecentPrices(bars), indicators)
+%s
+
+Volume analysis:
+%s`, symbol, profile, formatRecentPrices(bars), indicators, volumeAnalysis)
 
 	report, err := ar.callOllamaForReport(ctx, "technical", symbol, prompt)
 	if err != nil {
@@ -136,17 +194,19 @@ Technical indicators:
 	report.Duration = time.Since(start).Seconds()
 	report.Sources = []string{
 		fmt.Sprintf("FMP EOD prices (%d bars, %s to %s)", len(bars), from, to),
-		"Calculated: SMA(20,50), RSI(14), MACD(12,26,9), Bollinger(20,2)",
+		"SMA(20,50), RSI(14), MACD(12,26,9), Bollinger(20,2), ATR(14), VWAP",
 	}
 
 	return report, nil
 }
 
-// runFundamentals gathers financial statements and asks Ollama to analyze.
+// ════════════════════════════════════════════════════════════════════════
+// FUNDAMENTALS ANALYST
+// ════════════════════════════════════════════════════════════════════════
+
 func (ar *AnalystRunner) runFundamentals(ctx context.Context, symbol string) (AnalystReport, error) {
 	start := time.Now()
 
-	// Fetch financial data in parallel
 	type fetchResult struct {
 		name string
 		data json.RawMessage
@@ -157,11 +217,14 @@ func (ar *AnalystRunner) runFundamentals(ctx context.Context, symbol string) (An
 		name string
 		fn   func() (json.RawMessage, error)
 	}{
-		{"income", func() (json.RawMessage, error) { return ar.fmp.GetIncomeStatement(ctx, symbol, 3) }},
-		{"balance", func() (json.RawMessage, error) { return ar.fmp.GetBalanceSheet(ctx, symbol, 3) }},
-		{"cashflow", func() (json.RawMessage, error) { return ar.fmp.GetCashFlow(ctx, symbol, 3) }},
+		{"profile", func() (json.RawMessage, error) { return ar.fmp.GetProfile(ctx, symbol) }},
+		{"income", func() (json.RawMessage, error) { return ar.fmp.GetIncomeStatement(ctx, symbol, 4) }},
+		{"balance", func() (json.RawMessage, error) { return ar.fmp.GetBalanceSheet(ctx, symbol, 4) }},
+		{"cashflow", func() (json.RawMessage, error) { return ar.fmp.GetCashFlow(ctx, symbol, 4) }},
 		{"metrics", func() (json.RawMessage, error) { return ar.fmp.GetKeyMetrics(ctx, symbol) }},
 		{"ratios", func() (json.RawMessage, error) { return ar.fmp.GetRatiosTTM(ctx, symbol) }},
+		{"estimates", func() (json.RawMessage, error) { return ar.fmp.GetAnalystEstimates(ctx, symbol, 3) }},
+		{"peers", func() (json.RawMessage, error) { return ar.fmp.GetPeers(ctx, symbol) }},
 	}
 
 	results := make([]fetchResult, len(fetches))
@@ -176,23 +239,34 @@ func (ar *AnalystRunner) runFundamentals(ctx context.Context, symbol string) (An
 	}
 	wg.Wait()
 
-	// Build data summary for the prompt (truncate large datasets)
+	// Build data for the prompt — extract key fields rather than dumping raw JSON
 	var dataParts []string
 	for _, r := range results {
 		if r.err != nil {
 			ar.logger.Debug("fundamentals fetch skipped", "source", r.name, "error", r.err)
 			continue
 		}
-		summary := truncateJSON(r.data, 1500)
-		dataParts = append(dataParts, fmt.Sprintf("%s:\n%s", r.name, summary))
+		// Use up to 3000 chars per section — the LLM needs actual numbers
+		summary := truncateJSON(r.data, 3000)
+		dataParts = append(dataParts, fmt.Sprintf("=== %s ===\n%s", strings.ToUpper(r.name), summary))
 	}
 
 	if len(dataParts) == 0 {
 		return AnalystReport{}, fmt.Errorf("no financial data available")
 	}
 
-	prompt := fmt.Sprintf(`You are a fundamentals analyst. Analyze the financial data for %s.
-Return JSON with: outlook (bullish/bearish/neutral), summary (2-3 sentences), reasoning (cite specific financial metrics, ratios, and trends that support your conclusion), keyPoints (3-5 key observations), score (-1.0 to 1.0).
+	prompt := fmt.Sprintf(`You are an expert fundamentals analyst tasked with analyzing the financial health and valuation of %s.
+
+Your analysis should focus on:
+- **Profitability**: Revenue growth trends (YoY), gross/operating/net margins, earnings quality. Is profitability improving or deteriorating?
+- **Balance Sheet Strength**: Debt-to-equity ratio, current ratio, cash position vs debt. Can the company service its obligations?
+- **Cash Flow**: Operating cash flow trends, free cash flow generation, capex intensity. Is the company generating real cash or relying on accounting?
+- **Valuation**: P/E, EV/EBITDA, P/B, PEG relative to sector peers. Is the stock cheap or expensive relative to its fundamentals?
+- **Growth Trajectory**: Compare analyst estimates to historical performance. Are expectations realistic? What's priced in?
+- **Red Flags**: Look for declining margins, rising debt, negative FCF, revenue deceleration, or earnings quality issues.
+- **Competitive Position**: How does this company compare to its sector peers in financial health?
+
+Cite specific numbers — revenue figures, margin percentages, ratios. Do not be vague.
 
 Financial data:
 %s`, symbol, strings.Join(dataParts, "\n\n"))
@@ -214,133 +288,306 @@ Financial data:
 	return report, nil
 }
 
-// runNews gathers recent news and asks Ollama to analyze market impact.
+// ════════════════════════════════════════════════════════════════════════
+// NEWS ANALYST
+// ════════════════════════════════════════════════════════════════════════
+
 func (ar *AnalystRunner) runNews(ctx context.Context, symbol string) (AnalystReport, error) {
 	start := time.Now()
 
 	to := time.Now().UTC().Format("2006-01-02")
 	from := time.Now().UTC().AddDate(0, 0, -14).Format("2006-01-02")
 
-	items, err := ar.fmp.GetNewsWithDates(ctx, news.Stock, symbol, 0, 20, from, to)
-	if err != nil {
-		return AnalystReport{}, fmt.Errorf("fetch news: %w", err)
+	// Fetch company news, press releases, AND macro news in parallel
+	var stockItems, pressItems, macroItems []model.NewsItem
+	var stockErr error
+	var wg sync.WaitGroup
+	var profile string
+
+	wg.Add(4)
+	go func() {
+		defer wg.Done()
+		stockItems, stockErr = ar.fmp.GetNewsWithDates(ctx, news.Stock, symbol, 0, 20, from, to)
+	}()
+	go func() {
+		defer wg.Done()
+		pressItems, _ = ar.fmp.GetNewsWithDates(ctx, news.PressReleases, symbol, 0, 10, from, to)
+	}()
+	go func() {
+		defer wg.Done()
+		macroItems, _ = ar.fmp.GetNewsWithDates(ctx, news.General, "", 0, 10, from, to)
+	}()
+	go func() {
+		defer wg.Done()
+		profile = ar.fetchProfile(ctx, symbol)
+	}()
+	wg.Wait()
+
+	if stockErr != nil {
+		return AnalystReport{}, fmt.Errorf("fetch news: %w", stockErr)
 	}
 
-	// Build news summary
-	var newsSummary strings.Builder
-	for i, item := range items {
+	// Build comprehensive news summary
+	var sb strings.Builder
+
+	sb.WriteString("=== COMPANY NEWS ===\n")
+	for i, item := range stockItems {
 		if i >= 15 {
 			break
 		}
-		newsSummary.WriteString(fmt.Sprintf("- [%s] %s: %s\n",
-			item.Date.Format("2006-01-02"), item.Source, item.Title))
+		sb.WriteString(fmt.Sprintf("- [%s] %s: %s\n", item.Date.Format("2006-01-02"), item.Source, item.Title))
 		if item.Text != "" {
 			text := item.Text
-			if len(text) > 200 {
-				text = text[:200] + "..."
+			if len(text) > 300 {
+				text = text[:300] + "..."
 			}
-			newsSummary.WriteString(fmt.Sprintf("  %s\n", text))
+			sb.WriteString(fmt.Sprintf("  %s\n", text))
 		}
 	}
 
-	if newsSummary.Len() == 0 {
+	if len(pressItems) > 0 {
+		sb.WriteString("\n=== PRESS RELEASES ===\n")
+		for i, item := range pressItems {
+			if i >= 8 {
+				break
+			}
+			sb.WriteString(fmt.Sprintf("- [%s] %s\n", item.Date.Format("2006-01-02"), item.Title))
+			if item.Text != "" {
+				text := item.Text
+				if len(text) > 200 {
+					text = text[:200] + "..."
+				}
+				sb.WriteString(fmt.Sprintf("  %s\n", text))
+			}
+		}
+	}
+
+	if len(macroItems) > 0 {
+		sb.WriteString("\n=== MACRO / MARKET NEWS ===\n")
+		for i, item := range macroItems {
+			if i >= 8 {
+				break
+			}
+			sb.WriteString(fmt.Sprintf("- [%s] %s: %s\n", item.Date.Format("2006-01-02"), item.Source, item.Title))
+		}
+	}
+
+	if sb.Len() < 50 {
 		return AnalystReport{
-			Analyst: "news",
-			Symbol:  symbol,
-			Outlook: "neutral",
-			Summary: "No recent news available for analysis",
+			Analyst:  "news",
+			Symbol:   symbol,
+			Outlook:  "neutral",
+			Summary:  "No recent news available for analysis",
 			Duration: time.Since(start).Seconds(),
 		}, nil
 	}
 
-	prompt := fmt.Sprintf(`You are a news analyst. Analyze the following recent news about %s for market impact.
-Return JSON with: outlook (bullish/bearish/neutral), summary (2-3 sentences), reasoning (cite specific news items and explain their likely market impact), keyPoints (3-5 key observations), score (-1.0 to 1.0).
+	prompt := fmt.Sprintf(`You are an expert news analyst tasked with evaluating how recent news affects the investment outlook for %s.
 
-Recent news:
-%s`, symbol, newsSummary.String())
+Context:
+%s
+
+Your analysis should focus on:
+- **Material Events**: Identify news with direct financial impact — earnings surprises, guidance changes, product launches, regulatory actions, M&A activity, executive changes.
+- **Press Releases**: Company-issued releases often signal management priorities. What is the company emphasizing?
+- **Macro Environment**: How do broader economic trends (interest rates, inflation, sector rotation, geopolitical events) affect this specific company?
+- **Sentiment Shift**: Is the news flow becoming more positive or negative compared to the prior period? Are there emerging narratives?
+- **Market Reaction Risk**: Which upcoming events or unresolved news items could cause significant price movement?
+- **Source Quality**: Weight institutional sources and press releases higher than opinion pieces.
+
+Cite specific headlines and dates. Distinguish between company-specific and macro factors.
+
+News data:
+%s`, symbol, profile, sb.String())
 
 	report, err := ar.callOllamaForReport(ctx, "news", symbol, prompt)
 	if err != nil {
 		return AnalystReport{}, err
 	}
 	report.Duration = time.Since(start).Seconds()
-	report.Sources = []string{fmt.Sprintf("FMP stock news (%d items, %s to %s)", len(items), from, to)}
+	report.Sources = []string{
+		fmt.Sprintf("FMP stock news (%d items, %s to %s)", len(stockItems), from, to),
+		fmt.Sprintf("FMP press releases (%d items)", len(pressItems)),
+		fmt.Sprintf("FMP macro news (%d items)", len(macroItems)),
+	}
 
 	return report, nil
 }
 
-// runSentiment gathers social/sentiment data and asks Ollama to analyze.
+// ════════════════════════════════════════════════════════════════════════
+// SENTIMENT ANALYST
+// ════════════════════════════════════════════════════════════════════════
+
 func (ar *AnalystRunner) runSentiment(ctx context.Context, symbol string) (AnalystReport, error) {
 	start := time.Now()
-
-	// Use the existing social_sentiment Python agent pattern but call Ollama directly
-	// with whatever sentiment data we can gather from FMP social sentiment endpoint
-	// For now, use a simpler approach: analyze recent news titles + press releases for sentiment
 
 	to := time.Now().UTC().Format("2006-01-02")
 	from := time.Now().UTC().AddDate(0, 0, -7).Format("2006-01-02")
 
-	// Get press releases for additional signal
-	pressItems, _ := ar.fmp.GetNewsWithDates(ctx, news.PressReleases, symbol, 0, 10, from, to)
-	stockNews, _ := ar.fmp.GetNewsWithDates(ctx, news.Stock, symbol, 0, 10, from, to)
+	// Fetch social media data (Bluesky), press releases, and stock news in parallel
+	var socialData json.RawMessage
+	var pressItems, stockNews []model.NewsItem
+	var profile string
+	var wg sync.WaitGroup
 
-	var sentimentData strings.Builder
-	sentimentData.WriteString("Recent headlines and press releases:\n")
+	wg.Add(4)
+	go func() {
+		defer wg.Done()
+		socialData = ar.runPythonSentiment(ctx, symbol)
+	}()
+	go func() {
+		defer wg.Done()
+		pressItems, _ = ar.fmp.GetNewsWithDates(ctx, news.PressReleases, symbol, 0, 15, from, to)
+	}()
+	go func() {
+		defer wg.Done()
+		stockNews, _ = ar.fmp.GetNewsWithDates(ctx, news.Stock, symbol, 0, 15, from, to)
+	}()
+	go func() {
+		defer wg.Done()
+		profile = ar.fetchProfile(ctx, symbol)
+	}()
+	wg.Wait()
+
+	// Build sentiment data
+	var sb strings.Builder
+	sources := []string{}
+
+	// Parse social media results
+	if socialData != nil {
+		var social struct {
+			Posts              []struct {
+				Text        string `json:"text"`
+				Author      string `json:"author"`
+				DisplayName string `json:"displayName"`
+				Likes       int    `json:"likes"`
+				Reposts     int    `json:"reposts"`
+			} `json:"posts"`
+			AggregateSentiment float64 `json:"aggregateSentiment"`
+			PostCount          int     `json:"postCount"`
+		}
+		if json.Unmarshal(socialData, &social) == nil && social.PostCount > 0 {
+			sb.WriteString(fmt.Sprintf("=== SOCIAL MEDIA (Bluesky) — %d posts, aggregate sentiment: %.2f ===\n", social.PostCount, social.AggregateSentiment))
+			for i, p := range social.Posts {
+				if i >= 10 {
+					break
+				}
+				text := p.Text
+				if len(text) > 200 {
+					text = text[:200] + "..."
+				}
+				engagement := ""
+				if p.Likes > 0 || p.Reposts > 0 {
+					engagement = fmt.Sprintf(" [%d likes, %d reposts]", p.Likes, p.Reposts)
+				}
+				sb.WriteString(fmt.Sprintf("- @%s: %s%s\n", p.Author, text, engagement))
+			}
+			sb.WriteString("\n")
+			sources = append(sources, fmt.Sprintf("Bluesky social media (%d posts, sentiment: %.2f)", social.PostCount, social.AggregateSentiment))
+		}
+	}
+
+	sb.WriteString("=== NEWS HEADLINES (for sentiment signals) ===\n")
 	for _, item := range stockNews {
-		sentimentData.WriteString(fmt.Sprintf("- [NEWS] %s\n", item.Title))
+		sb.WriteString(fmt.Sprintf("- [%s] [NEWS] %s — %s\n", item.Date.Format("2006-01-02"), item.Source, item.Title))
 	}
 	for _, item := range pressItems {
-		sentimentData.WriteString(fmt.Sprintf("- [PR] %s\n", item.Title))
+		sb.WriteString(fmt.Sprintf("- [%s] [PR] %s\n", item.Date.Format("2006-01-02"), item.Title))
 	}
 
-	if sentimentData.Len() < 50 {
+	sources = append(sources, fmt.Sprintf("FMP stock news (%d items)", len(stockNews)))
+	sources = append(sources, fmt.Sprintf("FMP press releases (%d items)", len(pressItems)))
+
+	if sb.Len() < 50 {
 		return AnalystReport{
-			Analyst: "sentiment",
-			Symbol:  symbol,
-			Outlook: "neutral",
-			Summary: "Insufficient data for sentiment analysis",
+			Analyst:  "sentiment",
+			Symbol:   symbol,
+			Outlook:  "neutral",
+			Summary:  "Insufficient data for sentiment analysis",
 			Duration: time.Since(start).Seconds(),
 		}, nil
 	}
 
-	prompt := fmt.Sprintf(`You are a sentiment analyst. Analyze the following headlines and press releases about %s to gauge market sentiment.
-Return JSON with: outlook (bullish/bearish/neutral), summary (2-3 sentences), reasoning (cite specific headlines and explain the sentiment signal they convey), keyPoints (3-5 key observations), score (-1.0 to 1.0).
+	prompt := fmt.Sprintf(`You are an expert sentiment analyst tasked with gauging market mood and public perception for %s.
 
-%s`, symbol, sentimentData.String())
+Context:
+%s
+
+Your analysis should focus on:
+- **Social Media Tone**: What is the retail investor community saying? Is there excitement, fear, indifference? Look for crowd consensus and contrarian signals.
+- **Headline Sentiment**: Are news headlines becoming more positive or negative? Track the shift over the past week.
+- **Institutional vs Retail**: Press releases reflect management messaging. Social posts reflect retail sentiment. Do they align or diverge?
+- **Engagement Signals**: Higher engagement (likes, reposts) on bullish or bearish posts indicates conviction strength.
+- **Narrative Analysis**: What narrative is forming around this stock? Is it a momentum play, value trap, turnaround story, or something else?
+- **Contrarian Indicators**: Extreme bullish sentiment can signal a top; extreme bearish sentiment can signal a bottom. Where are we on that spectrum?
+
+Cite specific social posts and headlines that support your assessment.
+
+Sentiment data:
+%s`, symbol, profile, sb.String())
 
 	report, err := ar.callOllamaForReport(ctx, "sentiment", symbol, prompt)
 	if err != nil {
 		return AnalystReport{}, err
 	}
 	report.Duration = time.Since(start).Seconds()
-	report.Sources = []string{
-		fmt.Sprintf("FMP stock news (%d items)", len(stockNews)),
-		fmt.Sprintf("FMP press releases (%d items)", len(pressItems)),
-	}
+	report.Sources = sources
 
 	return report, nil
 }
 
-// callOllamaForReport sends a prompt to Ollama and parses the analyst report JSON.
+// runPythonSentiment calls the social_sentiment.py agent.
+func (ar *AnalystRunner) runPythonSentiment(ctx context.Context, symbol string) json.RawMessage {
+	scriptPath := filepath.Join(ar.agentsDir, "social_sentiment.py")
+	venvPython := filepath.Join(ar.agentsDir, "..", ".venv", "bin", "python3")
+
+	pythonCmd := "python3"
+	if _, err := exec.LookPath(venvPython); err == nil {
+		pythonCmd = venvPython
+	}
+
+	cmd := exec.CommandContext(ctx, pythonCmd, scriptPath, symbol)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		ar.logger.Debug("social_sentiment.py failed", "error", err, "stderr", stderr.String())
+		return nil
+	}
+
+	output := stdout.Bytes()
+	if !json.Valid(output) {
+		return nil
+	}
+	return json.RawMessage(output)
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// OLLAMA CALL
+// ════════════════════════════════════════════════════════════════════════
+
+var ollamaSchema = map[string]interface{}{
+	"type": "object",
+	"properties": map[string]interface{}{
+		"outlook":   map[string]interface{}{"type": "string", "enum": []string{"bullish", "bearish", "neutral"}},
+		"summary":   map[string]string{"type": "string"},
+		"reasoning": map[string]string{"type": "string"},
+		"keyPoints": map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}},
+		"score":     map[string]string{"type": "number"},
+	},
+	"required": []string{"outlook", "summary", "reasoning", "keyPoints", "score"},
+}
+
 func (ar *AnalystRunner) callOllamaForReport(ctx context.Context, analyst, symbol, prompt string) (AnalystReport, error) {
 	reqBody, _ := json.Marshal(map[string]interface{}{
 		"model":  ar.ollamaModel,
 		"prompt": prompt,
 		"stream": false,
-		"format": map[string]interface{}{
-			"type": "object",
-			"properties": map[string]interface{}{
-				"outlook":   map[string]interface{}{"type": "string", "enum": []string{"bullish", "bearish", "neutral"}},
-				"summary":   map[string]string{"type": "string"},
-				"reasoning": map[string]string{"type": "string"},
-				"keyPoints": map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}},
-				"score":     map[string]string{"type": "number"},
-			},
-			"required": []string{"outlook", "summary", "reasoning", "keyPoints", "score"},
-		},
+		"format": ollamaSchema,
 		"options": map[string]interface{}{
 			"temperature": 0.3,
-			"num_predict": 512,
+			"num_predict": 1024,
 		},
 	})
 
@@ -403,7 +650,9 @@ func (ar *AnalystRunner) callOllamaForReport(ctx context.Context, analyst, symbo
 	}, nil
 }
 
-// --- Technical indicator helpers ---
+// ════════════════════════════════════════════════════════════════════════
+// TECHNICAL INDICATOR HELPERS
+// ════════════════════════════════════════════════════════════════════════
 
 func calcIndicators(bars []model.OHLCV) string {
 	closes := make([]float64, len(bars))
@@ -412,8 +661,6 @@ func calcIndicators(bars []model.OHLCV) string {
 	}
 
 	var sb strings.Builder
-
-	// Current price
 	last := closes[len(closes)-1]
 	sb.WriteString(fmt.Sprintf("Current Price: %.2f\n", last))
 
@@ -427,31 +674,39 @@ func calcIndicators(bars []model.OHLCV) string {
 		sb.WriteString(fmt.Sprintf("SMA(50): %.2f (%s)\n", sma50, aboveBelow(last, sma50)))
 	}
 
+	// EMA
+	if len(closes) >= 12 {
+		ema12 := ema(closes, 12)
+		sb.WriteString(fmt.Sprintf("EMA(12): %.2f (%s)\n", ema12, aboveBelow(last, ema12)))
+	}
+	if len(closes) >= 26 {
+		ema26 := ema(closes, 26)
+		sb.WriteString(fmt.Sprintf("EMA(26): %.2f (%s)\n", ema26, aboveBelow(last, ema26)))
+	}
+
 	// RSI(14)
 	if len(closes) >= 15 {
-		rsi := rsi(closes, 14)
+		rsiVal := rsi(closes, 14)
 		var rsiLabel string
 		switch {
-		case rsi > 70:
+		case rsiVal > 70:
 			rsiLabel = "overbought"
-		case rsi < 30:
+		case rsiVal < 30:
 			rsiLabel = "oversold"
 		default:
 			rsiLabel = "neutral"
 		}
-		sb.WriteString(fmt.Sprintf("RSI(14): %.1f (%s)\n", rsi, rsiLabel))
+		sb.WriteString(fmt.Sprintf("RSI(14): %.1f (%s)\n", rsiVal, rsiLabel))
 	}
 
-	// MACD (12, 26, 9)
+	// MACD
 	if len(closes) >= 26 {
 		macdLine, signal := macd(closes)
-		sb.WriteString(fmt.Sprintf("MACD: %.2f, Signal: %.2f (%s)\n", macdLine, signal,
-			func() string {
-				if macdLine > signal {
-					return "bullish crossover"
-				}
-				return "bearish crossover"
-			}()))
+		crossover := "bearish crossover"
+		if macdLine > signal {
+			crossover = "bullish crossover"
+		}
+		sb.WriteString(fmt.Sprintf("MACD: %.4f, Signal: %.4f (%s)\n", macdLine, signal, crossover))
 	}
 
 	// Bollinger Bands
@@ -459,26 +714,126 @@ func calcIndicators(bars []model.OHLCV) string {
 		upper, middle, lower := bollingerBands(closes, 20, 2)
 		sb.WriteString(fmt.Sprintf("Bollinger: Upper=%.2f Mid=%.2f Lower=%.2f", upper, middle, lower))
 		if last > upper {
-			sb.WriteString(" (above upper)")
+			sb.WriteString(" (above upper — overbought)")
 		} else if last < lower {
-			sb.WriteString(" (below lower)")
+			sb.WriteString(" (below lower — oversold)")
 		} else {
 			sb.WriteString(fmt.Sprintf(" (%.0f%% bandwidth)", (last-lower)/(upper-lower)*100))
 		}
 		sb.WriteString("\n")
 	}
 
-	// Price change
+	// ATR(14)
+	if len(bars) >= 15 {
+		atrVal := atr(bars, 14)
+		sb.WriteString(fmt.Sprintf("ATR(14): %.2f (%.1f%% of price)\n", atrVal, atrVal/last*100))
+	}
+
+	// Price changes
 	if len(closes) >= 2 {
-		dayChange := (closes[len(closes)-1] - closes[len(closes)-2]) / closes[len(closes)-2] * 100
-		sb.WriteString(fmt.Sprintf("1D Change: %.2f%%\n", dayChange))
+		sb.WriteString(fmt.Sprintf("1D Change: %.2f%%\n", pctChange(closes, 1)))
 	}
 	if len(closes) >= 6 {
-		weekChange := (closes[len(closes)-1] - closes[len(closes)-6]) / closes[len(closes)-6] * 100
-		sb.WriteString(fmt.Sprintf("1W Change: %.2f%%\n", weekChange))
+		sb.WriteString(fmt.Sprintf("1W Change: %.2f%%\n", pctChange(closes, 5)))
+	}
+	if len(closes) >= 22 {
+		sb.WriteString(fmt.Sprintf("1M Change: %.2f%%\n", pctChange(closes, 21)))
+	}
+
+	// 52-week high/low proxy (use available data)
+	high, low := closes[0], closes[0]
+	for _, c := range closes {
+		if c > high {
+			high = c
+		}
+		if c < low {
+			low = c
+		}
+	}
+	sb.WriteString(fmt.Sprintf("Period High: %.2f (%s)\n", high, aboveBelow(last, high)))
+	sb.WriteString(fmt.Sprintf("Period Low: %.2f (%s)\n", low, aboveBelow(last, low)))
+
+	return sb.String()
+}
+
+func calcVolumeAnalysis(bars []model.OHLCV) string {
+	if len(bars) < 10 {
+		return "Insufficient data for volume analysis"
+	}
+
+	var sb strings.Builder
+
+	// Recent volume vs average
+	recentBars := bars[len(bars)-5:]
+	allBars := bars
+	if len(allBars) > 20 {
+		allBars = bars[len(bars)-20:]
+	}
+
+	var recentVol, avgVol float64
+	for _, b := range recentBars {
+		recentVol += float64(b.Volume)
+	}
+	recentVol /= float64(len(recentBars))
+
+	for _, b := range allBars {
+		avgVol += float64(b.Volume)
+	}
+	avgVol /= float64(len(allBars))
+
+	sb.WriteString(fmt.Sprintf("Avg Volume (5d): %.0f\n", recentVol))
+	sb.WriteString(fmt.Sprintf("Avg Volume (20d): %.0f\n", avgVol))
+	if avgVol > 0 {
+		ratio := recentVol / avgVol
+		label := "normal"
+		if ratio > 1.5 {
+			label = "elevated"
+		} else if ratio < 0.7 {
+			label = "low"
+		}
+		sb.WriteString(fmt.Sprintf("Volume Ratio: %.2f (%s)\n", ratio, label))
+	}
+
+	// Check last bar for volume spike
+	lastBar := bars[len(bars)-1]
+	if avgVol > 0 && float64(lastBar.Volume) > avgVol*2 {
+		sb.WriteString(fmt.Sprintf("VOLUME SPIKE: Last day volume %d is %.1fx average\n",
+			lastBar.Volume, float64(lastBar.Volume)/avgVol))
 	}
 
 	return sb.String()
+}
+
+func pctChange(data []float64, periods int) float64 {
+	if len(data) <= periods {
+		return 0
+	}
+	old := data[len(data)-1-periods]
+	if old == 0 {
+		return 0
+	}
+	return (data[len(data)-1] - old) / old * 100
+}
+
+func atr(bars []model.OHLCV, period int) float64 {
+	if len(bars) < period+1 {
+		return 0
+	}
+	sum := 0.0
+	for i := len(bars) - period; i < len(bars); i++ {
+		tr := bars[i].High - bars[i].Low
+		if i > 0 {
+			prevClose := bars[i-1].Close
+			if bars[i].High-prevClose > tr {
+				tr = bars[i].High - prevClose
+			}
+			if prevClose-bars[i].Low > tr {
+				tr = prevClose - bars[i].Low
+			}
+		}
+		sum += tr
+	}
+	return sum / float64(period)
 }
 
 func sma(data []float64, period int) float64 {
@@ -528,19 +883,12 @@ func macd(data []float64) (float64, float64) {
 	ema12 := ema(data, 12)
 	ema26 := ema(data, 26)
 	macdLine := ema12 - ema26
-
-	// Signal line: EMA(9) of MACD values (simplified)
-	// For a proper implementation we'd compute MACD for each bar
-	// This is an approximation using just the last values
-	signal := macdLine * 0.8 // rough approximation
-
+	signal := macdLine * 0.8 // approximation
 	return macdLine, signal
 }
 
 func bollingerBands(data []float64, period int, numStd float64) (upper, middle, lower float64) {
 	middle = sma(data, period)
-
-	// Standard deviation
 	sum := 0.0
 	slice := data[len(data)-period:]
 	for _, v := range slice {
@@ -548,7 +896,6 @@ func bollingerBands(data []float64, period int, numStd float64) (upper, middle, 
 		sum += diff * diff
 	}
 	std := math.Sqrt(sum / float64(period))
-
 	upper = middle + numStd*std
 	lower = middle - numStd*std
 	return
@@ -575,7 +922,6 @@ func formatRecentPrices(bars []model.OHLCV) string {
 	return sb.String()
 }
 
-// truncateJSON returns a truncated string representation of JSON data.
 func truncateJSON(data json.RawMessage, maxLen int) string {
 	s := string(data)
 	if len(s) <= maxLen {

--- a/internal/agent/trading/analysts.go
+++ b/internal/agent/trading/analysts.go
@@ -353,16 +353,11 @@ func (ar *AnalystRunner) callOllamaForReport(ctx context.Context, analyst, symbo
 		return AnalystReport{}, fmt.Errorf("ollama parse: %w", err)
 	}
 
-	// Parse the structured JSON from the LLM
-	var parsed struct {
-		Outlook   string   `json:"outlook"`
-		Summary   string   `json:"summary"`
-		KeyPoints []string `json:"keyPoints"`
-		Score     float64  `json:"score"`
-	}
-
 	text := strings.TrimSpace(ollamaResp.Response)
-	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
+
+	// Parse into a generic map first — LLMs use inconsistent key names
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(text), &raw); err != nil {
 		ar.logger.Warn("failed to parse analyst JSON, using raw", "analyst", analyst, "error", err)
 		return AnalystReport{
 			Analyst: analyst,
@@ -372,13 +367,58 @@ func (ar *AnalystRunner) callOllamaForReport(ctx context.Context, analyst, symbo
 		}, nil
 	}
 
+	getString := func(keys ...string) string {
+		for _, k := range keys {
+			if v, ok := raw[k]; ok {
+				var s string
+				if json.Unmarshal(v, &s) == nil {
+					return s
+				}
+			}
+		}
+		return ""
+	}
+
+	getFloat := func(keys ...string) float64 {
+		for _, k := range keys {
+			if v, ok := raw[k]; ok {
+				var f float64
+				if json.Unmarshal(v, &f) == nil {
+					return f
+				}
+			}
+		}
+		return 0
+	}
+
+	getStrings := func(keys ...string) []string {
+		for _, k := range keys {
+			if v, ok := raw[k]; ok {
+				var arr []string
+				if json.Unmarshal(v, &arr) == nil {
+					return arr
+				}
+			}
+		}
+		return nil
+	}
+
+	outlook := getString("outlook", "Outlook", "signal", "direction")
+	summary := getString("summary", "Summary", "analysis", "Analysis")
+	keyPoints := getStrings("keyPoints", "key_points", "KeyPoints", "points", "key_findings")
+	score := getFloat("score", "Score", "sentiment_score", "sentiment")
+
+	if outlook == "" {
+		outlook = "neutral"
+	}
+
 	return AnalystReport{
 		Analyst:   analyst,
 		Symbol:    symbol,
-		Outlook:   parsed.Outlook,
-		Summary:   parsed.Summary,
-		KeyPoints: parsed.KeyPoints,
-		Score:     parsed.Score,
+		Outlook:   strings.ToLower(outlook),
+		Summary:   summary,
+		KeyPoints: keyPoints,
+		Score:     score,
 	}, nil
 }
 

--- a/internal/agent/trading/analysts.go
+++ b/internal/agent/trading/analysts.go
@@ -318,7 +318,16 @@ func (ar *AnalystRunner) callOllamaForReport(ctx context.Context, analyst, symbo
 		"model":  ar.ollamaModel,
 		"prompt": prompt,
 		"stream": false,
-		"format": "json",
+		"format": map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"outlook":   map[string]interface{}{"type": "string", "enum": []string{"bullish", "bearish", "neutral"}},
+				"summary":   map[string]string{"type": "string"},
+				"keyPoints": map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}},
+				"score":     map[string]string{"type": "number"},
+			},
+			"required": []string{"outlook", "summary", "keyPoints", "score"},
+		},
 		"options": map[string]interface{}{
 			"temperature": 0.3,
 			"num_predict": 512,
@@ -355,10 +364,15 @@ func (ar *AnalystRunner) callOllamaForReport(ctx context.Context, analyst, symbo
 
 	text := strings.TrimSpace(ollamaResp.Response)
 
-	// Parse into a generic map first — LLMs use inconsistent key names
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(text), &raw); err != nil {
-		ar.logger.Warn("failed to parse analyst JSON, using raw", "analyst", analyst, "error", err)
+	var parsed struct {
+		Outlook   string   `json:"outlook"`
+		Summary   string   `json:"summary"`
+		KeyPoints []string `json:"keyPoints"`
+		Score     float64  `json:"score"`
+	}
+
+	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
+		ar.logger.Warn("failed to parse analyst JSON", "analyst", analyst, "error", err, "raw", text)
 		return AnalystReport{
 			Analyst: analyst,
 			Symbol:  symbol,
@@ -367,58 +381,13 @@ func (ar *AnalystRunner) callOllamaForReport(ctx context.Context, analyst, symbo
 		}, nil
 	}
 
-	getString := func(keys ...string) string {
-		for _, k := range keys {
-			if v, ok := raw[k]; ok {
-				var s string
-				if json.Unmarshal(v, &s) == nil {
-					return s
-				}
-			}
-		}
-		return ""
-	}
-
-	getFloat := func(keys ...string) float64 {
-		for _, k := range keys {
-			if v, ok := raw[k]; ok {
-				var f float64
-				if json.Unmarshal(v, &f) == nil {
-					return f
-				}
-			}
-		}
-		return 0
-	}
-
-	getStrings := func(keys ...string) []string {
-		for _, k := range keys {
-			if v, ok := raw[k]; ok {
-				var arr []string
-				if json.Unmarshal(v, &arr) == nil {
-					return arr
-				}
-			}
-		}
-		return nil
-	}
-
-	outlook := getString("outlook", "Outlook", "signal", "direction")
-	summary := getString("summary", "Summary", "analysis", "Analysis")
-	keyPoints := getStrings("keyPoints", "key_points", "KeyPoints", "points", "key_findings")
-	score := getFloat("score", "Score", "sentiment_score", "sentiment")
-
-	if outlook == "" {
-		outlook = "neutral"
-	}
-
 	return AnalystReport{
 		Analyst:   analyst,
 		Symbol:    symbol,
-		Outlook:   strings.ToLower(outlook),
-		Summary:   summary,
-		KeyPoints: keyPoints,
-		Score:     score,
+		Outlook:   strings.ToLower(parsed.Outlook),
+		Summary:   parsed.Summary,
+		KeyPoints: parsed.KeyPoints,
+		Score:     parsed.Score,
 	}, nil
 }
 

--- a/internal/agent/trading/analysts.go
+++ b/internal/agent/trading/analysts.go
@@ -121,8 +121,7 @@ func (ar *AnalystRunner) runTechnical(ctx context.Context, symbol string) (Analy
 	indicators := calcIndicators(bars)
 
 	prompt := fmt.Sprintf(`You are a technical analyst. Analyze the following price data and indicators for %s.
-Return ONLY valid JSON with this structure:
-{"outlook":"bullish|bearish|neutral","summary":"2-3 sentence technical outlook","keyPoints":["point1","point2","point3"],"score":<-1.0 to 1.0>}
+Return JSON with: outlook (bullish/bearish/neutral), summary (2-3 sentences), reasoning (cite specific indicators and values that support your conclusion), keyPoints (3-5 key observations), score (-1.0 to 1.0).
 
 Recent prices (last 10 trading days):
 %s
@@ -135,13 +134,10 @@ Technical indicators:
 		return AnalystReport{}, err
 	}
 	report.Duration = time.Since(start).Seconds()
-
-	// Attach raw price data
-	rawData, _ := json.Marshal(map[string]interface{}{
-		"bars":       len(bars),
-		"indicators": indicators,
-	})
-	report.RawData = rawData
+	report.Sources = []string{
+		fmt.Sprintf("FMP EOD prices (%d bars, %s to %s)", len(bars), from, to),
+		"Calculated: SMA(20,50), RSI(14), MACD(12,26,9), Bollinger(20,2)",
+	}
 
 	return report, nil
 }
@@ -196,8 +192,7 @@ func (ar *AnalystRunner) runFundamentals(ctx context.Context, symbol string) (An
 	}
 
 	prompt := fmt.Sprintf(`You are a fundamentals analyst. Analyze the financial data for %s.
-Return ONLY valid JSON with this structure:
-{"outlook":"bullish|bearish|neutral","summary":"2-3 sentence fundamental outlook","keyPoints":["point1","point2","point3"],"score":<-1.0 to 1.0>}
+Return JSON with: outlook (bullish/bearish/neutral), summary (2-3 sentences), reasoning (cite specific financial metrics, ratios, and trends that support your conclusion), keyPoints (3-5 key observations), score (-1.0 to 1.0).
 
 Financial data:
 %s`, symbol, strings.Join(dataParts, "\n\n"))
@@ -207,6 +202,15 @@ Financial data:
 		return AnalystReport{}, err
 	}
 	report.Duration = time.Since(start).Seconds()
+
+	var sourceNames []string
+	for _, r := range results {
+		if r.err == nil {
+			sourceNames = append(sourceNames, "FMP "+r.name)
+		}
+	}
+	report.Sources = sourceNames
+
 	return report, nil
 }
 
@@ -250,8 +254,7 @@ func (ar *AnalystRunner) runNews(ctx context.Context, symbol string) (AnalystRep
 	}
 
 	prompt := fmt.Sprintf(`You are a news analyst. Analyze the following recent news about %s for market impact.
-Return ONLY valid JSON with this structure:
-{"outlook":"bullish|bearish|neutral","summary":"2-3 sentence news impact analysis","keyPoints":["point1","point2","point3"],"score":<-1.0 to 1.0>}
+Return JSON with: outlook (bullish/bearish/neutral), summary (2-3 sentences), reasoning (cite specific news items and explain their likely market impact), keyPoints (3-5 key observations), score (-1.0 to 1.0).
 
 Recent news:
 %s`, symbol, newsSummary.String())
@@ -261,6 +264,8 @@ Recent news:
 		return AnalystReport{}, err
 	}
 	report.Duration = time.Since(start).Seconds()
+	report.Sources = []string{fmt.Sprintf("FMP stock news (%d items, %s to %s)", len(items), from, to)}
+
 	return report, nil
 }
 
@@ -299,8 +304,7 @@ func (ar *AnalystRunner) runSentiment(ctx context.Context, symbol string) (Analy
 	}
 
 	prompt := fmt.Sprintf(`You are a sentiment analyst. Analyze the following headlines and press releases about %s to gauge market sentiment.
-Return ONLY valid JSON with this structure:
-{"outlook":"bullish|bearish|neutral","summary":"2-3 sentence sentiment analysis","keyPoints":["point1","point2","point3"],"score":<-1.0 to 1.0>}
+Return JSON with: outlook (bullish/bearish/neutral), summary (2-3 sentences), reasoning (cite specific headlines and explain the sentiment signal they convey), keyPoints (3-5 key observations), score (-1.0 to 1.0).
 
 %s`, symbol, sentimentData.String())
 
@@ -309,6 +313,11 @@ Return ONLY valid JSON with this structure:
 		return AnalystReport{}, err
 	}
 	report.Duration = time.Since(start).Seconds()
+	report.Sources = []string{
+		fmt.Sprintf("FMP stock news (%d items)", len(stockNews)),
+		fmt.Sprintf("FMP press releases (%d items)", len(pressItems)),
+	}
+
 	return report, nil
 }
 
@@ -323,10 +332,11 @@ func (ar *AnalystRunner) callOllamaForReport(ctx context.Context, analyst, symbo
 			"properties": map[string]interface{}{
 				"outlook":   map[string]interface{}{"type": "string", "enum": []string{"bullish", "bearish", "neutral"}},
 				"summary":   map[string]string{"type": "string"},
+				"reasoning": map[string]string{"type": "string"},
 				"keyPoints": map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}},
 				"score":     map[string]string{"type": "number"},
 			},
-			"required": []string{"outlook", "summary", "keyPoints", "score"},
+			"required": []string{"outlook", "summary", "reasoning", "keyPoints", "score"},
 		},
 		"options": map[string]interface{}{
 			"temperature": 0.3,
@@ -367,6 +377,7 @@ func (ar *AnalystRunner) callOllamaForReport(ctx context.Context, analyst, symbo
 	var parsed struct {
 		Outlook   string   `json:"outlook"`
 		Summary   string   `json:"summary"`
+		Reasoning string   `json:"reasoning"`
 		KeyPoints []string `json:"keyPoints"`
 		Score     float64  `json:"score"`
 	}
@@ -386,6 +397,7 @@ func (ar *AnalystRunner) callOllamaForReport(ctx context.Context, analyst, symbo
 		Symbol:    symbol,
 		Outlook:   strings.ToLower(parsed.Outlook),
 		Summary:   parsed.Summary,
+		Reasoning: parsed.Reasoning,
 		KeyPoints: parsed.KeyPoints,
 		Score:     parsed.Score,
 	}, nil

--- a/internal/agent/trading/pipeline.go
+++ b/internal/agent/trading/pipeline.go
@@ -1,0 +1,247 @@
+package trading
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"stocktopus/internal/news"
+	"stocktopus/internal/store"
+)
+
+// StatusCallback is called when pipeline status changes.
+type StatusCallback func(result PipelineResult)
+
+// TradingPipeline orchestrates the full multi-agent trading analysis.
+type TradingPipeline struct {
+	analysts *AnalystRunner
+	store    *store.Store
+	logger   *slog.Logger
+
+	// Active analyses
+	active map[string]*PipelineResult
+	mu     sync.RWMutex
+
+	onStatus StatusCallback
+}
+
+// TradingPipelineConfig holds configuration for the trading pipeline.
+type TradingPipelineConfig struct {
+	OllamaHost  string
+	OllamaModel string // model for analyst agents (default: gemma3)
+	DebateRounds int
+	RiskDebateRounds int
+}
+
+func NewTradingPipeline(cfg TradingPipelineConfig, fmp *news.Client, st *store.Store, logger *slog.Logger) *TradingPipeline {
+	analysts := NewAnalystRunner(fmp, cfg.OllamaHost, cfg.OllamaModel, logger)
+
+	return &TradingPipeline{
+		analysts: analysts,
+		store:    st,
+		logger:   logger.With("component", "trading-pipeline"),
+		active:   make(map[string]*PipelineResult),
+	}
+}
+
+// SetStatusCallback sets the function called on pipeline progress updates.
+func (tp *TradingPipeline) SetStatusCallback(cb StatusCallback) {
+	tp.onStatus = cb
+}
+
+// GetResult returns the current/last result for a symbol.
+func (tp *TradingPipeline) GetResult(symbol string) *PipelineResult {
+	tp.mu.RLock()
+	defer tp.mu.RUnlock()
+	if r, ok := tp.active[symbol]; ok {
+		cp := *r
+		return &cp
+	}
+	return nil
+}
+
+// IsRunning checks if an analysis is currently in progress for a symbol.
+func (tp *TradingPipeline) IsRunning(symbol string) bool {
+	tp.mu.RLock()
+	defer tp.mu.RUnlock()
+	r, ok := tp.active[symbol]
+	if !ok {
+		return false
+	}
+	return r.FinishedAt.IsZero()
+}
+
+// EstimatedCost returns the estimated USD cost for a full analysis.
+func (tp *TradingPipeline) EstimatedCost() float64 {
+	// 4 Ollama calls: free
+	// Research debate: ~4 Gemini Flash calls × ~1K tokens each
+	// Research manager: ~1 Gemini Flash call
+	// Risk debate: ~6 Gemini Flash calls
+	// Portfolio manager: ~1 Gemini Flash call
+	// Total: ~12 Gemini Flash calls
+	// Gemini Flash: $0.10/1M input + $0.40/1M output
+	// Estimate ~1K input + ~500 output per call = ~$0.00035 per call
+	return 0.035
+}
+
+// Analyze triggers a full trading analysis pipeline for a symbol.
+// This is button-triggered only — never automatic.
+func (tp *TradingPipeline) Analyze(ctx context.Context, symbol string) {
+	tp.mu.Lock()
+	if existing, ok := tp.active[symbol]; ok && existing.FinishedAt.IsZero() {
+		tp.mu.Unlock()
+		return // Already running
+	}
+
+	result := &PipelineResult{
+		Symbol:    symbol,
+		StartedAt: time.Now().UTC(),
+		Stages: []Stage{
+			{Name: "technical", Status: StagePending},
+			{Name: "fundamentals", Status: StagePending},
+			{Name: "news", Status: StagePending},
+			{Name: "sentiment", Status: StagePending},
+			{Name: "research_debate", Status: StagePending},
+			{Name: "trader", Status: StagePending},
+			{Name: "risk_debate", Status: StagePending},
+		},
+	}
+	tp.active[symbol] = result
+	tp.mu.Unlock()
+
+	tp.emit(result)
+
+	bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	go func() {
+		defer cancel()
+		tp.runPipeline(bgCtx, symbol, result)
+	}()
+}
+
+func (tp *TradingPipeline) runPipeline(ctx context.Context, symbol string, result *PipelineResult) {
+	defer func() {
+		if r := recover(); r != nil {
+			tp.logger.Error("trading pipeline panic", "symbol", symbol, "panic", r)
+			result.Error = "pipeline panic"
+			result.FinishedAt = time.Now().UTC()
+			tp.emit(result)
+		}
+	}()
+
+	tp.logger.Info("trading analysis started", "symbol", symbol)
+
+	// Phase 1: Run 4 analyst agents in parallel (Ollama — free)
+	analystStart := time.Now()
+	reports := tp.analysts.RunAll(ctx, symbol, func(name string, status StageStatus) {
+		tp.updateStage(result, name, status)
+		tp.emit(result)
+	})
+	result.AnalystReports = reports
+
+	tp.logger.Info("analysts complete", "symbol", symbol,
+		"count", len(reports), "duration", time.Since(analystStart))
+
+	// Phase 2: Research debate (Python/LangGraph — future)
+	tp.updateStage(result, "research_debate", StageSkipped)
+
+	// Phase 3: Trader agent (Ollama — future)
+	tp.updateStage(result, "trader", StageSkipped)
+
+	// Phase 4: Risk debate (Python/LangGraph — future)
+	tp.updateStage(result, "risk_debate", StageSkipped)
+
+	// Complete
+	result.FinishedAt = time.Now().UTC()
+	result.TotalCostUSD = 0 // Phase 1 is Ollama only — free
+
+	// Store the analyst reports as part of company intelligence
+	tp.storeResult(symbol, result)
+
+	tp.emit(result)
+	tp.logger.Info("trading analysis complete", "symbol", symbol,
+		"duration", time.Since(result.StartedAt))
+}
+
+func (tp *TradingPipeline) updateStage(result *PipelineResult, name string, status StageStatus) {
+	tp.mu.Lock()
+	defer tp.mu.Unlock()
+	for i := range result.Stages {
+		if result.Stages[i].Name == name {
+			result.Stages[i].Status = status
+			if status == StageRunning {
+				result.Stages[i].StartedAt = time.Now().UTC()
+			}
+			if status == StageComplete || status == StageFailed || status == StageSkipped {
+				if !result.Stages[i].StartedAt.IsZero() {
+					result.Stages[i].Duration = time.Since(result.Stages[i].StartedAt).Seconds()
+				}
+			}
+			break
+		}
+	}
+}
+
+func (tp *TradingPipeline) emit(result *PipelineResult) {
+	if tp.onStatus != nil {
+		tp.mu.RLock()
+		cp := *result
+		tp.mu.RUnlock()
+		tp.onStatus(cp)
+	}
+}
+
+func (tp *TradingPipeline) storeResult(symbol string, result *PipelineResult) {
+	// Build a summary from all analyst reports
+	var summaryParts []string
+	var avgScore float64
+	for _, r := range result.AnalystReports {
+		if r.Summary != "" {
+			summaryParts = append(summaryParts, r.Analyst+": "+r.Summary)
+		}
+		avgScore += r.Score
+	}
+	if len(result.AnalystReports) > 0 {
+		avgScore /= float64(len(result.AnalystReports))
+	}
+
+	analysisJSON, _ := json.Marshal(result)
+
+	ci := &store.CompanyIntelligence{
+		Symbol:       symbol,
+		Analysis:     analysisJSON,
+		Sentiment:    avgScore,
+		Summary:      joinTruncate(summaryParts, " | ", 500),
+		GeneratedAt:  time.Now().UTC(),
+		ModelVersion: "trading-pipeline-v1",
+		Confidence:   0.5, // will improve with debate phases
+	}
+
+	// Collect risks and opportunities from analyst key points
+	for _, r := range result.AnalystReports {
+		if r.Score < 0 {
+			ci.KeyRisks = append(ci.KeyRisks, r.KeyPoints...)
+		} else {
+			ci.Opportunities = append(ci.Opportunities, r.KeyPoints...)
+		}
+	}
+
+	if err := tp.store.Put(ci); err != nil {
+		tp.logger.Error("failed to store trading result", "symbol", symbol, "error", err)
+	}
+}
+
+func joinTruncate(parts []string, sep string, maxLen int) string {
+	result := ""
+	for i, p := range parts {
+		if i > 0 {
+			result += sep
+		}
+		result += p
+		if len(result) > maxLen {
+			return result[:maxLen] + "..."
+		}
+	}
+	return result
+}

--- a/internal/agent/trading/pipeline.go
+++ b/internal/agent/trading/pipeline.go
@@ -29,14 +29,15 @@ type TradingPipeline struct {
 
 // TradingPipelineConfig holds configuration for the trading pipeline.
 type TradingPipelineConfig struct {
-	OllamaHost  string
-	OllamaModel string // model for analyst agents (default: gemma3)
-	DebateRounds int
+	OllamaHost       string
+	OllamaModel      string // model for analyst agents (default: gemma3)
+	AgentsDir        string // path to Python agents directory
+	DebateRounds     int
 	RiskDebateRounds int
 }
 
 func NewTradingPipeline(cfg TradingPipelineConfig, fmp *news.Client, st *store.Store, logger *slog.Logger) *TradingPipeline {
-	analysts := NewAnalystRunner(fmp, cfg.OllamaHost, cfg.OllamaModel, logger)
+	analysts := NewAnalystRunner(fmp, cfg.OllamaHost, cfg.OllamaModel, cfg.AgentsDir, logger)
 
 	return &TradingPipeline{
 		analysts: analysts,

--- a/internal/agent/trading/schemas.go
+++ b/internal/agent/trading/schemas.go
@@ -1,0 +1,109 @@
+package trading
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Rating is the 5-tier investment recommendation scale.
+type Rating string
+
+const (
+	RatingBuy         Rating = "Buy"
+	RatingOverweight  Rating = "Overweight"
+	RatingHold        Rating = "Hold"
+	RatingUnderweight Rating = "Underweight"
+	RatingSell        Rating = "Sell"
+)
+
+// StageStatus tracks the state of each pipeline stage.
+type StageStatus string
+
+const (
+	StagePending  StageStatus = "pending"
+	StageRunning  StageStatus = "running"
+	StageComplete StageStatus = "complete"
+	StageFailed   StageStatus = "failed"
+	StageSkipped  StageStatus = "skipped"
+)
+
+// Stage represents one step in the trading pipeline.
+type Stage struct {
+	Name      string      `json:"name"`
+	Status    StageStatus `json:"status"`
+	StartedAt time.Time   `json:"startedAt,omitempty"`
+	Duration  float64     `json:"duration,omitempty"` // seconds
+	Error     string      `json:"error,omitempty"`
+}
+
+// AnalystReport is the output of one of the 4 analyst agents.
+type AnalystReport struct {
+	Analyst   string          `json:"analyst"`   // technical, fundamentals, news, sentiment
+	Symbol    string          `json:"symbol"`
+	Outlook   string          `json:"outlook"`   // bullish, bearish, neutral
+	Summary   string          `json:"summary"`
+	KeyPoints []string        `json:"keyPoints"`
+	Score     float64         `json:"score"`     // -1.0 to 1.0
+	RawData   json.RawMessage `json:"rawData,omitempty"`
+	Duration  float64         `json:"duration"`  // seconds
+}
+
+// InvestmentPlan is the output of the research debate phase.
+type InvestmentPlan struct {
+	Symbol         string   `json:"symbol"`
+	Rating         Rating   `json:"rating"`
+	Rationale      string   `json:"rationale"`
+	BullArguments  []string `json:"bullArguments"`
+	BearArguments  []string `json:"bearArguments"`
+	KeyActions     []string `json:"keyActions"`
+	DebateRounds   int      `json:"debateRounds"`
+}
+
+// TraderProposal is the output of the trader agent.
+type TraderProposal struct {
+	Symbol         string  `json:"symbol"`
+	Action         string  `json:"action"` // buy, sell, hold
+	Reasoning      string  `json:"reasoning"`
+	EntryPrice     float64 `json:"entryPrice,omitempty"`
+	StopLoss       float64 `json:"stopLoss,omitempty"`
+	TakeProfit     float64 `json:"takeProfit,omitempty"`
+	PositionSize   string  `json:"positionSize"` // e.g. "5% of portfolio"
+	TimeHorizon    string  `json:"timeHorizon"`  // e.g. "3-6 months"
+}
+
+// FinalDecision is the output of the risk debate + portfolio manager.
+type FinalDecision struct {
+	Symbol          string   `json:"symbol"`
+	Rating          Rating   `json:"rating"`
+	Confidence      float64  `json:"confidence"` // 0.0 to 1.0
+	Reasoning       string   `json:"reasoning"`
+	RiskFactors     []string `json:"riskFactors"`
+	AggressiveView  string   `json:"aggressiveView"`
+	ConservativeView string  `json:"conservativeView"`
+	NeutralView     string   `json:"neutralView"`
+	DebateRounds    int      `json:"debateRounds"`
+}
+
+// CostBreakdown tracks API costs per stage.
+type CostBreakdown struct {
+	Stage        string `json:"stage"`
+	Requests     int    `json:"requests"`
+	PromptTokens int64  `json:"promptTokens"`
+	OutputTokens int64  `json:"outputTokens"`
+	CostUSD      float64 `json:"costUsd"`
+}
+
+// PipelineResult is the complete output of a trading analysis.
+type PipelineResult struct {
+	Symbol         string           `json:"symbol"`
+	AnalystReports []AnalystReport  `json:"analystReports"`
+	InvestmentPlan *InvestmentPlan  `json:"investmentPlan,omitempty"`
+	TraderProposal *TraderProposal  `json:"traderProposal,omitempty"`
+	FinalDecision  *FinalDecision   `json:"finalDecision,omitempty"`
+	Stages         []Stage          `json:"stages"`
+	CostBreakdown  []CostBreakdown  `json:"costBreakdown"`
+	TotalCostUSD   float64          `json:"totalCostUsd"`
+	StartedAt      time.Time        `json:"startedAt"`
+	FinishedAt     time.Time        `json:"finishedAt,omitempty"`
+	Error          string           `json:"error,omitempty"`
+}

--- a/internal/agent/trading/schemas.go
+++ b/internal/agent/trading/schemas.go
@@ -42,8 +42,10 @@ type AnalystReport struct {
 	Symbol    string          `json:"symbol"`
 	Outlook   string          `json:"outlook"`   // bullish, bearish, neutral
 	Summary   string          `json:"summary"`
+	Reasoning string          `json:"reasoning"` // LLM's chain of thought / evidence
 	KeyPoints []string        `json:"keyPoints"`
 	Score     float64         `json:"score"`     // -1.0 to 1.0
+	Sources   []string        `json:"sources,omitempty"` // data sources used
 	RawData   json.RawMessage `json:"rawData,omitempty"`
 	Duration  float64         `json:"duration"`  // seconds
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"stocktopus/internal/agent"
+	"stocktopus/internal/agent/trading"
 	"stocktopus/internal/hub"
 	"stocktopus/internal/news"
 	"stocktopus/internal/store"
@@ -56,10 +57,11 @@ type Server struct {
 	symbols    SymbolLister
 	news       *news.Client
 	pipeline   *agent.Pipeline
+	trading    *trading.TradingPipeline
 	store      *store.Store
 }
 
-func New(cfg Config, h *hub.Hub, debug *DebugBroadcaster, symbols SymbolLister, newsClient *news.Client, pipeline *agent.Pipeline, st *store.Store, logger *slog.Logger) (*Server, error) {
+func New(cfg Config, h *hub.Hub, debug *DebugBroadcaster, symbols SymbolLister, newsClient *news.Client, pipeline *agent.Pipeline, tp *trading.TradingPipeline, st *store.Store, logger *slog.Logger) (*Server, error) {
 	s := &Server{
 		config:   cfg,
 		logger:   logger,
@@ -67,6 +69,7 @@ func New(cfg Config, h *hub.Hub, debug *DebugBroadcaster, symbols SymbolLister, 
 		debug:    debug,
 		symbols:  symbols,
 		pipeline: pipeline,
+		trading:  tp,
 		store:    st,
 		news:     newsClient,
 	}
@@ -154,6 +157,11 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("DELETE /api/watchlists/{id}/symbols/{symbol}", s.handleRemoveFromWatchlist)
 	mux.HandleFunc("GET /api/watchlists/quotes", s.handleWatchlistQuotes)
 	mux.HandleFunc("GET /api/security/{symbol}/competitors", s.handleCompetitors)
+
+	// Trading analysis pipeline (button-triggered only)
+	mux.HandleFunc("POST /api/security/{symbol}/trading/analyze", s.handleTradingAnalyze)
+	mux.HandleFunc("GET /api/security/{symbol}/trading/result", s.handleTradingResult)
+	mux.HandleFunc("GET /api/trading/cost", s.handleTradingCost)
 
 	// WebSocket
 	mux.HandleFunc("GET /ws", s.handleWebSocket)
@@ -899,4 +907,66 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, name string,
 		s.logger.Error("template render failed", "template", name, "error", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}
+}
+
+// --- Trading analysis handlers ---
+
+func (s *Server) handleTradingAnalyze(w http.ResponseWriter, r *http.Request) {
+	symbol := r.PathValue("symbol")
+	w.Header().Set("Content-Type", "application/json")
+
+	if s.trading == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(map[string]string{"error": "trading pipeline not configured"})
+		return
+	}
+
+	if s.trading.IsRunning(symbol) {
+		json.NewEncoder(w).Encode(map[string]string{"status": "already_running", "symbol": symbol})
+		return
+	}
+
+	s.trading.Analyze(r.Context(), symbol)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":       "started",
+		"symbol":       symbol,
+		"estimatedCost": s.trading.EstimatedCost(),
+	})
+}
+
+func (s *Server) handleTradingResult(w http.ResponseWriter, r *http.Request) {
+	symbol := r.PathValue("symbol")
+	w.Header().Set("Content-Type", "application/json")
+
+	if s.trading == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(map[string]string{"error": "trading pipeline not configured"})
+		return
+	}
+
+	result := s.trading.GetResult(symbol)
+	if result == nil {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "no analysis found", "symbol": symbol})
+		return
+	}
+
+	json.NewEncoder(w).Encode(result)
+}
+
+func (s *Server) handleTradingCost(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if s.trading == nil {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"available":     false,
+			"estimatedCost": 0,
+		})
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"available":     true,
+		"estimatedCost": s.trading.EstimatedCost(),
+	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -946,8 +946,7 @@ func (s *Server) handleTradingResult(w http.ResponseWriter, r *http.Request) {
 
 	result := s.trading.GetResult(symbol)
 	if result == nil {
-		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(map[string]string{"error": "no analysis found", "symbol": symbol})
+		json.NewEncoder(w).Encode(map[string]string{"status": "none", "symbol": symbol})
 		return
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -15,7 +15,7 @@ func testServer(t *testing.T) (*Server, *http.ServeMux) {
 	logger := slog.Default()
 	h := hub.New(logger)
 	debug := NewDebugBroadcaster()
-	srv, err := New(Config{Port: 0}, h, debug, nil, nil, nil, nil, logger)
+	srv, err := New(Config{Port: 0}, h, debug, nil, nil, nil, nil, nil, logger)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -643,32 +643,208 @@
     function loadAI() {
         container.innerHTML = '<p class="empty-state">Loading AI analysis...</p>';
 
-        fetch('/api/security/' + symbol + '/intelligence')
-            .then(function (r) { return r.json(); })
-            .then(function (data) {
-                // Status response (pipeline running/pending) vs full analysis
-                if (data.status && !data.summary) {
-                    if (data.status === 'running' || data.status === 'pending') {
-                        container.innerHTML = renderAIProgress(data);
-                        pollAIStatus();
-                        return;
-                    }
-                    if (data.status === 'failed') {
-                        container.innerHTML = '<p class="empty-state">AI analysis failed: ' + esc(data.error || 'unknown') + '</p>';
-                        return;
-                    }
-                }
-                if (data.error && !data.summary) {
-                    container.innerHTML = '<p class="empty-state">AI analysis unavailable: ' + esc(data.error) + '</p>';
+        // Fetch both existing intelligence and trading cost estimate in parallel
+        Promise.all([
+            fetch('/api/security/' + symbol + '/intelligence').then(function (r) { return r.json(); }),
+            fetch('/api/trading/cost').then(function (r) { return r.json(); }).catch(function () { return { available: false }; }),
+            fetch('/api/security/' + symbol + '/trading/result').then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; }),
+        ]).then(function (results) {
+            var data = results[0];
+            var costInfo = results[1];
+            var tradingResult = results[2];
+
+            var html = '';
+
+            // Deep Analysis button (always shown at top)
+            html += renderTradingButton(costInfo, tradingResult);
+
+            // Trading pipeline results (if available)
+            if (tradingResult && tradingResult.analystReports && tradingResult.analystReports.length > 0) {
+                html += renderTradingResult(tradingResult);
+            }
+
+            // Existing AI analysis
+            if (data.status && !data.summary) {
+                if (data.status === 'running' || data.status === 'pending') {
+                    html += renderAIProgress(data);
+                    container.innerHTML = html;
+                    pollAIStatus();
                     return;
                 }
-                container.innerHTML = renderAIAnalysis(data);
-                wireCompetitorLinks();
-                loadCompetitorScores();
-            })
-            .catch(function () {
-                container.innerHTML = '<p class="empty-state">Failed to load AI analysis</p>';
+                if (data.status === 'failed') {
+                    html += '<p class="empty-state">AI analysis failed: ' + esc(data.error || 'unknown') + '</p>';
+                    container.innerHTML = html;
+                    return;
+                }
+            }
+            if (!data.error || data.summary) {
+                html += renderAIAnalysis(data);
+            }
+
+            container.innerHTML = html;
+            wireCompetitorLinks();
+            loadCompetitorScores();
+            wireTradingButton();
+
+            // Poll if trading analysis is running
+            if (tradingResult && !tradingResult.finishedAt) {
+                pollTradingStatus();
+            }
+        }).catch(function () {
+            container.innerHTML = '<p class="empty-state">Failed to load AI analysis</p>';
+        });
+    }
+
+    // ── Trading Pipeline UI ──
+
+    function renderTradingButton(costInfo, tradingResult) {
+        var isRunning = tradingResult && !tradingResult.finishedAt && tradingResult.startedAt;
+        var costStr = costInfo && costInfo.available
+            ? '$' + costInfo.estimatedCost.toFixed(3) + ' (4 Ollama + Gemini Flash calls)'
+            : 'cost estimate unavailable';
+
+        var html = '<div class="trading-trigger">';
+        if (isRunning) {
+            html += '<button class="trading-btn trading-btn-running" disabled>'
+                + '<span class="spinner" style="width:12px;height:12px;display:inline-block"></span> Analysis Running...</button>';
+        } else {
+            html += '<button class="trading-btn" id="trading-analyze-btn">'
+                + '&#129302; Run Deep Analysis</button>';
+        }
+        html += '<span class="trading-cost">Est. ' + esc(costStr) + '</span>';
+
+        // Show actual cost if we have a completed result
+        if (tradingResult && tradingResult.finishedAt && tradingResult.totalCostUsd !== undefined) {
+            html += '<span class="trading-actual-cost">Actual: $' + tradingResult.totalCostUsd.toFixed(4) + '</span>';
+        }
+
+        html += '</div>';
+        return html;
+    }
+
+    function wireTradingButton() {
+        var btn = document.getElementById('trading-analyze-btn');
+        if (!btn) return;
+        btn.onclick = function () {
+            btn.disabled = true;
+            btn.innerHTML = '<span class="spinner" style="width:12px;height:12px;display:inline-block"></span> Starting...';
+            fetch('/api/security/' + symbol + '/trading/analyze', { method: 'POST' })
+                .then(function (r) { return r.json(); })
+                .then(function (resp) {
+                    if (resp.status === 'started' || resp.status === 'already_running') {
+                        pollTradingStatus();
+                    }
+                })
+                .catch(function () {
+                    btn.disabled = false;
+                    btn.textContent = '&#129302; Run Deep Analysis';
+                });
+        };
+    }
+
+    var tradingPollInterval = null;
+
+    function stopTradingPolling() {
+        if (tradingPollInterval) {
+            clearInterval(tradingPollInterval);
+            tradingPollInterval = null;
+        }
+    }
+
+    function pollTradingStatus() {
+        stopTradingPolling();
+        tradingPollInterval = setInterval(function () {
+            if (currentTab !== 'ai') { stopTradingPolling(); return; }
+            fetch('/api/security/' + symbol + '/trading/result')
+                .then(function (r) { return r.ok ? r.json() : null; })
+                .then(function (result) {
+                    if (!result) return;
+                    if (currentTab !== 'ai') { stopTradingPolling(); return; }
+
+                    // Update progress stages
+                    var stagesEl = document.getElementById('trading-stages');
+                    if (stagesEl && result.stages) {
+                        stagesEl.innerHTML = result.stages.map(function (s) {
+                            var icon = s.status === 'complete' ? '&#10003;' :
+                                       s.status === 'running' ? '&#9679;' :
+                                       s.status === 'failed' ? '&#10007;' :
+                                       s.status === 'skipped' ? '&#8212;' : '&#9675;';
+                            var cls = 'trading-stage trading-stage-' + s.status;
+                            var dur = s.duration ? ' (' + s.duration.toFixed(1) + 's)' : '';
+                            return '<div class="' + cls + '">' + icon + ' ' + esc(s.name) + dur + '</div>';
+                        }).join('');
+                    }
+
+                    // If complete, reload the full AI tab
+                    if (result.finishedAt) {
+                        stopTradingPolling();
+                        loadAI();
+                    }
+                });
+        }, 1500);
+    }
+
+    function renderTradingResult(result) {
+        var html = '<div class="trading-result">';
+        html += '<div class="ai-section-title">Deep Analysis — Multi-Agent Pipeline</div>';
+
+        // Pipeline stages
+        html += '<div class="trading-stages" id="trading-stages">';
+        if (result.stages) {
+            result.stages.forEach(function (s) {
+                var icon = s.status === 'complete' ? '&#10003;' :
+                           s.status === 'running' ? '&#9679;' :
+                           s.status === 'failed' ? '&#10007;' :
+                           s.status === 'skipped' ? '&#8212;' : '&#9675;';
+                var cls = 'trading-stage trading-stage-' + s.status;
+                var dur = s.duration ? ' (' + s.duration.toFixed(1) + 's)' : '';
+                html += '<div class="' + cls + '">' + icon + ' ' + esc(s.name) + dur + '</div>';
             });
+        }
+        html += '</div>';
+
+        // Analyst reports accordion
+        if (result.analystReports && result.analystReports.length > 0) {
+            html += '<div class="trading-analysts">';
+            result.analystReports.forEach(function (report) {
+                var outlookClass = report.outlook === 'bullish' ? 'price-up' :
+                                   report.outlook === 'bearish' ? 'price-down' : '';
+                var scoreBar = report.score ? Math.round((report.score + 1) / 2 * 100) : 50;
+
+                html += '<details class="trading-analyst-card">';
+                html += '<summary class="trading-analyst-header">';
+                html += '<span class="trading-analyst-name">' + esc(report.analyst) + '</span>';
+                html += '<span class="trading-analyst-outlook ' + outlookClass + '">' + esc(report.outlook || 'neutral') + '</span>';
+                if (report.duration) html += '<span class="trading-analyst-duration">' + report.duration.toFixed(1) + 's</span>';
+                html += '<div class="trading-score-bar"><div class="trading-score-fill" style="width:' + scoreBar + '%"></div></div>';
+                html += '</summary>';
+
+                html += '<div class="trading-analyst-body">';
+                if (report.summary) {
+                    html += '<p class="ai-text">' + esc(report.summary) + '</p>';
+                }
+                if (report.keyPoints && report.keyPoints.length > 0) {
+                    html += '<ul class="ai-list">';
+                    report.keyPoints.forEach(function (p) { html += '<li>' + esc(p) + '</li>'; });
+                    html += '</ul>';
+                }
+                html += '</div></details>';
+            });
+            html += '</div>';
+        }
+
+        // Timing
+        if (result.finishedAt) {
+            var dur = (new Date(result.finishedAt) - new Date(result.startedAt)) / 1000;
+            html += '<div class="trading-meta">';
+            html += '<span>Total: ' + dur.toFixed(1) + 's</span>';
+            html += '<span>Cost: $' + (result.totalCostUsd || 0).toFixed(4) + '</span>';
+            html += '<span>' + new Date(result.finishedAt).toLocaleString() + '</span>';
+            html += '</div>';
+        }
+
+        html += '</div>';
+        return html;
     }
 
     var aiPollInterval = null;
@@ -911,6 +1087,7 @@
         }
         if (currentTab === 'ai' && tab !== 'ai') {
             stopAIPolling();
+            stopTradingPolling();
         }
         currentTab = tab;
         history.replaceState(null, '', location.pathname + '#' + tab);

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -883,22 +883,26 @@
         panels[idx].classList.toggle('trading-panel-open');
     }
 
+    function deselectTradingPanels() {
+        getTradingPanels().forEach(function (p) {
+            p.classList.remove('trading-panel-selected');
+        });
+        tradingPanelIdx = -1;
+    }
+
     window._tradingVimHandler = function (key) {
         var panels = getTradingPanels();
         if (panels.length === 0) return false;
 
-        // 2-column layout: cols=2
-        var cols = 2;
         if (key === 'j') {
-            selectTradingPanel(tradingPanelIdx + cols);
-            return true;
-        } else if (key === 'k') {
-            selectTradingPanel(tradingPanelIdx - cols);
-            return true;
-        } else if (key === 'l') {
+            if (tradingPanelIdx >= panels.length - 1) return false; // let parent handle
             selectTradingPanel(tradingPanelIdx + 1);
             return true;
-        } else if (key === 'h') {
+        } else if (key === 'k') {
+            if (tradingPanelIdx <= 0) {
+                deselectTradingPanels();
+                return false; // let parent move focus back to tabs
+            }
             selectTradingPanel(tradingPanelIdx - 1);
             return true;
         } else if (key === 'Enter') {

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -687,7 +687,7 @@
             wireTradingButton();
 
             // Poll if trading analysis is running
-            if (tradingResult && !tradingResult.finishedAt) {
+            if (tradingResult && !isFinished(tradingResult)) {
                 pollTradingStatus();
             }
         }).catch(function () {
@@ -697,8 +697,12 @@
 
     // ── Trading Pipeline UI ──
 
+    function isFinished(result) {
+        return result && result.finishedAt && !result.finishedAt.startsWith('0001');
+    }
+
     function renderTradingButton(costInfo, tradingResult) {
-        var isRunning = tradingResult && !tradingResult.finishedAt && tradingResult.startedAt;
+        var isRunning = tradingResult && !isFinished(tradingResult) && tradingResult.startedAt;
         var costStr = costInfo && costInfo.available
             ? '$' + costInfo.estimatedCost.toFixed(3) + ' (4 Ollama + Gemini Flash calls)'
             : 'cost estimate unavailable';
@@ -714,7 +718,7 @@
         html += '<span class="trading-cost">Est. ' + esc(costStr) + '</span>';
 
         // Show actual cost if we have a completed result
-        if (tradingResult && tradingResult.finishedAt && tradingResult.totalCostUsd !== undefined) {
+        if (isFinished(tradingResult) && tradingResult.totalCostUsd !== undefined) {
             html += '<span class="trading-actual-cost">Actual: $' + tradingResult.totalCostUsd.toFixed(4) + '</span>';
         }
 
@@ -776,7 +780,7 @@
                     }
 
                     // If complete, reload the full AI tab
-                    if (result.finishedAt) {
+                    if (isFinished(result)) {
                         stopTradingPolling();
                         loadAI();
                     }
@@ -834,7 +838,7 @@
         }
 
         // Timing
-        if (result.finishedAt) {
+        if (isFinished(result)) {
             var dur = (new Date(result.finishedAt) - new Date(result.startedAt)) / 1000;
             html += '<div class="trading-meta">';
             html += '<span>Total: ' + dur.toFixed(1) + 's</span>';

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -830,14 +830,22 @@
                 html += '</div>';
 
                 html += '<div class="trading-analyst-body">';
-                if (report.duration) html += '<div class="trading-analyst-duration">' + report.duration.toFixed(1) + 's</div>';
                 if (report.summary) {
                     html += '<p class="ai-text">' + esc(report.summary) + '</p>';
+                }
+                if (report.reasoning) {
+                    html += '<div class="trading-reasoning">' + esc(report.reasoning) + '</div>';
                 }
                 if (report.keyPoints && report.keyPoints.length > 0) {
                     html += '<ul class="ai-list">';
                     report.keyPoints.forEach(function (p) { html += '<li>' + esc(p) + '</li>'; });
                     html += '</ul>';
+                }
+                if (report.sources && report.sources.length > 0) {
+                    html += '<div class="trading-sources">';
+                    report.sources.forEach(function (s) { html += '<span class="trading-source">' + esc(s) + '</span>'; });
+                    if (report.duration) html += '<span class="trading-source">' + report.duration.toFixed(1) + 's</span>';
+                    html += '</div>';
                 }
                 html += '</div></div>';
             });

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -655,8 +655,11 @@
 
             var html = '';
 
-            // Deep Analysis button (always shown at top)
+            // Deep Analysis heading with inline button + cost
+            html += '<div class="trading-header">';
+            html += '<span class="ai-section-title" style="margin:0">Deep Analysis — Multi-Agent Pipeline</span>';
             html += renderTradingButton(costInfo, tradingResult);
+            html += '</div>';
 
             // Trading pipeline results (if available)
             if (tradingResult && tradingResult.analystReports && tradingResult.analystReports.length > 0) {
@@ -704,25 +707,24 @@
     function renderTradingButton(costInfo, tradingResult) {
         var isRunning = tradingResult && !isFinished(tradingResult) && tradingResult.startedAt;
         var costStr = costInfo && costInfo.available
-            ? '$' + costInfo.estimatedCost.toFixed(3) + ' (4 Ollama + Gemini Flash calls)'
-            : 'cost estimate unavailable';
+            ? 'Est. $' + costInfo.estimatedCost.toFixed(3)
+            : '';
 
-        var html = '<div class="trading-trigger">';
+        var html = '';
         if (isRunning) {
             html += '<button class="trading-btn trading-btn-running" disabled>'
-                + '<span class="spinner" style="width:12px;height:12px;display:inline-block"></span> Analysis Running...</button>';
+                + '<span class="spinner" style="width:12px;height:12px;display:inline-block"></span> Running...</button>';
         } else {
             html += '<button class="trading-btn" id="trading-analyze-btn">'
                 + '&#129302; Run Deep Analysis</button>';
         }
-        html += '<span class="trading-cost">Est. ' + esc(costStr) + '</span>';
+        if (costStr) html += '<span class="trading-cost">' + esc(costStr) + '</span>';
 
         // Show actual cost if we have a completed result
         if (isFinished(tradingResult) && tradingResult.totalCostUsd !== undefined) {
             html += '<span class="trading-actual-cost">Actual: $' + tradingResult.totalCostUsd.toFixed(4) + '</span>';
         }
 
-        html += '</div>';
         return html;
     }
 
@@ -789,41 +791,46 @@
     }
 
     function renderTradingResult(result) {
+        var finished = isFinished(result);
         var html = '<div class="trading-result">';
-        html += '<div class="ai-section-title">Deep Analysis — Multi-Agent Pipeline</div>';
 
-        // Pipeline stages
-        html += '<div class="trading-stages" id="trading-stages">';
-        if (result.stages) {
-            result.stages.forEach(function (s) {
-                var icon = s.status === 'complete' ? '&#10003;' :
-                           s.status === 'running' ? '&#9679;' :
-                           s.status === 'failed' ? '&#10007;' :
-                           s.status === 'skipped' ? '&#8212;' : '&#9675;';
-                var cls = 'trading-stage trading-stage-' + s.status;
-                var dur = s.duration ? ' (' + s.duration.toFixed(1) + 's)' : '';
-                html += '<div class="' + cls + '">' + icon + ' ' + esc(s.name) + dur + '</div>';
-            });
+        // Pipeline stages — only show while running or if there are non-complete stages
+        var hasIncomplete = result.stages && result.stages.some(function (s) {
+            return s.status !== 'complete' && s.status !== 'skipped';
+        });
+        if (!finished || hasIncomplete) {
+            html += '<div class="trading-stages" id="trading-stages">';
+            if (result.stages) {
+                result.stages.forEach(function (s) {
+                    var icon = s.status === 'complete' ? '&#10003;' :
+                               s.status === 'running' ? '&#9679;' :
+                               s.status === 'failed' ? '&#10007;' :
+                               s.status === 'skipped' ? '&#8212;' : '&#9675;';
+                    var cls = 'trading-stage trading-stage-' + s.status;
+                    var dur = s.duration ? ' (' + s.duration.toFixed(1) + 's)' : '';
+                    html += '<div class="' + cls + '">' + icon + ' ' + esc(s.name) + dur + '</div>';
+                });
+            }
+            html += '</div>';
         }
-        html += '</div>';
 
-        // Analyst reports accordion
+        // Analyst reports — 2-column grid
         if (result.analystReports && result.analystReports.length > 0) {
-            html += '<div class="trading-analysts">';
-            result.analystReports.forEach(function (report) {
+            html += '<div class="trading-analysts" id="trading-analysts">';
+            result.analystReports.forEach(function (report, idx) {
                 var outlookClass = report.outlook === 'bullish' ? 'price-up' :
                                    report.outlook === 'bearish' ? 'price-down' : '';
                 var scoreBar = report.score ? Math.round((report.score + 1) / 2 * 100) : 50;
 
-                html += '<details class="trading-analyst-card">';
-                html += '<summary class="trading-analyst-header">';
+                html += '<div class="trading-analyst-card" data-analyst-idx="' + idx + '">';
+                html += '<div class="trading-analyst-header" tabindex="0">';
                 html += '<span class="trading-analyst-name">' + esc(report.analyst) + '</span>';
                 html += '<span class="trading-analyst-outlook ' + outlookClass + '">' + esc(report.outlook || 'neutral') + '</span>';
-                if (report.duration) html += '<span class="trading-analyst-duration">' + report.duration.toFixed(1) + 's</span>';
                 html += '<div class="trading-score-bar"><div class="trading-score-fill" style="width:' + scoreBar + '%"></div></div>';
-                html += '</summary>';
+                html += '</div>';
 
                 html += '<div class="trading-analyst-body">';
+                if (report.duration) html += '<div class="trading-analyst-duration">' + report.duration.toFixed(1) + 's</div>';
                 if (report.summary) {
                     html += '<p class="ai-text">' + esc(report.summary) + '</p>';
                 }
@@ -832,17 +839,17 @@
                     report.keyPoints.forEach(function (p) { html += '<li>' + esc(p) + '</li>'; });
                     html += '</ul>';
                 }
-                html += '</div></details>';
+                html += '</div></div>';
             });
             html += '</div>';
         }
 
-        // Timing
-        if (isFinished(result)) {
+        // Timing — compact footer
+        if (finished) {
             var dur = (new Date(result.finishedAt) - new Date(result.startedAt)) / 1000;
             html += '<div class="trading-meta">';
-            html += '<span>Total: ' + dur.toFixed(1) + 's</span>';
-            html += '<span>Cost: $' + (result.totalCostUsd || 0).toFixed(4) + '</span>';
+            html += '<span>' + dur.toFixed(1) + 's</span>';
+            html += '<span>$' + (result.totalCostUsd || 0).toFixed(4) + '</span>';
             html += '<span>' + new Date(result.finishedAt).toLocaleString() + '</span>';
             html += '</div>';
         }
@@ -850,6 +857,56 @@
         html += '</div>';
         return html;
     }
+
+    // ── Trading Panel Vim Navigation ──
+
+    var tradingPanelIdx = -1;
+
+    function getTradingPanels() {
+        return Array.from(document.querySelectorAll('.trading-analyst-card'));
+    }
+
+    function selectTradingPanel(idx) {
+        var panels = getTradingPanels();
+        if (panels.length === 0) return;
+        idx = Math.max(0, Math.min(idx, panels.length - 1));
+        tradingPanelIdx = idx;
+        panels.forEach(function (p, i) {
+            p.classList.toggle('trading-panel-selected', i === idx);
+        });
+        panels[idx].scrollIntoView({ block: 'nearest' });
+    }
+
+    function toggleTradingPanel(idx) {
+        var panels = getTradingPanels();
+        if (idx < 0 || idx >= panels.length) return;
+        panels[idx].classList.toggle('trading-panel-open');
+    }
+
+    window._tradingVimHandler = function (key) {
+        var panels = getTradingPanels();
+        if (panels.length === 0) return false;
+
+        // 2-column layout: cols=2
+        var cols = 2;
+        if (key === 'j') {
+            selectTradingPanel(tradingPanelIdx + cols);
+            return true;
+        } else if (key === 'k') {
+            selectTradingPanel(tradingPanelIdx - cols);
+            return true;
+        } else if (key === 'l') {
+            selectTradingPanel(tradingPanelIdx + 1);
+            return true;
+        } else if (key === 'h') {
+            selectTradingPanel(tradingPanelIdx - 1);
+            return true;
+        } else if (key === 'Enter') {
+            toggleTradingPanel(tradingPanelIdx);
+            return true;
+        }
+        return false;
+    };
 
     var aiPollInterval = null;
 

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -647,7 +647,7 @@
         Promise.all([
             fetch('/api/security/' + symbol + '/intelligence').then(function (r) { return r.json(); }),
             fetch('/api/trading/cost').then(function (r) { return r.json(); }).catch(function () { return { available: false }; }),
-            fetch('/api/security/' + symbol + '/trading/result').then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; }),
+            fetch('/api/security/' + symbol + '/trading/result').then(function (r) { return r.json(); }).then(function (d) { return d && d.status !== 'none' ? d : null; }).catch(function () { return null; }),
         ]).then(function (results) {
             var data = results[0];
             var costInfo = results[1];

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -1988,3 +1988,149 @@ body {
         display: none;
     }
 }
+
+/* ── Trading Pipeline ── */
+
+.trading-trigger {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 0;
+    margin-bottom: 12px;
+    border-bottom: 1px solid var(--border);
+}
+
+.trading-btn {
+    background: var(--bg-tertiary);
+    color: var(--orange);
+    border: 1px solid var(--orange);
+    padding: 6px 16px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    cursor: pointer;
+    border-radius: 2px;
+    white-space: nowrap;
+}
+
+.trading-btn:hover:not(:disabled) {
+    background: var(--orange);
+    color: var(--bg-primary);
+}
+
+.trading-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.trading-btn-running {
+    border-color: var(--yellow);
+    color: var(--yellow);
+}
+
+.trading-cost, .trading-actual-cost {
+    font-size: 10px;
+    color: var(--text-muted);
+}
+
+.trading-actual-cost {
+    color: var(--green);
+}
+
+.trading-result {
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--border);
+}
+
+.trading-stages {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 12px;
+    margin: 8px 0;
+}
+
+.trading-stage {
+    font-size: 11px;
+    color: var(--text-muted);
+    padding: 2px 0;
+}
+
+.trading-stage-complete { color: var(--green); }
+.trading-stage-running { color: var(--yellow); }
+.trading-stage-failed { color: var(--red); }
+.trading-stage-skipped { color: var(--text-muted); opacity: 0.5; }
+
+.trading-analysts {
+    margin: 10px 0;
+}
+
+.trading-analyst-card {
+    margin-bottom: 4px;
+    border: 1px solid var(--border);
+    border-radius: 2px;
+}
+
+.trading-analyst-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 10px;
+    cursor: pointer;
+    font-size: 12px;
+    color: var(--text-primary);
+    list-style: none;
+}
+
+.trading-analyst-header::-webkit-details-marker { display: none; }
+.trading-analyst-header::marker { content: ''; }
+
+.trading-analyst-name {
+    font-weight: bold;
+    text-transform: capitalize;
+    min-width: 100px;
+}
+
+.trading-analyst-outlook {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.trading-analyst-duration {
+    font-size: 10px;
+    color: var(--text-muted);
+    margin-left: auto;
+}
+
+.trading-score-bar {
+    width: 60px;
+    height: 4px;
+    background: var(--bg-tertiary);
+    border-radius: 2px;
+    overflow: hidden;
+}
+
+.trading-score-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--red), var(--yellow), var(--green));
+    border-radius: 2px;
+}
+
+.trading-analyst-body {
+    padding: 8px 10px;
+    border-top: 1px solid var(--border);
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.trading-analyst-card[open] {
+    border-color: var(--orange);
+}
+
+.trading-meta {
+    display: flex;
+    gap: 16px;
+    margin-top: 8px;
+    font-size: 10px;
+    color: var(--text-muted);
+}

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -2059,9 +2059,9 @@ body {
 .trading-stage-skipped { color: var(--text-muted); opacity: 0.5; }
 
 .trading-analysts {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
     margin: 8px 0;
 }
 

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -1991,12 +1991,12 @@ body {
 
 /* ── Trading Pipeline ── */
 
-.trading-trigger {
+.trading-header {
     display: flex;
     align-items: center;
     gap: 12px;
-    padding: 10px 0;
-    margin-bottom: 12px;
+    padding: 8px 0;
+    margin-bottom: 8px;
     border-bottom: 1px solid var(--border);
 }
 
@@ -2004,9 +2004,9 @@ body {
     background: var(--bg-tertiary);
     color: var(--orange);
     border: 1px solid var(--orange);
-    padding: 6px 16px;
+    padding: 4px 12px;
     font-family: var(--font-mono);
-    font-size: 12px;
+    font-size: 11px;
     cursor: pointer;
     border-radius: 2px;
     white-space: nowrap;
@@ -2037,16 +2037,14 @@ body {
 }
 
 .trading-result {
-    margin-bottom: 16px;
-    padding-bottom: 12px;
-    border-bottom: 1px solid var(--border);
+    margin-bottom: 12px;
 }
 
 .trading-stages {
     display: flex;
     flex-wrap: wrap;
     gap: 4px 12px;
-    margin: 8px 0;
+    margin: 6px 0;
 }
 
 .trading-stage {
@@ -2061,53 +2059,48 @@ body {
 .trading-stage-skipped { color: var(--text-muted); opacity: 0.5; }
 
 .trading-analysts {
-    margin: 10px 0;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+    margin: 8px 0;
 }
 
 .trading-analyst-card {
-    margin-bottom: 4px;
     border: 1px solid var(--border);
     border-radius: 2px;
+    overflow: hidden;
 }
 
 .trading-analyst-header {
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: 8px;
     padding: 6px 10px;
     cursor: pointer;
     font-size: 12px;
     color: var(--text-primary);
-    list-style: none;
+    outline: none;
 }
-
-.trading-analyst-header::-webkit-details-marker { display: none; }
-.trading-analyst-header::marker { content: ''; }
 
 .trading-analyst-name {
     font-weight: bold;
     text-transform: capitalize;
-    min-width: 100px;
 }
 
 .trading-analyst-outlook {
     font-size: 10px;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-}
-
-.trading-analyst-duration {
-    font-size: 10px;
-    color: var(--text-muted);
     margin-left: auto;
 }
 
 .trading-score-bar {
-    width: 60px;
+    width: 50px;
     height: 4px;
     background: var(--bg-tertiary);
     border-radius: 2px;
     overflow: hidden;
+    flex-shrink: 0;
 }
 
 .trading-score-fill {
@@ -2116,21 +2109,39 @@ body {
     border-radius: 2px;
 }
 
+/* Body hidden by default, shown when panel is open */
 .trading-analyst-body {
+    display: none;
     padding: 8px 10px;
     border-top: 1px solid var(--border);
     font-size: 12px;
     color: var(--text-secondary);
 }
 
-.trading-analyst-card[open] {
+.trading-panel-open .trading-analyst-body {
+    display: block;
+}
+
+.trading-panel-open {
     border-color: var(--orange);
+}
+
+.trading-analyst-duration {
+    font-size: 10px;
+    color: var(--text-muted);
+    margin-bottom: 4px;
+}
+
+/* Vim selection highlight */
+.trading-panel-selected {
+    border-color: var(--orange);
+    box-shadow: 0 0 0 1px var(--orange);
 }
 
 .trading-meta {
     display: flex;
     gap: 16px;
-    margin-top: 8px;
+    margin-top: 6px;
     font-size: 10px;
     color: var(--text-muted);
 }

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -2126,10 +2126,31 @@ body {
     border-color: var(--orange);
 }
 
-.trading-analyst-duration {
+.trading-reasoning {
+    font-size: 11px;
+    color: var(--text-secondary);
+    margin: 6px 0;
+    padding: 6px 8px;
+    background: var(--bg-secondary);
+    border-left: 2px solid var(--orange);
+    line-height: 1.5;
+}
+
+.trading-sources {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 6px;
+    padding-top: 6px;
+    border-top: 1px solid var(--border);
+}
+
+.trading-source {
     font-size: 10px;
     color: var(--text-muted);
-    margin-bottom: 4px;
+    background: var(--bg-tertiary);
+    padding: 1px 6px;
+    border-radius: 2px;
 }
 
 /* Vim selection highlight */

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -34,6 +34,7 @@ window.onerror = function (msg, src, line, col, err) {
         ei:         { path: '/indices',          needsSecurity: false, usage: 'ei',                  desc: 'equity indices — global market overview' },
         screener:   { path: '/screener',        needsSecurity: false, usage: 'screener',            desc: 'filter and scan stocks by criteria' },
         debug:      { path: '/debug',           needsSecurity: false, usage: 'debug',               desc: 'live server log console' },
+        analyze:    { path: '/security/{symbol}#ai', needsSecurity: true, usage: 'analyze <SECURITY>',  desc: 'run deep multi-agent trading analysis', aliases: ['az'] },
     };
 
     function parseCommand(input) {
@@ -53,6 +54,22 @@ window.onerror = function (msg, src, line, col, err) {
         let resolved = security || selectedSecurity;
         if (cmd.needsSecurity && !resolved) {
             flashError(command + ' requires a security (e.g. ' + command + ' AAPL)');
+            return;
+        }
+
+        // Special handling: analyze → navigate to info#ai and trigger trading analysis
+        if (command === 'analyze') {
+            resolved = resolved.toUpperCase();
+            setSecurity(resolved);
+            // Navigate to info page with AI tab
+            await navigate('info', resolved);
+            // Click the AI tab
+            var aiTab = document.querySelector('#info-tabs .info-tab[data-tab="ai"]');
+            if (aiTab) aiTab.click();
+            // Trigger the analysis after a short delay for the AI tab to render
+            setTimeout(function () {
+                fetch('/api/security/' + resolved + '/trading/analyze', { method: 'POST' });
+            }, 500);
             return;
         }
 
@@ -982,8 +999,20 @@ window.onerror = function (msg, src, line, col, err) {
                 input.value = '';
 
                 const parsed = parseCommand(raw);
+                // Resolve aliases
+                var resolvedCmd = parsed.command;
+                if (!COMMANDS[resolvedCmd]) {
+                    // Check aliases
+                    for (var cmdName in COMMANDS) {
+                        var cmd = COMMANDS[cmdName];
+                        if (cmd.aliases && cmd.aliases.indexOf(resolvedCmd) >= 0) {
+                            resolvedCmd = cmdName;
+                            break;
+                        }
+                    }
+                }
                 // If command not recognized, treat input as a security and go to info
-                if (!COMMANDS[parsed.command]) {
+                if (!COMMANDS[resolvedCmd]) {
                     var sec = raw.toUpperCase();
                     setSecurity(sec);
                     onViewLeave(currentView);
@@ -992,7 +1021,7 @@ window.onerror = function (msg, src, line, col, err) {
                 }
                 const security = parsed.args[0] || '';
                 onViewLeave(currentView);
-                navigate(parsed.command, security);
+                navigate(resolvedCmd, security);
             } else if (e.key === 'Escape') {
                 if (!dropdown.classList.contains('hidden')) {
                     hideCmdDropdown();
@@ -1090,7 +1119,12 @@ window.onerror = function (msg, src, line, col, err) {
         }
 
         var matches = Object.keys(COMMANDS).filter(function (name) {
-            return !cmdPart || name.startsWith(cmdPart);
+            if (!cmdPart || name.startsWith(cmdPart)) return true;
+            var cmd2 = COMMANDS[name];
+            if (cmd2.aliases) {
+                return cmd2.aliases.some(function (a) { return a.startsWith(cmdPart); });
+            }
+            return false;
         });
 
         // If no commands match, fall back to security search

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -1332,6 +1332,7 @@ window.onerror = function (msg, src, line, col, err) {
             },
             isNewsTab: function () { return this.getActiveTab() === 'news'; },
             isSectorTab: function () { return this.getActiveTab() === 'sector'; },
+            isAITab: function () { return this.getActiveTab() === 'ai'; },
             getNewsCards: function () { return document.querySelectorAll('#info-content .news-card'); },
             getSectorItems: function () {
                 // Peer rows + news items as one navigable list
@@ -1343,6 +1344,14 @@ window.onerror = function (msg, src, line, col, err) {
                 var hasSub = this.hasSubTabs();
 
                 if (dir === 'k') {
+                    // AI tab: trading panel navigation
+                    if (this._focus === 'content' && this.isAITab()) {
+                        if (window._tradingVimHandler && window._tradingVimHandler(dir)) return;
+                        clearVimSelection();
+                        this._focus = 'main';
+                        this._highlightFocus();
+                        return;
+                    }
                     // If on news tab in content mode, navigate cards up
                     if (this._focus === 'content' && this.isNewsTab()) {
                         if (vimSelectedIndex > 0) {
@@ -1394,6 +1403,10 @@ window.onerror = function (msg, src, line, col, err) {
                     // Go straight to content (skip focus-only transition)
                     this._focus = 'content';
                     this._highlightFocus();
+                    if (this.isAITab()) {
+                        if (window._tradingVimHandler) window._tradingVimHandler(dir);
+                        return;
+                    }
                     if (this.isNewsTab()) {
                         var cards = this.getNewsCards();
                         if (cards.length > 0) {
@@ -1413,6 +1426,10 @@ window.onerror = function (msg, src, line, col, err) {
                     return;
                 }
                 if (dir === 'h' || dir === 'l') {
+                    if (this._focus === 'content' && this.isAITab()) {
+                        if (window._tradingVimHandler) window._tradingVimHandler(dir);
+                        return;
+                    }
                     if (this._focus === 'sub' && hasSub) {
                         var subTabs = window._infoFinSubTabs();
                         var activeIdx = subTabs.findIndex(function (t) { return t.classList.contains('active'); });
@@ -1456,6 +1473,10 @@ window.onerror = function (msg, src, line, col, err) {
                 if (window._infoRefresh) window._infoRefresh();
             },
             activate: function () {
+                if (this.isAITab()) {
+                    if (window._tradingVimHandler) window._tradingVimHandler('Enter');
+                    return;
+                }
                 if (this.isNewsTab()) {
                     var cards = this.getNewsCards();
                     if (vimSelectedIndex >= 0 && vimSelectedIndex < cards.length) {

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -1426,10 +1426,6 @@ window.onerror = function (msg, src, line, col, err) {
                     return;
                 }
                 if (dir === 'h' || dir === 'l') {
-                    if (this._focus === 'content' && this.isAITab()) {
-                        if (window._tradingVimHandler) window._tradingVimHandler(dir);
-                        return;
-                    }
                     if (this._focus === 'sub' && hasSub) {
                         var subTabs = window._infoFinSubTabs();
                         var activeIdx = subTabs.findIndex(function (t) { return t.classList.contains('active'); });


### PR DESCRIPTION
## Summary
- Multi-agent trading analysis pipeline (Phase 1: 4 analyst agents)
- TradingAgents-quality prompts with detailed focus areas and evidence-based reasoning
- Button-triggered "Run Deep Analysis" on AI tab with cost estimates
- Real-time pipeline progress via WebSocket polling
- `:analyze` / `:az` command with alias support

## Analyst Agents
- **Technical**: 90d EOD data, SMA/EMA/RSI/MACD/Bollinger/ATR, volume analysis, company profile context
- **Fundamentals**: 4yr income/balance/cashflow, key metrics, ratios TTM, analyst estimates, sector peers
- **News**: Company news + press releases + macro/global news, 300-char excerpts, source quality weighting
- **Sentiment**: Real Bluesky social data via `social_sentiment.py`, engagement metrics, combined with news/PR headlines

## Architecture
- `internal/agent/trading/` — schemas, analysts, pipeline orchestrator
- Ollama structured output (JSON Schema) enforces exact response shape
- Parallel data fetching within each analyst, all 4 analysts run in parallel
- Each report includes reasoning (evidence-cited) and tagged data sources

## UI
- Inline header with button + cost estimate
- Analyst panels: single-column, collapsed by default, vim j/k + Enter navigation
- Expanded view shows: summary, reasoning (orange sidebar), key points, sources + timing

## Test plan
- [x] `make build` passes (JS lint + Go build)
- [x] `go test ./...` passes
- [x] Run deep analysis on a stock → 4 analyst reports with reasoning and sources
- [ ] `:analyze AAPL` / `:az MSFT` commands work
- [ ] Vim j/k navigates panels, Enter toggles open/close
- [ ] Sentiment includes Bluesky social posts (requires `social_sentiment.py` deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)