### PR TITLE
feat: quick-wins bundle + UX bug fixes

### DIFF
--- a/internal/agent/trading/people.go
+++ b/internal/agent/trading/people.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"stocktopus/internal/store"
@@ -24,6 +25,9 @@ type PeopleExtractor struct {
 	store       *store.Store
 	client      *http.Client
 	logger      *slog.Logger
+
+	mu       sync.Mutex
+	inFlight map[string]bool // symbol → currently being processed
 }
 
 func NewPeopleExtractor(ollamaHost, ollamaModel, agentsDir string, st *store.Store, logger *slog.Logger) *PeopleExtractor {
@@ -40,42 +44,50 @@ func NewPeopleExtractor(ollamaHost, ollamaModel, agentsDir string, st *store.Sto
 		store:       st,
 		client:      &http.Client{Timeout: 60 * time.Second},
 		logger:      logger.With("component", "people-extractor"),
+		inFlight:    make(map[string]bool),
 	}
 }
 
 // ExtractFromFilings processes recent 8-K filings for a symbol and extracts key people changes.
+// Per-symbol singleflight: a second concurrent call for the same symbol returns immediately.
+// Filings are marked processed_for_people=1 after each attempt so 8-Ks with no personnel changes
+// aren't re-LLM'd on every refresh.
 func (pe *PeopleExtractor) ExtractFromFilings(ctx context.Context, symbol string) {
-	filings, err := pe.store.GetSECFilings(symbol, "8-K", 10)
+	pe.mu.Lock()
+	if pe.inFlight[symbol] {
+		pe.mu.Unlock()
+		return
+	}
+	pe.inFlight[symbol] = true
+	pe.mu.Unlock()
+	defer func() {
+		pe.mu.Lock()
+		delete(pe.inFlight, symbol)
+		pe.mu.Unlock()
+	}()
+
+	filings, err := pe.store.GetUnprocessedSECFilings(symbol, "8-K", 10)
 	if err != nil || len(filings) == 0 {
 		return
 	}
 
-	// Check if we already have people for this symbol (avoid re-processing)
-	existing, _ := pe.store.GetKeyPeople(symbol)
-	existingSources := make(map[string]bool)
-	for _, p := range existing {
-		existingSources[p.Source] = true
-	}
-
 	for _, f := range filings {
-		if existingSources[f.Link] {
-			continue // Already processed this filing
-		}
-
 		pe.logger.Debug("extracting people from 8-K", "symbol", symbol, "date", f.FilingDate)
 
 		// Fetch filing text via fetch_article.py (--no-llm flag for text only)
 		text := pe.fetchFilingText(ctx, f.Link)
-		if text == "" {
-			continue
+		if text != "" {
+			people := pe.extractPeople(ctx, symbol, text, f.FilingDate, f.Link)
+			for _, p := range people {
+				if err := pe.store.PutKeyPerson(p); err != nil {
+					pe.logger.Debug("failed to store person", "error", err)
+				}
+			}
 		}
 
-		// Extract people via Ollama
-		people := pe.extractPeople(ctx, symbol, text, f.FilingDate, f.Link)
-		for _, p := range people {
-			if err := pe.store.PutKeyPerson(p); err != nil {
-				pe.logger.Debug("failed to store person", "error", err)
-			}
+		// Mark processed regardless of result so we don't re-run on filings with no personnel events.
+		if err := pe.store.MarkSECFilingProcessedForPeople(symbol, f.Link); err != nil {
+			pe.logger.Debug("failed to mark filing processed", "link", f.Link, "error", err)
 		}
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,6 +3,8 @@ package server
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -48,30 +50,32 @@ type SymbolLister interface {
 }
 
 type Server struct {
-	config     Config
-	logger     *slog.Logger
-	httpServer *http.Server
-	pages      map[string]*template.Template
-	hub        *hub.Hub
-	debug      *DebugBroadcaster
-	symbols    SymbolLister
-	news       *news.Client
-	pipeline   *agent.Pipeline
-	trading    *trading.TradingPipeline
-	store      *store.Store
+	config       Config
+	logger       *slog.Logger
+	httpServer   *http.Server
+	pages        map[string]*template.Template
+	hub          *hub.Hub
+	debug        *DebugBroadcaster
+	symbols      SymbolLister
+	news         *news.Client
+	pipeline     *agent.Pipeline
+	trading      *trading.TradingPipeline
+	store        *store.Store
+	assetVersion string
 }
 
 func New(cfg Config, h *hub.Hub, debug *DebugBroadcaster, symbols SymbolLister, newsClient *news.Client, pipeline *agent.Pipeline, tp *trading.TradingPipeline, st *store.Store, logger *slog.Logger) (*Server, error) {
 	s := &Server{
-		config:   cfg,
-		logger:   logger,
-		hub:      h,
-		debug:    debug,
-		symbols:  symbols,
-		pipeline: pipeline,
-		trading:  tp,
-		store:    st,
-		news:     newsClient,
+		config:       cfg,
+		logger:       logger,
+		hub:          h,
+		debug:        debug,
+		symbols:      symbols,
+		pipeline:     pipeline,
+		trading:      tp,
+		store:        st,
+		news:         newsClient,
+		assetVersion: newAssetVersion(),
 	}
 
 	if err := s.loadTemplates(); err != nil {
@@ -907,11 +911,28 @@ func (s *Server) renderPage(w http.ResponseWriter, r *http.Request, name string,
 		templateName = "content"
 	}
 
+	if data == nil {
+		data = map[string]any{}
+	}
+	data["AssetVersion"] = s.assetVersion
+
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := t.ExecuteTemplate(w, templateName, data); err != nil {
 		s.logger.Error("template render failed", "template", name, "error", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}
+}
+
+// newAssetVersion returns a random hex string used as a per-process cache buster
+// for static assets. A new value is generated each time the server starts so
+// browsers refetch CSS/JS after a deploy without us having to bump versions by hand.
+func newAssetVersion() string {
+	var b [6]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Fall back to start-time nanos — still unique per process start.
+		return strconv.FormatInt(time.Now().UnixNano(), 36)
+	}
+	return hex.EncodeToString(b[:])
 }
 
 // --- SEC filing handlers ---

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -40,12 +40,34 @@
     var allCandles = [], allVolumes = [];
 
     // ── Chart ──
+    var MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+    function tickFormatter(time, tickType) {
+        // time may be a BusinessDay object {year, month, day}, "YYYY-MM-DD" string, or unix seconds
+        var d;
+        if (time && typeof time === 'object' && time.year != null) {
+            d = new Date(Date.UTC(time.year, time.month - 1, time.day));
+        } else if (typeof time === 'number') {
+            d = new Date(time * 1000);
+        } else if (typeof time === 'string') {
+            d = new Date(time + 'T00:00:00Z');
+        } else {
+            return '';
+        }
+        if (isNaN(d.getTime())) return '';
+        var T = LightweightCharts.TickMarkType || {};
+        if (tickType === T.Year) return String(d.getUTCFullYear());
+        if (tickType === T.Month) return MONTHS[d.getUTCMonth()] + ' ' + String(d.getUTCFullYear()).slice(2);
+        if (tickType === T.DayOfMonth) return MONTHS[d.getUTCMonth()] + ' ' + d.getUTCDate();
+        if (tickType === T.Time) return ('0' + d.getUTCHours()).slice(-2) + ':' + ('0' + d.getUTCMinutes()).slice(-2);
+        if (tickType === T.TimeWithSeconds) return ('0' + d.getUTCHours()).slice(-2) + ':' + ('0' + d.getUTCMinutes()).slice(-2) + ':' + ('0' + d.getUTCSeconds()).slice(-2);
+        return MONTHS[d.getUTCMonth()] + ' ' + d.getUTCDate();
+    }
     var chart = LightweightCharts.createChart(container, {
         layout: { background: { color: '#0a0a0a' }, textColor: '#888888', fontFamily: "'SF Mono','Consolas',monospace", fontSize: 11 },
         grid: { vertLines: { color: '#1a1a1a' }, horzLines: { color: '#1a1a1a' } },
         crosshair: { mode: LightweightCharts.CrosshairMode.Normal, vertLine: { color: '#555', style: 2 }, horzLine: { color: '#555', style: 2 } },
         rightPriceScale: { borderColor: '#2a2a2a', scaleMargins: { top: 0.05, bottom: 0.25 } },
-        timeScale: { borderColor: '#2a2a2a', timeVisible: true, secondsVisible: false, rightOffset: 5 },
+        timeScale: { borderColor: '#2a2a2a', timeVisible: true, secondsVisible: false, rightOffset: 5, tickMarkFormatter: tickFormatter },
         handleScroll: true, handleScale: true,
     });
     window._stocktopusChart = chart;
@@ -386,7 +408,18 @@
         if (!candle) { tooltipEl.classList.add('hidden'); return; }
 
         var chgClass = candle.close >= candle.open ? 'price-up' : 'price-down';
+        var dateStr = '';
+        if (param.time) {
+            if (typeof param.time === 'object' && param.time.year != null) {
+                dateStr = MONTHS[param.time.month - 1] + ' ' + param.time.day + ' ' + param.time.year;
+            } else if (typeof param.time === 'number') {
+                var d = new Date(param.time * 1000);
+                dateStr = MONTHS[d.getUTCMonth()] + ' ' + d.getUTCDate() + ' ' +
+                    ('0' + d.getUTCHours()).slice(-2) + ':' + ('0' + d.getUTCMinutes()).slice(-2);
+            }
+        }
         tooltipEl.innerHTML = '<span class="tt-sym">' + symbol + '</span>'
+            + (dateStr ? ' <span class="tt-date">' + dateStr + '</span>' : '')
             + ' O:<span class="' + chgClass + '">' + candle.open.toFixed(2) + '</span>'
             + ' H:<span class="' + chgClass + '">' + candle.high.toFixed(2) + '</span>'
             + ' L:<span class="' + chgClass + '">' + candle.low.toFixed(2) + '</span>'

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -314,6 +314,24 @@
         if (n >= 0 && n < tabs.length) tabs[n].click();
     };
 
+    // Financial table row vim navigation
+    var finSelectedRow = -1;
+    window._finGetRows = function () { return Array.from(document.querySelectorAll('.fin-row')); };
+    window._finGetSelectedRow = function () { return finSelectedRow; };
+    window._finSelectRow = function (idx) {
+        var rows = window._finGetRows();
+        if (rows.length === 0) return;
+        idx = Math.max(0, Math.min(idx, rows.length - 1));
+        finSelectedRow = idx;
+        rows.forEach(function (r, i) { r.classList.toggle('vim-selected', i === idx); });
+        rows[idx].scrollIntoView({ block: 'nearest' });
+    };
+    window._finClearRow = function () {
+        var rows = window._finGetRows();
+        rows.forEach(function (r) { r.classList.remove('vim-selected'); });
+        finSelectedRow = -1;
+    };
+
     var FIN_EXPLAINERS = {
         income: 'The income statement shows how much money the company earned (revenue), what it cost to earn it (expenses), and what was left over (profit). Read top to bottom: revenue minus costs gives gross profit, minus operating expenses gives operating income, minus interest and taxes gives net income. Margins show these as percentages of revenue — higher is better, and the trend matters more than the absolute number.',
         balance: 'The balance sheet is a snapshot of what the company owns (assets), what it owes (liabilities), and what belongs to shareholders (equity) at a single point in time. Assets = Liabilities + Equity, always. Key things to watch: cash vs debt levels, whether goodwill is a large portion of assets (acquisition risk), and whether equity is growing or shrinking over time.',
@@ -400,11 +418,13 @@
                 });
                 html += '</tr></thead><tbody>';
 
-                rows.forEach(function (row) {
+                rows.forEach(function (row, rowIdx) {
                     var field = row[0].toLowerCase().replace(/[^a-z0-9]/g, '-');
                     var tip = HELP[field] ? '<span class="help-tip hidden">' + esc(HELP[field]) + '</span>' : '';
                     var format = row[2] || '';
-                    html += '<tr><td class="fin-label">' + row[0] + tip + '</td>';
+                    var finKey = format === 'calc' ? row[3] + '/' + row[4] : (row[1] || '');
+                    html += '<tr class="fin-row" data-fin-idx="' + rowIdx + '" data-fin-key="' + esc(finKey) + '" data-fin-label="' + esc(row[0]) + '" data-fin-format="' + format + '">';
+                    html += '<td class="fin-label">' + row[0] + tip + '</td>';
                     data.forEach(function (d) {
                         var val;
                         if (format === 'calc') {
@@ -421,6 +441,7 @@
 
                 html += '</tbody></table>';
                 tc.innerHTML = html;
+                finSelectedRow = -1;
             })
             .catch(function () {
                 tc.innerHTML = '<p class="empty-state">Failed to load financials</p>';
@@ -711,11 +732,16 @@
     var secFormTypes = null; // cached form type reference data
     var secFilter = ''; // current form type filter
     var secSelectedRow = -1;
+    var secView = 'filings'; // 'filings' | 'people'
 
     function loadSEC() {
+        // Preserve vim sub-tab focus highlight across re-renders
+        var prevSubTabs = document.getElementById('sec-filters');
+        var hadFocus = !!(prevSubTabs && prevSubTabs.classList.contains('tab-row-focused'));
+
         container.innerHTML = '<p class="empty-state">Loading SEC filings...</p>';
 
-        // Fetch form types (once) and filings in parallel
+        // Fetch form types (once), filings, and key people in parallel
         var formTypesP = secFormTypes
             ? Promise.resolve(secFormTypes)
             : fetch('/api/sec-form-types').then(function (r) { return r.json(); }).then(function (types) { secFormTypes = types; return types; });
@@ -723,15 +749,17 @@
         Promise.all([
             formTypesP,
             fetch('/api/security/' + symbol + '/sec-filings').then(function (r) { return r.json(); }),
+            fetch('/api/security/' + symbol + '/key-people').then(function (r) { return r.json(); }).catch(function () { return []; }),
         ]).then(function (results) {
             var types = results[0] || [];
             var filings = results[1] || [];
+            var people = results[2] || [];
 
             // Build type lookup
             var typeMap = {};
             types.forEach(function (t) { typeMap[t.formType] = t; });
 
-            // Category filters
+            // Category filters (only meaningful in filings view)
             var categories = [
                 { key: '', label: 'All' },
                 { key: 'periodic', label: 'Periodic' },
@@ -743,50 +771,69 @@
 
             var html = '<div class="sec-view">';
 
-            // Filter badges
+            // Sub-tab row: category filters + Key People view switcher
             html += '<div class="info-sub-tabs" id="sec-filters">';
             categories.forEach(function (cat) {
-                var active = secFilter === cat.key ? ' active' : '';
-                html += '<button class="info-sub-tab' + active + '" data-cat="' + cat.key + '">' + cat.label + '</button>';
+                var active = (secView === 'filings' && secFilter === cat.key) ? ' active' : '';
+                html += '<button class="info-sub-tab' + active + '" data-cat="' + cat.key + '" data-view="filings">' + cat.label + '</button>';
             });
+            // Visual separator + Key People view switcher
+            html += '<span class="sec-tab-sep" aria-hidden="true">|</span>';
+            var peopleActive = secView === 'people' ? ' active' : '';
+            html += '<button class="info-sub-tab' + peopleActive + '" data-view="people">Key People</button>';
             html += '</div>';
 
-            // Filing count
-            var filteredFilings = secFilter ? filings.filter(function (f) {
-                var t = typeMap[f.formType];
-                return t && t.category === secFilter;
-            }) : filings;
+            if (secView === 'filings') {
+                // Filing count
+                var filteredFilings = secFilter ? filings.filter(function (f) {
+                    var t = typeMap[f.formType];
+                    return t && t.category === secFilter;
+                }) : filings;
 
-            html += '<div class="sec-count">' + filteredFilings.length + ' filings</div>';
+                html += '<div class="sec-count">' + filteredFilings.length + ' filings</div>';
 
-            // Filings table
-            if (filteredFilings.length > 0) {
-                html += '<table class="fin-table sec-table" id="sec-table"><thead><tr>';
-                html += '<th>Date</th><th>Form</th><th>Description</th><th>Link</th>';
-                html += '</tr></thead><tbody>';
-                filteredFilings.forEach(function (f, idx) {
-                    var t = typeMap[f.formType] || {};
-                    var catClass = 'sec-cat-' + (t.category || 'other');
-                    var date = (f.filingDate || '').substring(0, 10);
-                    html += '<tr class="sec-row" data-idx="' + idx + '" data-link="' + esc(f.link || f.finalLink || '') + '">';
-                    html += '<td class="sec-date">' + date + '</td>';
-                    html += '<td><span class="sec-badge ' + catClass + '">' + esc(f.formType) + '</span></td>';
-                    html += '<td class="sec-desc">' + esc(t.title || f.formType) + '</td>';
-                    html += '<td><a href="' + esc(f.link || f.finalLink || '') + '" target="_blank" rel="noopener" class="sec-link">&#8599;</a></td>';
-                    html += '</tr>';
-                });
-                html += '</tbody></table>';
+                if (filteredFilings.length > 0) {
+                    html += '<table class="fin-table sec-table" id="sec-table"><thead><tr>';
+                    html += '<th>Date</th><th>Form</th><th>Description</th><th>Link</th>';
+                    html += '</tr></thead><tbody>';
+                    filteredFilings.forEach(function (f, idx) {
+                        var t = typeMap[f.formType] || {};
+                        var catClass = 'sec-cat-' + (t.category || 'other');
+                        var date = (f.filingDate || '').substring(0, 10);
+                        html += '<tr class="sec-row" data-idx="' + idx + '" data-link="' + esc(f.link || f.finalLink || '') + '">';
+                        html += '<td class="sec-date">' + date + '</td>';
+                        html += '<td><span class="sec-badge ' + catClass + '">' + esc(f.formType) + '</span></td>';
+                        html += '<td class="sec-desc">' + esc(t.title || f.formType) + '</td>';
+                        html += '<td><a href="' + esc(f.link || f.finalLink || '') + '" target="_blank" rel="noopener" class="sec-link">&#8599;</a></td>';
+                        html += '</tr>';
+                    });
+                    html += '</tbody></table>';
+                } else {
+                    html += '<p class="empty-state">No filings found' + (secFilter ? ' for this category' : '') + '</p>';
+                }
             } else {
-                html += '<p class="empty-state">No filings found' + (secFilter ? ' for this category' : '') + '</p>';
+                // Key People timeline
+                html += renderKeyPeopleTimeline(people);
             }
 
             html += '</div>';
             container.innerHTML = html;
 
-            // Wire filter buttons
+            // Restore vim sub-tab focus highlight across re-renders
+            if (hadFocus) {
+                var newSubTabs = document.getElementById('sec-filters');
+                if (newSubTabs) newSubTabs.classList.add('tab-row-focused');
+            }
+
+            // Wire sub-tab buttons
             container.querySelectorAll('#sec-filters .info-sub-tab').forEach(function (btn) {
                 btn.onclick = function () {
-                    secFilter = btn.dataset.cat;
+                    if (btn.dataset.view === 'people') {
+                        secView = 'people';
+                    } else {
+                        secView = 'filings';
+                        secFilter = btn.dataset.cat;
+                    }
                     secSelectedRow = -1;
                     loadSEC();
                 };
@@ -796,8 +843,35 @@
         });
     }
 
-    // Expose for vim
-    window._secGetRows = function () { return Array.from(document.querySelectorAll('.sec-row')); };
+    function renderKeyPeopleTimeline(people) {
+        if (!people || people.length === 0) {
+            return '<p class="empty-state">No executive changes recorded yet. Key people are extracted from 8-K filings as they arrive.</p>';
+        }
+        // Sort newest first
+        people.sort(function (a, b) { return (b.eventDate || '').localeCompare(a.eventDate || ''); });
+
+        var html = '<div class="sec-count">' + people.length + ' executive change' + (people.length === 1 ? '' : 's') + '</div>';
+        html += '<ul class="kp-timeline">';
+        people.forEach(function (p, idx) {
+            var date = (p.eventDate || '').substring(0, 10) || '—';
+            var evt = (p.eventType || '').toLowerCase();
+            var evtClass = 'kp-event-' + (evt || 'other');
+            html += '<li class="kp-row" data-idx="' + idx + '" data-link="' + esc(p.source || '') + '">';
+            html += '<span class="kp-date">' + esc(date) + '</span>';
+            html += '<span class="kp-event ' + evtClass + '">' + esc(p.eventType || 'change') + '</span>';
+            html += '<span class="kp-name">' + esc(p.name || '—') + '</span>';
+            html += '<span class="kp-title">' + esc(p.title || '') + '</span>';
+            if (p.source) {
+                html += '<a class="kp-link" href="' + esc(p.source) + '" target="_blank" rel="noopener">&#8599;</a>';
+            }
+            html += '</li>';
+        });
+        html += '</ul>';
+        return html;
+    }
+
+    // Expose for vim — sec-row in filings view, kp-row in key-people view
+    window._secGetRows = function () { return Array.from(document.querySelectorAll('.sec-row, .kp-row')); };
     window._secGetSelectedRow = function () { return secSelectedRow; };
     window._secSelectRow = function (idx) {
         var rows = window._secGetRows();
@@ -818,6 +892,7 @@
         var cats = ['', 'periodic', 'event', 'ownership', 'proxy', 'registration'];
         var idx = cats.indexOf(secFilter);
         secFilter = cats[(idx + 1) % cats.length];
+        secView = 'filings';
         secSelectedRow = -1;
         loadSEC();
     };
@@ -840,7 +915,7 @@
             var html = '';
 
             // Deep Analysis heading with inline button + cost
-            html += '<div class="trading-header">';
+            html += '<div class="trading-header trading-vim-item" data-trading-vim="btn" tabindex="0">';
             html += '<span class="ai-section-title" style="margin:0">Deep Analysis — Multi-Agent Pipeline</span>';
             html += renderTradingButton(costInfo, tradingResult);
             html += '</div>';
@@ -960,8 +1035,7 @@
                                        s.status === 'failed' ? '&#10007;' :
                                        s.status === 'skipped' ? '&#8212;' : '&#9675;';
                             var cls = 'trading-stage trading-stage-' + s.status;
-                            var dur = s.duration ? ' (' + s.duration.toFixed(1) + 's)' : '';
-                            return '<div class="' + cls + '">' + icon + ' ' + esc(s.name) + dur + '</div>';
+                            return '<div class="' + cls + '">' + icon + ' ' + esc(s.name) + '</div>';
                         }).join('');
                     }
 
@@ -991,8 +1065,7 @@
                                s.status === 'failed' ? '&#10007;' :
                                s.status === 'skipped' ? '&#8212;' : '&#9675;';
                     var cls = 'trading-stage trading-stage-' + s.status;
-                    var dur = s.duration ? ' (' + s.duration.toFixed(1) + 's)' : '';
-                    html += '<div class="' + cls + '">' + icon + ' ' + esc(s.name) + dur + '</div>';
+                    html += '<div class="' + cls + '">' + icon + ' ' + esc(s.name) + '</div>';
                 });
             }
             html += '</div>';
@@ -1006,7 +1079,7 @@
                                    report.outlook === 'bearish' ? 'price-down' : '';
                 var scoreBar = report.score ? Math.round((report.score + 1) / 2 * 100) : 50;
 
-                html += '<div class="trading-analyst-card" data-analyst-idx="' + idx + '">';
+                html += '<div class="trading-analyst-card trading-vim-item" data-analyst-idx="' + idx + '">';
                 html += '<div class="trading-analyst-header" tabindex="0">';
                 html += '<span class="trading-analyst-name">' + esc(report.analyst) + '</span>';
                 html += '<span class="trading-analyst-outlook ' + outlookClass + '">' + esc(report.outlook || 'neutral') + '</span>';
@@ -1028,7 +1101,6 @@
                 if (report.sources && report.sources.length > 0) {
                     html += '<div class="trading-sources">';
                     report.sources.forEach(function (s) { html += '<span class="trading-source">' + esc(s) + '</span>'; });
-                    if (report.duration) html += '<span class="trading-source">' + report.duration.toFixed(1) + 's</span>';
                     html += '</div>';
                 }
                 html += '</div></div>';
@@ -1040,7 +1112,7 @@
         if (result.investmentPlan && result.investmentPlan.rating) {
             var plan = result.investmentPlan;
             var ratingClass = 'rating-' + plan.rating.toLowerCase();
-            html += '<div class="trading-analyst-card trading-plan-card" data-analyst-idx="plan">';
+            html += '<div class="trading-analyst-card trading-plan-card trading-vim-item" data-analyst-idx="plan">';
             html += '<div class="trading-analyst-header" tabindex="0">';
             html += '<span class="trading-analyst-name">Research Verdict</span>';
             html += '<span class="trading-rating ' + ratingClass + '">' + esc(plan.rating) + '</span>';
@@ -1087,11 +1159,9 @@
             html += '</div></div>'; // close trading-analyst-body + trading-analyst-card
         }
 
-        // Timing — compact footer
+        // Footer — cost + timestamp
         if (finished) {
-            var dur = (new Date(result.finishedAt) - new Date(result.startedAt)) / 1000;
             html += '<div class="trading-meta">';
-            html += '<span>' + dur.toFixed(1) + 's</span>';
             html += '<span>$' + (result.totalCostUsd || 0).toFixed(4) + '</span>';
             html += '<span>' + new Date(result.finishedAt).toLocaleString() + '</span>';
             html += '</div>';
@@ -1106,7 +1176,7 @@
     var tradingPanelIdx = -1;
 
     function getTradingPanels() {
-        return Array.from(document.querySelectorAll('.trading-analyst-card'));
+        return Array.from(document.querySelectorAll('.trading-vim-item'));
     }
 
     function selectTradingPanel(idx) {
@@ -1123,6 +1193,12 @@
     function toggleTradingPanel(idx) {
         var panels = getTradingPanels();
         if (idx < 0 || idx >= panels.length) return;
+        // Button card: trigger the analyze button click
+        if (panels[idx].dataset.tradingVim === 'btn') {
+            var btn = document.getElementById('trading-analyze-btn');
+            if (btn && !btn.disabled) btn.click();
+            return;
+        }
         panels[idx].classList.toggle('trading-panel-open');
     }
 

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -1536,10 +1536,22 @@ body {
 
 .chart-container {
     width: 100%;
-    height: calc(100vh - 140px);
+    height: calc(100vh - 200px);
     border-radius: 4px;
     overflow: hidden;
     position: relative;
+}
+
+/* Graph view: fill remaining viewport so the time-axis labels aren't clipped */
+.terminal-content[data-view="graph"] {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+.terminal-content[data-view="graph"] .chart-container {
+    flex: 1;
+    height: auto;
+    min-height: 0;
 }
 
 .chart-tooltip {
@@ -1671,6 +1683,11 @@ body {
     color: var(--blue);
     font-weight: 700;
     margin-right: 6px;
+}
+
+.tt-date {
+    color: var(--text-muted);
+    margin-right: 8px;
 }
 
 /* ── Debug Panels ── */
@@ -2159,6 +2176,11 @@ body {
     box-shadow: 0 0 0 1px var(--orange);
 }
 
+.trading-header.trading-panel-selected {
+    box-shadow: 0 0 0 1px var(--orange);
+    border-bottom-color: var(--orange);
+}
+
 /* Trading plan (debate result) */
 
 .trading-plan {
@@ -2314,3 +2336,79 @@ body {
     font-size: 14px;
 }
 .sec-link:hover { color: var(--orange); }
+
+.sec-tab-sep {
+    color: var(--text-muted);
+    margin: 0 6px;
+    align-self: center;
+    user-select: none;
+}
+
+/* Key People timeline */
+
+.kp-timeline {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    border-left: 2px solid var(--border);
+    margin-left: 4px;
+}
+
+.kp-row {
+    display: grid;
+    grid-template-columns: 90px 90px 1fr 1.4fr 24px;
+    gap: 10px;
+    align-items: center;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--border);
+    font-size: 12px;
+    cursor: pointer;
+    position: relative;
+}
+
+.kp-row:hover { background: var(--bg-tertiary); }
+
+.kp-row::before {
+    content: '';
+    position: absolute;
+    left: -7px;
+    top: 50%;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--bg-primary);
+    border: 2px solid var(--border);
+    transform: translateY(-50%);
+}
+
+.kp-date { color: var(--text-muted); white-space: nowrap; }
+
+.kp-event {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 2px;
+    font-size: 10px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    text-align: center;
+}
+
+.kp-event-appointed,
+.kp-event-promoted { background: #1a3a2a; color: var(--green); }
+
+.kp-event-resigned,
+.kp-event-departed { background: #3a1a1a; color: var(--red); }
+
+.kp-event-other { background: var(--bg-tertiary); color: var(--text-muted); }
+
+.kp-name { color: var(--text-primary); font-weight: 500; }
+.kp-title { color: var(--text-secondary); }
+
+.kp-link {
+    color: var(--text-muted);
+    text-decoration: none;
+    font-size: 14px;
+    text-align: center;
+}
+.kp-link:hover { color: var(--orange); }

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -803,6 +803,7 @@ window.onerror = function (msg, src, line, col, err) {
                 highlightDropdown(items, dropdownIndex);
             } else if (e.key === 'Enter') {
                 e.preventDefault();
+                clearTimeout(searchTimer);
                 if (dropdownIndex >= 0 && items[dropdownIndex]) {
                     selectSecurity(items[dropdownIndex].dataset.symbol);
                 } else {
@@ -812,8 +813,10 @@ window.onerror = function (msg, src, line, col, err) {
                 dropdown.classList.add('hidden');
                 enterNormalMode();
             } else if (e.key === 'Escape') {
+                e.preventDefault();
+                clearTimeout(searchTimer);
                 dropdown.classList.add('hidden');
-                document.getElementById('cmd-input').focus();
+                enterNormalMode();
             }
         });
 
@@ -852,6 +855,12 @@ window.onerror = function (msg, src, line, col, err) {
     }
 
     function renderSecurityDropdown(results, dropdown) {
+        // Don't show dropdown if user has already moved on (e.g. hit Enter before a debounced search returned)
+        var input = document.getElementById('security-input');
+        if (!input || document.activeElement !== input) {
+            dropdown.classList.add('hidden');
+            return;
+        }
         if (!results || results.length === 0) {
             dropdown.classList.add('hidden');
             return;
@@ -1351,6 +1360,7 @@ window.onerror = function (msg, src, line, col, err) {
             isSectorTab: function () { return this.getActiveTab() === 'sector'; },
             isAITab: function () { return this.getActiveTab() === 'ai'; },
             isSECTab: function () { return this.getActiveTab() === 'sec'; },
+            isFinTab: function () { return this.getActiveTab() === 'financials'; },
             getNewsCards: function () { return document.querySelectorAll('#info-content .news-card'); },
             getSectorItems: function () {
                 // Peer rows + news items as one navigable list
@@ -1371,6 +1381,19 @@ window.onerror = function (msg, src, line, col, err) {
                             return;
                         }
                         clearVimSelection();
+                        this._focus = hasSub ? 'sub' : 'main';
+                        this._highlightFocus();
+                        return;
+                    }
+                    // Financials tab: row navigation
+                    if (this._focus === 'content' && this.isFinTab()) {
+                        var finRows = window._finGetRows ? window._finGetRows() : [];
+                        var finIdx = window._finGetSelectedRow ? window._finGetSelectedRow() : -1;
+                        if (finRows.length > 0 && finIdx > 0) {
+                            window._finSelectRow(finIdx - 1);
+                            return;
+                        }
+                        if (window._finClearRow) window._finClearRow();
                         this._focus = hasSub ? 'sub' : 'main';
                         this._highlightFocus();
                         return;
@@ -1442,6 +1465,14 @@ window.onerror = function (msg, src, line, col, err) {
                         }
                         return;
                     }
+                    if (this.isFinTab()) {
+                        var finRows = window._finGetRows ? window._finGetRows() : [];
+                        if (finRows.length > 0) {
+                            var finIdx = window._finGetSelectedRow ? window._finGetSelectedRow() : -1;
+                            window._finSelectRow(finIdx + 1);
+                        }
+                        return;
+                    }
                     if (this.isAITab()) {
                         if (window._tradingVimHandler) window._tradingVimHandler(dir);
                         return;
@@ -1488,9 +1519,11 @@ window.onerror = function (msg, src, line, col, err) {
             _highlightFocus: function () {
                 // Visual indicator of which tab row has focus
                 var mainTabs = document.getElementById('info-tabs');
-                var subTabs = document.getElementById('fin-sub-tabs');
+                var finSubTabs = document.getElementById('fin-sub-tabs');
+                var secSubTabs = document.getElementById('sec-filters');
                 if (mainTabs) mainTabs.classList.toggle('tab-row-focused', this._focus === 'main');
-                if (subTabs) subTabs.classList.toggle('tab-row-focused', this._focus === 'sub');
+                if (finSubTabs) finSubTabs.classList.toggle('tab-row-focused', this._focus === 'sub');
+                if (secSubTabs) secSubTabs.classList.toggle('tab-row-focused', this._focus === 'sub');
             },
             jumpToTab: function (n) {
                 this._focus = 'main';

--- a/internal/server/templates/indices.html
+++ b/internal/server/templates/indices.html
@@ -6,5 +6,5 @@
 <div id="indices-container">
     <p class="empty-state">Loading indices...</p>
 </div>
-<script src="/static/indices.js"></script>
+<script src="/static/indices.js?v={{.AssetVersion}}"></script>
 {{end}}

--- a/internal/server/templates/layout.html
+++ b/internal/server/templates/layout.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Stocktopus — {{.Title}}</title>
-    <link rel="stylesheet" href="/static/style.css?v=2">
+    <link rel="stylesheet" href="/static/style.css?v={{.AssetVersion}}">
 </head>
 <body>
     <header class="terminal-header">
@@ -40,6 +40,6 @@
         <div id="clock" class="footer-clocks"></div>
     </footer>
     <script src="/static/lightweight-charts.js"></script>
-    <script src="/static/terminal.js"></script>
+    <script src="/static/terminal.js?v={{.AssetVersion}}"></script>
 </body>
 </html>{{end}}

--- a/internal/server/templates/security.html
+++ b/internal/server/templates/security.html
@@ -14,5 +14,5 @@
 <div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
     <p class="empty-state">Loading...</p>
 </div>
-<script src="/static/info.js"></script>
+<script src="/static/info.js?v={{.AssetVersion}}"></script>
 {{end}}

--- a/internal/server/templates/stock.html
+++ b/internal/server/templates/stock.html
@@ -23,7 +23,8 @@
         <button class="chart-toggle" id="toggle-news" data-indicator="news" title=":sn">News</button>
     </div>
 </div>
-<div id="chart-container" class="chart-container" data-symbol="{{.Symbol}}"></div>
-<div id="chart-tooltip" class="chart-tooltip hidden"></div>
-<script src="/static/chart.js"></script>
+<div id="chart-container" class="chart-container" data-symbol="{{.Symbol}}">
+    <div id="chart-tooltip" class="chart-tooltip hidden"></div>
+</div>
+<script src="/static/chart.js?v={{.AssetVersion}}"></script>
 {{end}}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -165,6 +166,13 @@ func (s *Store) migrate() error {
 	if err != nil {
 		return err
 	}
+
+	// Idempotent column adds — ignore "duplicate column" errors on existing DBs.
+	if _, err := s.db.Exec(`ALTER TABLE sec_filings ADD COLUMN processed_for_people INTEGER NOT NULL DEFAULT 0`); err != nil &&
+		!strings.Contains(err.Error(), "duplicate column") {
+		return err
+	}
+
 	return s.seedSECFormTypes()
 }
 
@@ -653,6 +661,45 @@ func (s *Store) IsSECFresh(symbol string, maxAge time.Duration) bool {
 		return false
 	}
 	return time.Since(fetchedAt) < maxAge
+}
+
+// GetUnprocessedSECFilings returns filings that have not yet had key-people extraction attempted.
+// Use this so we don't repeatedly LLM-process 8-Ks that contained no personnel changes.
+func (s *Store) GetUnprocessedSECFilings(symbol, formType string, limit int) ([]SECFiling, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	query := `SELECT symbol, cik, form_type, filing_date, accepted_date, link, final_link FROM sec_filings WHERE symbol = ? AND processed_for_people = 0`
+	args := []interface{}{symbol}
+	if formType != "" {
+		query += ` AND form_type = ?`
+		args = append(args, formType)
+	}
+	query += ` ORDER BY filing_date DESC LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var filings []SECFiling
+	for rows.Next() {
+		var f SECFiling
+		if err := rows.Scan(&f.Symbol, &f.CIK, &f.FormType, &f.FilingDate, &f.AcceptedDate, &f.Link, &f.FinalLink); err != nil {
+			continue
+		}
+		filings = append(filings, f)
+	}
+	return filings, nil
+}
+
+// MarkSECFilingProcessedForPeople flags a filing as having been considered for key-people
+// extraction (regardless of whether any people were actually found in it).
+func (s *Store) MarkSECFilingProcessedForPeople(symbol, link string) error {
+	_, err := s.db.Exec(`UPDATE sec_filings SET processed_for_people = 1 WHERE symbol = ? AND link = ?`, symbol, link)
+	return err
 }
 
 // GetSECFormTypes returns all tracked SEC form type definitions.

--- a/tests/e2e/smoke_test.go
+++ b/tests/e2e/smoke_test.go
@@ -22,6 +22,7 @@ import (
 	"stocktopus/internal/poller"
 	"stocktopus/internal/provider/financialmodelingprep"
 	"stocktopus/internal/server"
+	"stocktopus/internal/store"
 )
 
 var (
@@ -71,8 +72,19 @@ func TestMain(m *testing.M) {
 	// Debug broadcaster
 	debug := server.NewDebugBroadcaster()
 
+	// In-memory store for tests
+	tmpDir, err := os.MkdirTemp("", "stocktopus-smoke-*")
+	if err != nil {
+		panic("failed to create temp dir: " + err.Error())
+	}
+	defer os.RemoveAll(tmpDir)
+	st, err := store.New(tmpDir + "/test.db")
+	if err != nil {
+		panic("failed to create store: " + err.Error())
+	}
+
 	// Server
-	srv, err := server.New(server.Config{Port: 0}, h, debug, poll, newsClient, nil, nil, logger)
+	srv, err := server.New(server.Config{Port: 0}, h, debug, poll, newsClient, nil, nil, st, logger)
 	if err != nil {
 		panic("failed to create server: " + err.Error())
 	}


### PR DESCRIPTION
## Summary

Bundle of small UX improvements + several bug fixes that surfaced while testing.

### Ideas shipped (from `ideas.md`)
- **#1** j/k row navigation on Income / Balance / Cash Flow tables. Rows expose `data-fin-key` so #3 (chart slide-in) can plug in trivially next.
- **#6** Run Deep Analysis button is now in the AI tab's j/k vim loop; Enter triggers it.
- **#7** Removed execution-time noise from AI Analysis (per-stage durations, per-analyst duration badge, total time footer).
- **#10** Key People sub-tab on the SEC page with a chronological timeline of executive changes.

### Bug fixes
- Graph symbol-picker: hitting Enter after a search left you in insert mode with the dropdown still open (200 ms debounce race). Now clears the search timer + gates `renderSecurityDropdown` on input focus. Esc now enters normal mode instead of refocusing the command bar.
- OHLC tooltip on `/graph/<symbol>` was rendered as a sibling of `chart-container`, so its `position: absolute` placed it at the top of the page covering the symbol-picker dropdown. Moved it inside the chart container; also includes the candle's date now.
- Chart bottom axis labels (Month / DayOfMonth) weren't visible: the chart-container was overflowing the viewport (`calc(100vh - 140px)` + `overflow: hidden`) clipping the time axis, and our `tickMarkFormatter` returned an empty string for string-typed times — which is exactly what EOD data passes (`"2026-04-27"`). Both fixed.
- People extractor was running away after every SEC tab refresh: same 8-Ks with no personnel events were re-LLM'd repeatedly, while multiple goroutines could fire for the same symbol in parallel. Fixed with a `processed_for_people` column on `sec_filings` (idempotent ALTER TABLE migration) and a per-symbol `inFlight` map for singleflight.
- SEC sub-tab focus highlight (the blue border) used to disappear when navigating between sub-tabs because each click re-rendered the whole view. Now preserved across re-renders.

### Plumbing
- Replaced the manual `?v=N` cache buster with a randomized per-process hex token (`AssetVersion`) generated at server start and injected by `renderPage`. No more hand-bumping.
- Repaired `make smoke` — `server.New`'s signature drifted in #39/#40 to take `*store.Store`, but the e2e test wasn't updated. Added an in-memory store fixture.

### Known follow-up (not in this PR)
Key people extraction is wired end-to-end but currently reads SEC's "undeclared automated tool" warning page instead of actual filings — SEC blocks our scraper UA, and the URLs FMP returns point at EDGAR document index pages, not the filings themselves. Needs a small dedicated SEC-compliant fetcher in a follow-up.

## Test plan
- [x] \`make build\`
- [x] \`make test\`
- [x] \`make smoke\`
- [x] Hard-refresh `/graph/AAPL`, switch ranges, confirm bottom axis labels render
- [x] Crosshair-hover on chart shows date in tooltip
- [x] Symbol picker: type, Enter → dropdown closes, normal mode; Esc → normal mode
- [x] Security info → Financials tab: j/k highlights rows; h/l between Income/Balance/Cashflow keeps focus border
- [x] Security info → AI tab: j focuses Run Deep Analysis button; Enter triggers
- [ ] Security info → SEC tab: h/l moves between category filters and Key People; focus border persists; Key People timeline renders
- [ ] After analysis completes, `ollama ps` shows model idle (not active inference)