### PR TITLE
perf: ~100x smaller LLM input for DEF 14A leadership extraction

### DIFF
--- a/internal/agent/trading/people.go
+++ b/internal/agent/trading/people.go
@@ -86,14 +86,6 @@ func (pe *PeopleExtractor) processForm(ctx context.Context, symbol, formType str
 	for _, f := range filings {
 		pe.logger.Debug("extracting people", "symbol", symbol, "form", formType, "date", f.FilingDate)
 
-		text, err := pe.sec.FetchFilingText(ctx, f.Link, formType)
-		if err != nil {
-			pe.logger.Debug("sec fetch failed", "url", f.Link, "error", err)
-			// Mark processed anyway so we don't retry endlessly on a permanently broken link
-			_ = pe.store.MarkSECFilingProcessedForPeople(symbol, f.Link)
-			continue
-		}
-
 		filingDate := f.FilingDate
 		if len(filingDate) > 10 {
 			filingDate = filingDate[:10]
@@ -101,6 +93,12 @@ func (pe *PeopleExtractor) processForm(ctx context.Context, symbol, formType str
 
 		switch formType {
 		case "8-K":
+			text, err := pe.sec.FetchFilingText(ctx, f.Link, formType)
+			if err != nil {
+				pe.logger.Debug("sec fetch failed", "url", f.Link, "error", err)
+				_ = pe.store.MarkSECFilingProcessedForPeople(symbol, f.Link)
+				continue
+			}
 			people := pe.extractEvents(ctx, symbol, text, filingDate, f.Link)
 			for _, p := range people {
 				if err := pe.store.PutKeyPerson(p); err != nil {
@@ -108,7 +106,21 @@ func (pe *PeopleExtractor) processForm(ctx context.Context, symbol, formType str
 				}
 			}
 		case "10-K", "DEF 14A":
-			section := relevantSection(text, formType)
+			// Snapshots: prefer table-only text (often <5k chars vs 200k+ for the
+			// full filing — 5–10x faster Ollama inference). Falls back to the
+			// section-marker narrowing of the full text when no leadership tables
+			// are detected by the structural heuristics.
+			text, fromTables, err := pe.sec.FetchLeadershipTables(ctx, f.Link, formType)
+			if err != nil {
+				pe.logger.Debug("sec fetch failed", "url", f.Link, "error", err)
+				_ = pe.store.MarkSECFilingProcessedForPeople(symbol, f.Link)
+				continue
+			}
+			section := text
+			if !fromTables {
+				section = relevantSection(text, formType)
+			}
+			pe.logger.Debug("extracted leadership section", "form", formType, "chars", len(section), "fromTables", fromTables)
 			people := pe.extractSnapshot(ctx, symbol, section, filingDate, f.Link, formType)
 			if len(people) > 0 {
 				if err := pe.store.ReplaceCurrentKeyPeople(symbol, formType, people); err != nil {

--- a/internal/agent/trading/sec_fetcher.go
+++ b/internal/agent/trading/sec_fetcher.go
@@ -42,22 +42,46 @@ func NewSECFetcher(logger *slog.Logger) *SECFetcher {
 // returns the document's text content. formType (e.g. "8-K", "10-K", "DEF 14A") is
 // used to disambiguate when a filing has multiple primary candidates.
 func (sf *SECFetcher) FetchFilingText(ctx context.Context, indexURL, formType string) (string, error) {
-	baseURL, err := deriveBaseURL(indexURL)
+	body, err := sf.fetchPrimaryHTML(ctx, indexURL, formType)
 	if err != nil {
 		return "", err
+	}
+	return htmlToText(body), nil
+}
+
+// FetchLeadershipTables resolves the primary filing document, walks its HTML tables,
+// and returns the concatenated text of the ones that look like director/executive
+// summary or bio tables. Returns (text, true, nil) when leadership tables are found,
+// (fullText, false, nil) when none match — caller should narrow further. Much smaller
+// than the whole filing, which keeps Ollama inference time tractable on consumer GPUs.
+func (sf *SECFetcher) FetchLeadershipTables(ctx context.Context, indexURL, formType string) (text string, fromTables bool, err error) {
+	body, err := sf.fetchPrimaryHTML(ctx, indexURL, formType)
+	if err != nil {
+		return "", false, err
+	}
+	if tableText := extractLeadershipTables(body); tableText != "" {
+		return tableText, true, nil
+	}
+	return htmlToText(body), false, nil
+}
+
+// fetchPrimaryHTML is the common path for FetchFilingText and FetchLeadershipTables.
+func (sf *SECFetcher) fetchPrimaryHTML(ctx context.Context, indexURL, formType string) ([]byte, error) {
+	baseURL, err := deriveBaseURL(indexURL)
+	if err != nil {
+		return nil, err
 	}
 
 	primaryName, err := sf.findPrimaryDocument(ctx, baseURL, formType)
 	if err != nil {
-		return "", fmt.Errorf("locating primary doc: %w", err)
+		return nil, fmt.Errorf("locating primary doc: %w", err)
 	}
 
 	body, err := sf.httpGet(ctx, baseURL+primaryName)
 	if err != nil {
-		return "", fmt.Errorf("fetching %s: %w", primaryName, err)
+		return nil, fmt.Errorf("fetching %s: %w", primaryName, err)
 	}
-
-	return htmlToText(body), nil
+	return body, nil
 }
 
 // httpGet performs a GET with the SEC-compliant User-Agent.
@@ -213,4 +237,97 @@ func walkText(n *html.Node, b *strings.Builder) {
 
 func collapseWhitespace(s string) string {
 	return strings.TrimSpace(wsRegex.ReplaceAllString(s, " "))
+}
+
+// extractLeadershipTables finds tables in an SEC filing that summarise directors
+// or executive officers and returns their concatenated text. Detection heuristics:
+//   - Header row contains "Name" plus "Age" plus one of {"Since", "Position",
+//     "Occupation", "Title"} → director / officer summary table
+//   - Body contains "Director Since:" alongside "Age:" → individual bio cards
+//
+// Returns empty string when nothing matches so the caller can fall back to the
+// full document text.
+func extractLeadershipTables(body []byte) string {
+	doc, err := html.Parse(strings.NewReader(string(body)))
+	if err != nil {
+		return ""
+	}
+	var tables []*html.Node
+	collectElements(doc, "table", &tables)
+
+	var out strings.Builder
+	for _, t := range tables {
+		if !isLeadershipTable(t) {
+			continue
+		}
+		var b strings.Builder
+		walkText(t, &b)
+		out.WriteString(collapseWhitespace(b.String()))
+		out.WriteString("\n\n")
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func isLeadershipTable(table *html.Node) bool {
+	// Read a small slice of text from the start of the table — enough for the
+	// header row plus a row or two of data.
+	var b strings.Builder
+	collectTextLimited(table, &b, 1500)
+	preview := strings.ToLower(collapseWhitespace(b.String()))
+	if preview == "" {
+		return false
+	}
+
+	// Bio-card pattern: "Director Since:" + age field
+	if strings.Contains(preview, "director since:") && strings.Contains(preview, "age") {
+		return true
+	}
+
+	// Summary-table pattern: name + age + (since / position / occupation / title)
+	hasName := strings.Contains(preview, "name")
+	hasAge := strings.Contains(preview, "age")
+	hasContext := strings.Contains(preview, "since") ||
+		strings.Contains(preview, "position") ||
+		strings.Contains(preview, "occupation") ||
+		strings.Contains(preview, "title")
+	if hasName && hasAge && hasContext {
+		// Reject obvious non-leadership tables that happen to share keywords
+		// (e.g. compensation tables that read "Name and Principal Position").
+		// A real summary table almost always names "director" or "officer" within
+		// the same preview window.
+		return strings.Contains(preview, "director") || strings.Contains(preview, "officer")
+	}
+	return false
+}
+
+func collectElements(n *html.Node, tag string, out *[]*html.Node) {
+	if n.Type == html.ElementNode && n.Data == tag {
+		*out = append(*out, n)
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		collectElements(c, tag, out)
+	}
+}
+
+// collectTextLimited writes node text into b until at least limit chars accumulate.
+func collectTextLimited(n *html.Node, b *strings.Builder, limit int) {
+	if b.Len() >= limit {
+		return
+	}
+	if n.Type == html.ElementNode {
+		switch n.Data {
+		case "script", "style", "head", "noscript":
+			return
+		}
+	}
+	if n.Type == html.TextNode {
+		b.WriteString(n.Data)
+		b.WriteByte(' ')
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if b.Len() >= limit {
+			return
+		}
+		collectTextLimited(c, b, limit)
+	}
 }


### PR DESCRIPTION
## Summary

The first version of DEF 14A processing fed the LLM ~40k chars of section-narrowed proxy text per filing, which on consumer GPUs took 30–90 s of gemma3 inference and made the fan very loud. This switches to structural extraction: walk the parsed HTML for tables that look like director / executive summary tables and send only those to the LLM.

### Detection heuristics

Match a `<table>` if either:
- Header row contains \`Name\` + \`Age\` + one of \`{Since, Position, Occupation, Title}\` AND the preview also mentions \`director\` or \`officer\` (the second check rejects pay tables that share header keywords like "Name and Principal Position")
- Body contains \`Director Since:\` alongside an \`Age\` field — captures per-director bio cards used by GME and similar issuers

When no tables match (e.g. Apple's 10-K which incorporates Items 10/11/12 by reference), falls back to the previous section-marker narrowing of the full text.

### Measured impact

Against the primary docs we already use elsewhere:

| Filing | Before | After | Reduction |
|---|---|---|---|
| AAPL DEF 14A | 303,295 chars | 661 chars | **459×** |
| GME DEF 14A | 177,492 chars | 2,072 chars | **86×** |

Should drop Ollama latency per DEF 14A from ~30–90 s to ~3–10 s. Bonus: the table-only text doesn't contain the XBRL pay-for-performance section, so the LLM has no opportunity to mistake \`PeoMember\` / \`NonPeoNeo\` element labels for people.

### API change
\`FetchLeadershipTables\` now returns \`(text, fromTables, err)\`. Callers use \`fromTables\` to decide whether to apply the legacy section-marker fallback. Internal-only — no other call sites.

## Test plan
- [x] \`make build\`
- [x] \`make test\`
- [x] \`make smoke\`
- [x] Restart server, visit \`/security/AAPL\` → SEC tab → Key People — should populate within ~5 s
- [x] Same for \`/security/GME\` and \`/security/MSFT\` — confirm directors appear, no XBRL junk
- [x] Watch \`ollama ps\` — model goes idle quickly after extraction completes

## Follow-up
Tracked as idea #11 in \`ideas.md\`: replace LLM extraction entirely with Form 4 XML parsing (schema'd insider filings) for an additional 10× speedup and 100% accuracy on the structured fields. Out of scope for this PR.