### PR TITLE
feat: financials preview chart slide-in (idea #3)

### DIFF
--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -332,6 +332,148 @@
         finSelectedRow = -1;
     };
 
+    // ── Financials Preview Chart Slide-in ──
+
+    var finChart = null;
+
+    function disposeFinChart() {
+        if (finChart) {
+            try { finChart.remove(); } catch (e) {}
+            finChart = null;
+        }
+    }
+
+    function buildFinSeries(rows, finKey, format) {
+        var pts = [];
+        rows.forEach(function (d) {
+            var v;
+            if (format === 'calc') {
+                var parts = String(finKey).split('/');
+                var num = d[parts[0]], den = d[parts[1]];
+                if (num != null && den != null && den !== 0) {
+                    v = (num / den) * 100;
+                }
+            } else {
+                v = d[finKey];
+            }
+            if (v != null) {
+                var year = String(d.fiscalYear || d.date || '').substring(0, 4);
+                if (year) pts.push({ time: year + '-12-31', value: Number(v) });
+            }
+        });
+        pts.sort(function (a, b) { return a.time < b.time ? -1 : 1; });
+        return pts;
+    }
+
+    function fmtAxisValue(v) {
+        var abs = Math.abs(v);
+        if (abs >= 1e12) return (v / 1e12).toFixed(1) + 'T';
+        if (abs >= 1e9)  return (v / 1e9).toFixed(1) + 'B';
+        if (abs >= 1e6)  return (v / 1e6).toFixed(1) + 'M';
+        if (abs >= 1e3)  return (v / 1e3).toFixed(1) + 'k';
+        return Number(v).toFixed(2);
+    }
+
+    window._finOpenChart = function () {
+        if (finSelectedRow < 0) return;
+        var rows = window._finGetRows();
+        if (finSelectedRow >= rows.length) return;
+        var row = rows[finSelectedRow];
+
+        var label  = row.dataset.finLabel || 'Metric';
+        var finKey = row.dataset.finKey || '';
+        var format = row.dataset.finFormat || '';
+        var type   = window._finCurrentType || 'income';
+        var data   = (window._finData && window._finData[type]) || [];
+
+        var series = buildFinSeries(data, finKey, format);
+
+        var reader = document.getElementById('article-reader');
+        var readerTitle = document.getElementById('reader-title');
+        var readerBody = document.getElementById('reader-body');
+        if (!reader || !readerBody) return;
+        reader.classList.remove('hidden');
+        reader.dataset.mode = 'fin-chart';
+        if (readerTitle) readerTitle.textContent = label + ' — 5y';
+
+        if (series.length === 0) {
+            readerBody.innerHTML = '<p class="empty-state">No data points for this metric.</p>';
+            return;
+        }
+
+        readerBody.innerHTML = '<div id="fin-chart-host" style="width:100%;height:280px"></div>'
+            + '<div class="fin-chart-points" id="fin-chart-points"></div>';
+
+        // Render values list below the chart, colored to match the chart segments
+        var isPct = format === 'calc';
+        var pointsEl = document.getElementById('fin-chart-points');
+        pointsEl.innerHTML = series.map(function (p, i) {
+            var year = p.time.substring(0, 4);
+            var val = isPct ? p.value.toFixed(1) + '%' : fmtAxisValue(p.value);
+            var dirClass = '';
+            if (i > 0) {
+                var prev = series[i - 1].value;
+                if (p.value > prev) dirClass = ' price-up';
+                else if (p.value < prev) dirClass = ' price-down';
+            }
+            return '<div class="fin-chart-point"><span class="fin-chart-year">' + year + '</span><span class="fin-chart-val' + dirClass + '">' + val + '</span></div>';
+        }).join('');
+
+        // Build the line chart — one LineSeries per year-over-year segment so
+        // each segment is colored green (up) or red (down) vs the previous year.
+        disposeFinChart();
+        var host = document.getElementById('fin-chart-host');
+        if (!window.LightweightCharts || !host) return;
+
+        finChart = LightweightCharts.createChart(host, {
+            layout: { background: { color: '#0a0a0a' }, textColor: '#888888', fontFamily: "'SF Mono','Consolas',monospace", fontSize: 10 },
+            grid: { vertLines: { color: '#1a1a1a' }, horzLines: { color: '#1a1a1a' } },
+            rightPriceScale: { borderColor: '#2a2a2a' },
+            timeScale: { borderColor: '#2a2a2a', timeVisible: false, fixLeftEdge: true, fixRightEdge: true },
+            handleScale: false,
+            handleScroll: false,
+        });
+        var priceFormat = isPct
+            ? { type: 'custom', formatter: function (v) { return v.toFixed(1) + '%'; }, minMove: 0.1 }
+            : { type: 'custom', formatter: fmtAxisValue, minMove: 0.01 };
+
+        var GREEN = '#00cc66', RED = '#ff4444', NEUTRAL = '#888888';
+        if (series.length === 1) {
+            // Just one data point — single series, neutral colour, marker at the point.
+            var solo = finChart.addSeries(LightweightCharts.LineSeries, {
+                color: NEUTRAL, lineWidth: 2, priceFormat: priceFormat,
+                pointMarkersVisible: true,
+            });
+            solo.setData(series);
+        } else {
+            for (var i = 1; i < series.length; i++) {
+                var prev = series[i - 1].value;
+                var curr = series[i].value;
+                var color = curr > prev ? GREEN : (curr < prev ? RED : NEUTRAL);
+                var seg = finChart.addSeries(LightweightCharts.LineSeries, {
+                    color: color, lineWidth: 2, priceFormat: priceFormat,
+                });
+                seg.setData([series[i - 1], series[i]]);
+            }
+        }
+        finChart.timeScale().fitContent();
+    };
+
+    window._finCloseChart = function () {
+        var reader = document.getElementById('article-reader');
+        if (!reader) return;
+        if (reader.dataset.mode !== 'fin-chart') return false;
+        disposeFinChart();
+        reader.classList.add('hidden');
+        delete reader.dataset.mode;
+        return true;
+    };
+
+    window._finIsChartOpen = function () {
+        var reader = document.getElementById('article-reader');
+        return !!(reader && !reader.classList.contains('hidden') && reader.dataset.mode === 'fin-chart');
+    };
+
     var FIN_EXPLAINERS = {
         income: 'The income statement shows how much money the company earned (revenue), what it cost to earn it (expenses), and what was left over (profit). Read top to bottom: revenue minus costs gives gross profit, minus operating expenses gives operating income, minus interest and taxes gives net income. Margins show these as percentages of revenue — higher is better, and the trend matters more than the absolute number.',
         balance: 'The balance sheet is a snapshot of what the company owns (assets), what it owes (liabilities), and what belongs to shareholders (equity) at a single point in time. Assets = Liabilities + Equity, always. Key things to watch: cash vs debt levels, whether goodwill is a large portion of assets (acquisition risk), and whether equity is growing or shrinking over time.',
@@ -350,6 +492,10 @@
                     tc.innerHTML = '<p class="empty-state">No data available</p>';
                     return;
                 }
+                // Cache for the chart slide-in (key by type so switching sub-tabs gets the right rows)
+                window._finData = window._finData || {};
+                window._finData[type] = data;
+                window._finCurrentType = type;
 
                 var html = '';
                 if (FIN_EXPLAINERS[type]) {

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -763,7 +763,8 @@ body {
 }
 
 .cpanel-spark a[href*="tradingview"],
-.chart-container a[href*="tradingview"] {
+.chart-container a[href*="tradingview"],
+#fin-chart-host a[href*="tradingview"] {
     display: none !important;
 }
 
@@ -922,6 +923,34 @@ body {
     text-align: left !important;
     color: var(--text-secondary);
     font-weight: 500;
+}
+
+/* Financials chart slide-in — values list beneath the chart */
+.fin-chart-points {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+    gap: 6px;
+    margin-top: 12px;
+    font-size: 11px;
+}
+
+.fin-chart-point {
+    display: flex;
+    flex-direction: column;
+    padding: 6px 8px;
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    background: var(--bg-tertiary);
+}
+
+.fin-chart-year {
+    color: var(--text-muted);
+    font-size: 10px;
+}
+
+.fin-chart-val {
+    color: var(--text-primary);
+    font-weight: 700;
 }
 
 .est-range {

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -1663,6 +1663,8 @@ window.onerror = function (msg, src, line, col, err) {
                 // Normal mode: close reader first, then focus command bar
                 var reader = document.getElementById('article-reader');
                 if (reader && !reader.classList.contains('hidden')) {
+                    // Dispose the financials chart instance if we're closing that mode
+                    if (window._finCloseChart) window._finCloseChart();
                     reader.classList.add('hidden');
                     return;
                 }
@@ -1736,6 +1738,17 @@ window.onerror = function (msg, src, line, col, err) {
                 if (handler && handler.isSECTab && handler.isSECTab()) {
                     e.preventDefault();
                     if (window._secCycleFilter) window._secCycleFilter();
+                }
+                return;
+            case 'p':
+                // Financials chart slide-in: toggle on the selected row.
+                if (handler && handler.isFinTab && handler.isFinTab()) {
+                    e.preventDefault();
+                    if (window._finIsChartOpen && window._finIsChartOpen()) {
+                        window._finCloseChart();
+                    } else if (window._finOpenChart) {
+                        window._finOpenChart();
+                    }
                 }
                 return;
             case '1': case '2': case '3': case '4': case '5': case '6': case '7':
@@ -1971,7 +1984,9 @@ window.onerror = function (msg, src, line, col, err) {
 
     window._closeReader = function () {
         var reader = document.getElementById('article-reader');
-        if (reader) reader.classList.add('hidden');
+        if (!reader) return;
+        if (window._finCloseChart) window._finCloseChart();
+        reader.classList.add('hidden');
     };
 
     // ── Browser History ──


### PR DESCRIPTION
## Summary

Press \`p\` on a highlighted Financials row to open a slide-in panel with a 5-year line chart of that metric. \`p\` or \`Esc\` closes.

### Behaviour

- **Trigger**: \`p\` in normal mode while on the Financials tab with a row selected (j/k navigation from #1)
- **Toggle**: pressing \`p\` again closes; \`Esc\` also closes; reuses the existing article-reader panel for layout / animation / header / close button
- **Per-segment colouring**: each year-over-year segment is its own LineSeries — green when up vs prior year, red when down, grey when unchanged. The values grid below the chart mirrors the same colour classes so the year cells line up visually with the chart
- **Format-aware axis**: calculated rows (Gross/Operating/Net Margin) plot as percentages with a \`%\` formatter; raw line items use the T/B/M/k shorthand
- **TradingView logo hidden** via the same \`a[href*="tradingview"]\` rule the main chart container already uses, extended to \`#fin-chart-host\`

### Implementation notes

- \`renderTradingTable\` caches the per-type financials response on \`window._finData[type]\` so toggling between Income / Balance / Cashflow keeps each dataset addressable by row metadata without refetching
- Mode flag (\`reader.dataset.mode = "fin-chart"\`) on the article-reader so the generic Esc / close paths know to dispose the chart instance and clear the mode
- Single-data-point edge case shows a neutral marker without colour split

## Test plan
- [x] \`make build\`
- [x] \`make test\`
- [x] \`make smoke\`
- [x] On Financials → Income, j/k a row, press p — chart opens with green/red segments
- [x] Press p again — closes
- [x] Highlight a different row, press p — chart updates with new metric
- [x] Switch to Balance/Cashflow sub-tabs, repeat — uses the right dataset
- [x] Calculated row (Gross Margin) shows percentages on the y-axis
- [x] Raw row (Revenue) shows T/B/M shorthand on the y-axis
- [x] No TradingView logo bottom-right