### PR TITLE
feat: :watch <name> autocomplete adds picker selection to that list (idea #5)

### DIFF
--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -139,6 +139,15 @@ body {
     font-size: 12px;
 }
 
+.cmd-option-empty {
+    color: var(--text-muted);
+    font-style: italic;
+    cursor: default !important;
+}
+.cmd-option-empty:hover {
+    background: transparent !important;
+}
+
 /* ── Security Selector ── */
 
 .security-selector {

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -923,21 +923,32 @@ window.onerror = function (msg, src, line, col, err) {
                 }
             } else if (e.key === 'Tab' && !dropdown.classList.contains('hidden')) {
                 e.preventDefault();
-                if (cmdDropdownIndex >= 0 && items[cmdDropdownIndex]) {
-                    var item = items[cmdDropdownIndex];
-                    if (item.dataset.symbol) {
+                var pickIdx = cmdDropdownIndex >= 0 ? cmdDropdownIndex : (items.length === 1 ? 0 : -1);
+                if (pickIdx >= 0 && items[pickIdx]) {
+                    var item = items[pickIdx];
+                    if (item.dataset.watchlistName) {
+                        input.value = ':watch ' + item.dataset.watchlistName;
+                        hideCmdDropdown();
+                    } else if (item.dataset.symbol) {
                         input.value = item.dataset.cmd + ' ' + item.dataset.symbol;
                     } else {
                         acceptCmdCompletion(item.dataset.cmd);
                     }
-                } else if (items.length === 1) {
-                    acceptCmdCompletion(items[0].dataset.cmd);
                 }
             } else if (e.key === 'Enter') {
                 e.preventDefault();
-                // If dropdown is visible and a security result is highlighted, execute it
+                // If dropdown is visible and a watchlist option is highlighted, execute the watch.
                 if (!dropdown.classList.contains('hidden') && cmdDropdownIndex >= 0 && items[cmdDropdownIndex]) {
                     var item = items[cmdDropdownIndex];
+                    if (item.dataset.watchlistName) {
+                        hideCmdDropdown();
+                        executeWatchCommand(parseInt(item.dataset.watchlistId, 10), item.dataset.watchlistName);
+                        commandHistory.push(':watch ' + item.dataset.watchlistName);
+                        historyIndex = commandHistory.length;
+                        input.value = '';
+                        enterNormalMode();
+                        return;
+                    }
                     if (item.dataset.symbol) {
                         hideCmdDropdown();
                         commandHistory.push(item.dataset.cmd + ' ' + item.dataset.symbol);
@@ -982,16 +993,29 @@ window.onerror = function (msg, src, line, col, err) {
                         return;
                     }
 
-                    // :watch or :watch SYMBOL — add to watchlist
+                    // :watch — add picker selection to active watchlist
+                    // :watch <WatchlistName> — add picker selection to that named watchlist
+                    // :watch <SYMBOL> (legacy) — add SYMBOL to active watchlist when no name match
                     if (colonLower === 'watch' || colonLower.startsWith('watch ')) {
-                        var watchArg = colonCmd.substring(5).trim().toUpperCase();
-                        var watchSym = watchArg || selectedSecurity;
-                        if (watchSym) {
-                            addToWatchlist(getActiveWatchlistId(), watchSym);
-                            subscribeSecurity(watchSym);
-                            flashError('Added ' + watchSym + ' to watchlist');
+                        var watchArg = colonCmd.substring(5).trim();
+                        if (!watchArg) {
+                            // No arg — add picker selection to active watchlist
+                            if (selectedSecurity) {
+                                addToWatchlist(getActiveWatchlistId(), selectedSecurity);
+                                subscribeSecurity(selectedSecurity);
+                                flashError('Added ' + selectedSecurity + ' to watchlist');
+                            } else {
+                                flashError('Select a security first (s key)');
+                            }
                         } else {
-                            flashError('Select a security first (s key)');
+                            var target = resolveWatchTarget(watchArg);
+                            if (target.type === 'watchlist') {
+                                executeWatchCommand(target.id, target.name);
+                            } else {
+                                addToWatchlist(getActiveWatchlistId(), target.symbol);
+                                subscribeSecurity(target.symbol);
+                                flashError('Added ' + target.symbol + ' to watchlist');
+                            }
                         }
                         input.value = '';
                         enterNormalMode();
@@ -1123,6 +1147,20 @@ window.onerror = function (msg, src, line, col, err) {
         var parts = raw.split(/\s+/);
         var cmdPart = parts[0].toLowerCase();
 
+        // :watch <prefix> — autocomplete watchlist names (adds selectedSecurity to that list)
+        if (raw.charAt(0) === ':') {
+            var afterColon = raw.substring(1);
+            var afterColonLower = afterColon.toLowerCase();
+            if (afterColonLower === 'watch' || afterColonLower.startsWith('watch ')) {
+                // Cancel any in-flight security autocomplete so a late response
+                // for :wat / :watc doesn't override the watchlist dropdown.
+                clearTimeout(searchTimer);
+                var query = afterColonLower === 'watch' ? '' : afterColon.substring(6);
+                renderCmdWatchlistDropdown(query);
+                return;
+            }
+        }
+
         // If we have a recognized command that accepts a security and there's a space,
         // switch to security autocomplete in the command dropdown
         var cmd = COMMANDS[cmdPart];
@@ -1158,8 +1196,84 @@ window.onerror = function (msg, src, line, col, err) {
         renderCmdDropdown(matches);
     }
 
+    function renderCmdWatchlistDropdown(query) {
+        var dropdown = document.getElementById('cmd-dropdown');
+        var input = document.getElementById('cmd-input');
+        var q = (query || '').toLowerCase();
+        var matches = (watchlistData || []).filter(function (wl) {
+            return !q || wl.name.toLowerCase().indexOf(q) >= 0;
+        });
+        // Prefix-matches first, then substring-matches; preserve declared order otherwise
+        matches.sort(function (a, b) {
+            var ap = a.name.toLowerCase().indexOf(q) === 0 ? 0 : 1;
+            var bp = b.name.toLowerCase().indexOf(q) === 0 ? 0 : 1;
+            if (ap !== bp) return ap - bp;
+            return 0;
+        });
+
+        var sym = selectedSecurity || '';
+        var noSymLabel = 'no security selected — press s first';
+
+        if (matches.length === 0) {
+            dropdown.innerHTML = '<div class="cmd-option cmd-option-empty">No watchlist matches "' + escapeHtml(query) + '"</div>';
+            dropdown.classList.remove('hidden');
+            cmdDropdownIndex = -1;
+            return;
+        }
+
+        dropdown.innerHTML = matches.map(function (wl) {
+            var desc = sym ? 'add ' + sym + ' to ' + wl.name + ' watchlist' : noSymLabel;
+            return '<div class="cmd-option cmd-watchlist-option" data-watchlist-id="' + wl.id + '" data-watchlist-name="' + escapeHtml(wl.name) + '">'
+                + '<span class="cmd-option-usage" style="color:' + escapeHtml(wl.color || '#ff8800') + '">watch ' + escapeHtml(wl.name) + '</span>'
+                + '<span class="cmd-option-desc">' + escapeHtml(desc) + '</span>'
+                + '</div>';
+        }).join('');
+        dropdown.classList.remove('hidden');
+        cmdDropdownIndex = -1;
+
+        dropdown.querySelectorAll('.cmd-watchlist-option').forEach(function (el) {
+            el.onmousedown = function (e) {
+                e.preventDefault();
+                executeWatchCommand(parseInt(el.dataset.watchlistId, 10), el.dataset.watchlistName);
+                input.value = '';
+                hideCmdDropdown();
+                enterNormalMode();
+            };
+        });
+    }
+
+    // Add the picker's currently-selected security to the named watchlist.
+    function executeWatchCommand(watchlistId, watchlistName) {
+        if (!selectedSecurity) {
+            flashError('No security selected — press s first');
+            return false;
+        }
+        addToWatchlist(watchlistId, selectedSecurity);
+        subscribeSecurity(selectedSecurity);
+        flashError('Added ' + selectedSecurity + ' to ' + watchlistName);
+        return true;
+    }
+
+    // Resolve a `:watch <X>` argument: prefer matching a watchlist name (case-insensitive,
+    // exact then prefix), fall back to treating X as a symbol added to the active list.
+    function resolveWatchTarget(arg) {
+        if (!arg) return null;
+        var lower = arg.toLowerCase();
+        var exact = (watchlistData || []).find(function (wl) { return wl.name.toLowerCase() === lower; });
+        if (exact) return { type: 'watchlist', id: exact.id, name: exact.name };
+        var prefix = (watchlistData || []).find(function (wl) { return wl.name.toLowerCase().indexOf(lower) === 0; });
+        if (prefix) return { type: 'watchlist', id: prefix.id, name: prefix.name };
+        return { type: 'symbol', symbol: arg.toUpperCase() };
+    }
+
     function renderCmdSecurityDropdown(results, cmdName) {
         var dropdown = document.getElementById('cmd-dropdown');
+        // Guard against stale debounced fires that come back after the user has
+        // typed past the search prefix (e.g. now on :watch ...).
+        var currentInput = document.getElementById('cmd-input');
+        if (currentInput && currentInput.value.trim().toLowerCase().indexOf(':watch') === 0) {
+            return;
+        }
         if (!results || results.length === 0) {
             hideCmdDropdown();
             return;


### PR DESCRIPTION
## Summary

Typing \`:watch\` in the command bar now opens a dropdown of watchlist names. Selecting one adds the symbol-picker's currently-selected security to that list — without forcing the user to remember which watchlist is "active".

### Flow
\`\`\`
s MSFT <Enter>          ← pick the security
Esc                     ← back to normal mode
:watch                  ← dropdown shows all watchlists immediately
D                       ← narrows to "Default", "DefenseStocks", …
Tab/Enter               ← Tab fills ":watch Default", Enter executes
\`\`\`

Each option reads **\`add <SYMBOL> to <Name> watchlist\`** so the action is unambiguous. When nothing is selected in the picker, the description reads "no security selected — press s first" and execution flashes the same error rather than silently failing.

### Implementation notes
- \`filterAndShowCommands\` branches on raw input starting with \`:watch\` (with or without trailing space) and routes to a new \`renderCmdWatchlistDropdown(query)\` instead of falling through to the security search.
- The 200ms debounced security search for partial inputs (\`:wat\`, \`:watc\`) was racing the watchlist dropdown render — late responses overwrote the freshly-rendered watchlist list. Fixed two ways: \`clearTimeout(searchTimer)\` when \`:watch\` is detected, plus a guard in \`renderCmdSecurityDropdown\` that bails if the input has moved on to \`:watch\`.
- Tab on a watchlist option fills \`:watch <Name>\`; Enter executes.
- New \`resolveWatchTarget()\` preserves the legacy \`:watch SYMBOL\` shortcut: when the argument doesn't match a watchlist name, treat it as a symbol and add it to the active list (so old muscle memory still works).
- Backend already uses \`INSERT OR IGNORE\` on \`watchlist_symbols\`, so re-adding the same symbol is idempotent.

## Test plan
- [x] \`make build\`
- [x] \`make test\`
- [x] \`make smoke\`
- [x] On any page, press \`s MSFT\`, Esc, \`:watch\` — dropdown appears with all watchlists, no need to type space
- [x] Type \`:watch D\` — narrows to lists starting with D
- [x] Tab fills \`:watch Default\` without executing; Enter then executes
- [x] Each row shows \`add MSFT to <Name> watchlist\`
- [x] Re-running on same symbol doesn't duplicate (silent idempotent)
- [x] No symbol selected → flashError on execute
- [x] \`:watch AAPL\` (no name match) still falls back to legacy add-to-active behaviour