### PR TITLE
feat: ideas sketchpad — comparative graphs across metrics (idea #2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ lint-js:
 	@node --check internal/server/static/terminal.js 2>&1 && echo "terminal.js OK" || (echo "terminal.js has syntax errors" && exit 1)
 	@node --check internal/server/static/info.js 2>&1 && echo "info.js OK" || (echo "info.js has syntax errors" && exit 1)
 	@node --check internal/server/static/chart.js 2>&1 && echo "chart.js OK" || (echo "chart.js has syntax errors" && exit 1)
+	@node --check internal/server/static/ideas.js 2>&1 && echo "ideas.js OK" || (echo "ideas.js has syntax errors" && exit 1)
 
 build: lint-js
 	CGO_ENABLED=1 go build -o bin/stocktopus ./cmd/stocktopus

--- a/internal/news/news.go
+++ b/internal/news/news.go
@@ -309,6 +309,26 @@ func (c *Client) GetAnalystEstimates(ctx context.Context, symbol string, limit i
 	return c.fetchJSON(ctx, "/stable/analyst-estimates", params)
 }
 
+// GetHistoricalPriceLight returns lightweight EOD prices ([{date, price}, ...]) for a symbol.
+// Works uniformly for stocks, commodities, forex pairs, crypto and indices on FMP's
+// /stable/historical-price-eod/light endpoint.
+func (c *Client) GetHistoricalPriceLight(ctx context.Context, symbol string) (json.RawMessage, error) {
+	params := url.Values{"symbol": {symbol}}
+	return c.fetchJSON(ctx, "/stable/historical-price-eod/light", params)
+}
+
+// GetFinancials dispatches to income / balance / cashflow by statementType.
+func (c *Client) GetFinancials(ctx context.Context, symbol, statementType string, limit int) (json.RawMessage, error) {
+	switch statementType {
+	case "balance":
+		return c.GetBalanceSheet(ctx, symbol, limit)
+	case "cashflow":
+		return c.GetCashFlow(ctx, symbol, limit)
+	default:
+		return c.GetIncomeStatement(ctx, symbol, limit)
+	}
+}
+
 // GetSECFilings searches SEC filings for a symbol within a date range.
 func (c *Client) GetSECFilings(ctx context.Context, symbol, from, to string) (json.RawMessage, error) {
 	params := url.Values{"symbol": {symbol}}

--- a/internal/server/ideas.go
+++ b/internal/server/ideas.go
@@ -1,0 +1,262 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"stocktopus/internal/store"
+)
+
+// globalOwnerID is the single user the sketchpad is scoped to today.
+// Refactored to per-user later by reading session/auth.
+const globalOwnerID = int64(1)
+
+// handleIdeas serves the /ideas page (default sketchpad) and /ideas/{id}.
+func (s *Server) handleIdeas(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	s.renderPage(w, r, "ideas.html", map[string]any{
+		"Title":     "Ideas",
+		"Active":    "ideas",
+		"SketchID":  id,
+	})
+}
+
+// handleListSketches returns sketches owned by the global user (newest first).
+func (s *Server) handleListSketches(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.store == nil {
+		json.NewEncoder(w).Encode([]any{})
+		return
+	}
+	sketches, err := s.store.ListSketches(globalOwnerID)
+	if err != nil {
+		s.logger.Error("list sketches", "error", err)
+		http.Error(w, "list failed", http.StatusInternalServerError)
+		return
+	}
+	if sketches == nil {
+		sketches = []store.Sketch{}
+	}
+	json.NewEncoder(w).Encode(sketches)
+}
+
+// handleCreateSketch creates an empty (or pre-populated) sketch and returns the new id.
+func (s *Server) handleCreateSketch(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.store == nil {
+		http.Error(w, "store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	var req struct {
+		Name string `json:"name"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&req)
+	id, err := s.store.CreateSketch(globalOwnerID, strings.TrimSpace(req.Name))
+	if err != nil {
+		http.Error(w, "create failed", http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]int64{"id": id})
+}
+
+func (s *Server) handleGetSketch(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		http.Error(w, "bad id", http.StatusBadRequest)
+		return
+	}
+	sk, err := s.store.GetSketch(id)
+	if err != nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	if sk.Metrics == nil {
+		sk.Metrics = []store.SketchMetric{}
+	}
+	json.NewEncoder(w).Encode(sk)
+}
+
+func (s *Server) handleRenameSketch(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		http.Error(w, "bad id", http.StatusBadRequest)
+		return
+	}
+	var req struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+	if err := s.store.RenameSketch(id, strings.TrimSpace(req.Name)); err != nil {
+		http.Error(w, "rename failed", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleSketchNotes(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		http.Error(w, "bad id", http.StatusBadRequest)
+		return
+	}
+	var req struct {
+		Notes string `json:"notes"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+	if err := s.store.UpdateSketchNotes(id, req.Notes); err != nil {
+		http.Error(w, "save failed", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleDeleteSketch(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		http.Error(w, "bad id", http.StatusBadRequest)
+		return
+	}
+	if err := s.store.DeleteSketch(id); err != nil {
+		http.Error(w, "delete failed", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleAddSketchMetric(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		http.Error(w, "bad id", http.StatusBadRequest)
+		return
+	}
+	var m store.SketchMetric
+	if err := json.NewDecoder(r.Body).Decode(&m); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+	m.SketchID = id
+	if m.Kind == "" || m.Identifier == "" {
+		http.Error(w, "kind and identifier required", http.StatusBadRequest)
+		return
+	}
+	mid, err := s.store.AddSketchMetric(m)
+	if err != nil {
+		http.Error(w, "add failed", http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]int64{"id": mid})
+}
+
+func (s *Server) handleRemoveSketchMetric(w http.ResponseWriter, r *http.Request) {
+	mid, err := strconv.ParseInt(r.PathValue("metricId"), 10, 64)
+	if err != nil {
+		http.Error(w, "bad metricId", http.StatusBadRequest)
+		return
+	}
+	if err := s.store.RemoveSketchMetric(mid); err != nil {
+		http.Error(w, "remove failed", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleHistorical fronts FMP's historical EOD endpoint for any kind+symbol.
+// kind is informational here — FMP's /historical-price-eod/light?symbol=X
+// is uniform across stocks, commodities, forex pairs, crypto, and indices.
+//
+// For kind="financial" with identifier "SYMBOL.field" we delegate to the
+// existing financials handler, since FMP exposes a different endpoint.
+//
+// Tickers can themselves contain periods (BRK.A, BRK.B, GOOG.L, etc.), so we
+// split on the *rightmost* dot — everything after is the FMP field name (which
+// is camelCase and case-sensitive — don't normalize the casing).
+func (s *Server) handleHistorical(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	kind := r.PathValue("kind")
+	rawSymbol := r.PathValue("symbol")
+
+	if kind == "financial" {
+		dot := strings.LastIndex(rawSymbol, ".")
+		if dot <= 0 || dot >= len(rawSymbol)-1 {
+			http.Error(w, "financial requires SYMBOL.field", http.StatusBadRequest)
+			return
+		}
+		sym := strings.ToUpper(rawSymbol[:dot])
+		field := rawSymbol[dot+1:] // preserve camelCase
+		stmt := guessStatementType(field)
+		raw, err := s.news.GetFinancials(r.Context(), sym, stmt, 5)
+		if err != nil {
+			http.Error(w, "fmp error", http.StatusBadGateway)
+			return
+		}
+		var rows []map[string]any
+		if err := json.Unmarshal(raw, &rows); err != nil {
+			http.Error(w, "bad fmp response", http.StatusBadGateway)
+			return
+		}
+		out := make([]map[string]any, 0, len(rows))
+		for _, row := range rows {
+			date, _ := row["date"].(string)
+			if date == "" {
+				if fy, ok := row["fiscalYear"].(string); ok {
+					date = fy + "-12-31"
+				}
+			}
+			v, ok := row[field]
+			if !ok {
+				continue
+			}
+			out = append(out, map[string]any{"date": date, "value": v})
+		}
+		json.NewEncoder(w).Encode(out)
+		return
+	}
+
+	// EOD path — covers stocks, commodities, forex, crypto, indices uniformly.
+	symbol := strings.ToUpper(rawSymbol)
+	raw, err := s.news.GetHistoricalPriceLight(r.Context(), symbol)
+	if err != nil {
+		s.logger.Error("historical fetch", "kind", kind, "symbol", symbol, "error", err)
+		http.Error(w, fmt.Sprintf("fmp error: %v", err), http.StatusBadGateway)
+		return
+	}
+	w.Write(raw)
+}
+
+// guessStatementType maps a financial field name to its statement type.
+// (FMP serves income / balance / cashflow as separate endpoints.)
+func guessStatementType(field string) string {
+	balance := map[string]bool{
+		"totalAssets": true, "totalLiabilities": true, "totalStockholdersEquity": true,
+		"totalDebt": true, "longTermDebt": true, "shortTermDebt": true,
+		"cashAndCashEquivalents": true, "shortTermInvestments": true,
+		"netReceivables": true, "inventory": true, "goodwill": true, "intangibleAssets": true,
+		"totalCurrentAssets": true, "totalCurrentLiabilities": true, "retainedEarnings": true,
+	}
+	cashflow := map[string]bool{
+		"operatingCashFlow": true, "freeCashFlow": true, "capitalExpenditure": true,
+		"netCashUsedForInvestingActivities": true, "netCashUsedProvidedByFinancingActivities": true,
+		"depreciationAndAmortization": true, "stockBasedCompensation": true,
+		"accountsReceivables": true, "accountsPayables": true,
+		"netChangeInCash": true, "dividendsPaid": true, "commonStockRepurchased": true,
+		"debtRepayment": true,
+	}
+	if balance[field] {
+		return "balance"
+	}
+	if cashflow[field] {
+		return "cashflow"
+	}
+	return "income"
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -113,7 +113,7 @@ func (s *Server) loadTemplates() error {
 	layoutPath := filepath.Join(templatesDir(), "layout.html")
 	s.pages = make(map[string]*template.Template)
 
-	pageNames := []string{"watchlist", "stock", "security", "screener", "feed", "debug", "news", "indices"}
+	pageNames := []string{"watchlist", "stock", "security", "screener", "feed", "debug", "news", "indices", "ideas"}
 	for _, page := range pageNames {
 		pagePath := filepath.Join(templatesDir(), page+".html")
 		t, err := template.ParseFiles(layoutPath, pagePath)
@@ -172,6 +172,17 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/security/{symbol}/trading/result", s.handleTradingResult)
 	mux.HandleFunc("GET /api/trading/cost", s.handleTradingCost)
 
+	// Ideas / sketchpad
+	mux.HandleFunc("GET /api/sketches", s.handleListSketches)
+	mux.HandleFunc("POST /api/sketches", s.handleCreateSketch)
+	mux.HandleFunc("GET /api/sketches/{id}", s.handleGetSketch)
+	mux.HandleFunc("PATCH /api/sketches/{id}", s.handleRenameSketch)
+	mux.HandleFunc("PUT /api/sketches/{id}/notes", s.handleSketchNotes)
+	mux.HandleFunc("DELETE /api/sketches/{id}", s.handleDeleteSketch)
+	mux.HandleFunc("POST /api/sketches/{id}/metrics", s.handleAddSketchMetric)
+	mux.HandleFunc("DELETE /api/sketches/{id}/metrics/{metricId}", s.handleRemoveSketchMetric)
+	mux.HandleFunc("GET /api/historical/{kind}/{symbol}", s.handleHistorical)
+
 	// WebSocket
 	mux.HandleFunc("GET /ws", s.handleWebSocket)
 	mux.HandleFunc("GET /ws/debug", s.handleDebugWS)
@@ -186,6 +197,8 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /feed", s.handleFeed)
 	mux.HandleFunc("GET /news", s.handleNews)
 	mux.HandleFunc("GET /indices", s.handleIndicesPage)
+	mux.HandleFunc("GET /ideas", s.handleIdeas)
+	mux.HandleFunc("GET /ideas/{id}", s.handleIdeas)
 	mux.HandleFunc("GET /debug", s.handleDebug)
 }
 

--- a/internal/server/static/ideas.js
+++ b/internal/server/static/ideas.js
@@ -1,0 +1,527 @@
+// Ideas / Sketchpad — comparative graph of multiple metrics rebased to 100.
+// Up to 3 series shown legibly; metrics persisted as named "sketches" owned
+// by the global user.
+
+(function () {
+    'use strict';
+
+    var SERIES_COLORS = ['#ff8800', '#4499ff', '#00cc66', '#bb88ff', '#ccaa00'];
+    var MAX_SERIES = 3;
+
+    var sidebarEl = document.getElementById('ideas-sidebar');
+    var listEl = document.getElementById('ideas-list');
+    var titleEl = document.getElementById('ideas-title');
+    var metaEl = document.getElementById('ideas-meta');
+    var hostEl = document.getElementById('ideas-chart-host');
+    var legendEl = document.getElementById('ideas-legend');
+    var emptyEl = document.getElementById('ideas-empty');
+    var script = document.currentScript;
+    var initialSketchID = (script && script.dataset.sketchId) ? script.dataset.sketchId : '';
+
+    // ── State ──
+    var currentSketch = null;     // {id, name, metrics: [...]}
+    var seriesData = {};          // metricId/identifier → array of {date, value}
+    var chart = null;
+    var seriesByID = {};          // metricId → LineSeries handle (for cleanup)
+    var sketches = [];            // sidebar list
+    var listSelectedIdx = -1;
+
+    function esc(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+
+    function fmtAxisValue(v) {
+        var abs = Math.abs(v);
+        if (abs >= 1e12) return (v / 1e12).toFixed(1) + 'T';
+        if (abs >= 1e9)  return (v / 1e9).toFixed(1) + 'B';
+        if (abs >= 1e6)  return (v / 1e6).toFixed(1) + 'M';
+        if (abs >= 1e3)  return (v / 1e3).toFixed(1) + 'k';
+        if (abs >= 1)    return v.toFixed(2);
+        return v.toFixed(4);
+    }
+
+    // ── Sidebar (saved sketches) ──
+
+    function loadSketches() {
+        return fetch('/api/sketches')
+            .then(function (r) { return r.ok ? r.json() : []; })
+            .then(function (list) {
+                sketches = list || [];
+                renderSidebar();
+                return sketches;
+            })
+            .catch(function () { return []; });
+    }
+
+    function renderSidebar() {
+        var countEl = document.getElementById('ideas-sketch-count');
+        if (countEl) countEl.textContent = sketches.length ? sketches.length + ' saved' : '';
+
+        if (!sketches.length) {
+            listEl.innerHTML = '<li class="empty-state">No saved sketches yet.</li>';
+            return;
+        }
+        var defaultRow = '<li class="ideas-list-item' + (currentSketch && !currentSketch.id ? ' active' : '') + '" data-sketch-id="">'
+            + '<span class="ideas-list-name">Default</span>'
+            + '<span class="ideas-list-meta">scratchpad</span></li>';
+        listEl.innerHTML = defaultRow + sketches.map(function (sk) {
+            var active = currentSketch && currentSketch.id === sk.id ? ' active' : '';
+            var when = sk.updatedAt ? new Date(sk.updatedAt).toLocaleDateString() : '';
+            return '<li class="ideas-list-item' + active + '" data-sketch-id="' + sk.id + '">'
+                + '<span class="ideas-list-name">' + esc(sk.name || '(untitled)') + '</span>'
+                + '<span class="ideas-list-meta">' + esc(when) + '</span>'
+                + '</li>';
+        }).join('');
+
+        Array.from(listEl.querySelectorAll('.ideas-list-item')).forEach(function (el) {
+            el.onclick = function () {
+                var sid = el.dataset.sketchId;
+                navigateToSketch(sid);
+            };
+        });
+    }
+
+    function navigateToSketch(id) {
+        var path = id ? '/ideas/' + id : '/ideas';
+        if (id) localStorage.setItem('stocktopus-last-sketch', id);
+        if (window.history && window.history.pushState) {
+            history.pushState({ view: 'ideas', sketchId: id || '' }, '', path);
+        }
+        loadSketch(id);
+    }
+
+    // ── Sketch loading ──
+
+    function loadSketch(id) {
+        // Reset chart + state
+        disposeChart();
+        seriesData = {};
+        seriesByID = {};
+        seriesErrors = {};
+
+        if (!id) {
+            currentSketch = { id: 0, name: '', metrics: [] };
+            renderSketch();
+            return;
+        }
+        if (id) localStorage.setItem('stocktopus-last-sketch', String(id));
+        return fetch('/api/sketches/' + id)
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (sk) {
+                if (!sk) {
+                    // Sketch missing — clear last-used so we don't dead-end
+                    // every future :add at this id.
+                    localStorage.removeItem('stocktopus-last-sketch');
+                    currentSketch = { id: 0, name: '', metrics: [] };
+                    renderSketch();
+                    return;
+                }
+                currentSketch = sk;
+                renderSketch();
+                return Promise.all((sk.metrics || []).map(fetchMetricData))
+                    .then(rebuildChart);
+            });
+    }
+
+    function renderSketch() {
+        titleEl.textContent = (currentSketch && currentSketch.name) || 'Default Sketchpad';
+        var n = (currentSketch.metrics || []).length;
+        metaEl.textContent = n ? n + ' metric' + (n === 1 ? '' : 's') : 'no metrics yet';
+        emptyEl.style.display = n ? 'none' : 'block';
+        hostEl.style.display = n ? 'block' : 'none';
+        renderLegend();
+        renderSidebar();
+        var notesEl = document.getElementById('ideas-notes-textarea');
+        if (notesEl) notesEl.value = (currentSketch && currentSketch.notes) || '';
+    }
+
+    function renderLegend() {
+        var metrics = (currentSketch && currentSketch.metrics) || [];
+        if (!metrics.length) { legendEl.innerHTML = ''; return; }
+        legendEl.innerHTML = metrics.map(function (m, i) {
+            var data = seriesData[m.id] || [];
+            var err = seriesErrors[m.id];
+            var color = m.color || SERIES_COLORS[i % SERIES_COLORS.length];
+            var labelHTML = '<span class="ideas-legend-swatch" style="background:' + esc(color) + '"></span>'
+                + '<span class="ideas-legend-label">' + esc(m.label || m.identifier) + '</span>';
+            var rightHTML;
+            if (err) {
+                rightHTML = '<span class="ideas-legend-err">' + esc(err) + '</span>';
+            } else {
+                var firstVal = data.length ? data[0].value : null;
+                var lastVal = data.length ? data[data.length - 1].value : null;
+                // Normalize by |firstVal| so sign reflects direction of change,
+                // not the sign of (a/b) where both are negative.
+                var pct = (firstVal != null && lastVal != null && firstVal !== 0)
+                    ? ((lastVal - firstVal) / Math.abs(firstVal) * 100) : null;
+                var pctClass = pct == null ? '' : (pct >= 0 ? 'price-up' : 'price-down');
+                var pctStr = pct == null ? '—' : (pct >= 0 ? '+' : '') + pct.toFixed(1) + '%';
+                var lastStr = lastVal == null ? '—' : fmtAxisValue(lastVal);
+                rightHTML = '<span class="ideas-legend-val">' + esc(lastStr) + '</span>'
+                    + '<span class="ideas-legend-pct ' + pctClass + '">' + pctStr + '</span>';
+            }
+            return '<div class="ideas-legend-row' + (err ? ' ideas-legend-row-err' : '') + '" data-metric-id="' + m.id + '">'
+                + labelHTML
+                + rightHTML
+                + '<button class="ideas-legend-del" data-metric-id="' + m.id + '" title="remove">×</button>'
+                + '</div>';
+        }).join('');
+
+        Array.from(legendEl.querySelectorAll('.ideas-legend-del')).forEach(function (btn) {
+            btn.onclick = function () { removeMetric(parseInt(btn.dataset.metricId, 10)); };
+        });
+    }
+
+    // ── Data fetch ──
+
+    var seriesErrors = {}; // metricId → human-readable error reason
+
+    function fetchMetricData(m) {
+        var url;
+        if (m.kind === 'financial') {
+            url = '/api/historical/financial/' + encodeURIComponent(m.identifier);
+        } else {
+            url = '/api/historical/' + encodeURIComponent(m.kind) + '/' + encodeURIComponent(m.identifier);
+        }
+        return fetch(url)
+            .then(function (r) {
+                if (!r.ok) {
+                    return r.text().then(function (text) {
+                        // FMP free tier returns 402 for commodities/forex/crypto historical.
+                        // Surface that to the user instead of silently rendering nothing.
+                        var reason = 'unavailable';
+                        if (/Premium|subscription/i.test(text)) reason = 'premium FMP plan required';
+                        else if (r.status === 502 || r.status === 503) reason = 'data source error';
+                        else if (r.status === 404) reason = 'symbol not found';
+                        seriesErrors[m.id] = reason;
+                        return null;
+                    });
+                }
+                seriesErrors[m.id] = null;
+                return r.json();
+            })
+            .then(function (rows) {
+                if (!Array.isArray(rows)) { seriesData[m.id] = []; return []; }
+                var out = rows.map(function (row) {
+                    var date = row.date || row.fiscalYear || '';
+                    if (date && date.length > 10) date = date.substring(0, 10);
+                    var v = row.value != null ? row.value :
+                            row.price != null ? row.price :
+                            row.close != null ? row.close : null;
+                    return { date: date, value: Number(v) };
+                }).filter(function (p) {
+                    return p.date && !isNaN(p.value);
+                });
+                var cutoff = new Date(); cutoff.setFullYear(cutoff.getFullYear() - 5);
+                var cutoffStr = cutoff.toISOString().substring(0, 10);
+                out = out.filter(function (p) { return p.date >= cutoffStr; });
+                out.sort(function (a, b) { return a.date < b.date ? -1 : 1; });
+                seriesData[m.id] = out;
+                return out;
+            })
+            .catch(function () {
+                seriesErrors[m.id] = 'fetch failed';
+                seriesData[m.id] = [];
+                return [];
+            });
+    }
+
+    // ── Chart rendering ──
+
+    function disposeChart() {
+        if (chart) { try { chart.remove(); } catch (e) {} chart = null; }
+        seriesByID = {};
+    }
+
+    function ensureChart() {
+        if (chart) return chart;
+        if (!window.LightweightCharts || !hostEl) return null;
+        chart = LightweightCharts.createChart(hostEl, {
+            layout: { background: { color: '#0a0a0a' }, textColor: '#888888', fontFamily: "'SF Mono','Consolas',monospace", fontSize: 11 },
+            grid: { vertLines: { color: '#1a1a1a' }, horzLines: { color: '#1a1a1a' } },
+            crosshair: { mode: LightweightCharts.CrosshairMode.Magnet, vertLine: { color: '#555', style: 2 }, horzLine: { color: '#555', style: 2 } },
+            rightPriceScale: { borderColor: '#2a2a2a' },
+            timeScale: { borderColor: '#2a2a2a', timeVisible: false, fixLeftEdge: true, fixRightEdge: true },
+        });
+        return chart;
+    }
+
+    var firstSeries = null;
+    var lastCrosshairValue = null;
+    var priceLines = [];
+
+    function rebuildChart() {
+        var metrics = (currentSketch && currentSketch.metrics) || [];
+        disposeChart();
+        if (!metrics.length) { renderLegend(); return; }
+        var c = ensureChart();
+        if (!c) return;
+
+        firstSeries = null;
+        priceLines = [];
+        metrics.slice(0, MAX_SERIES).forEach(function (m, i) {
+            var data = seriesData[m.id] || [];
+            if (data.length < 2) return;
+            // Plot % change from start: (value - base) / |base| * 100.
+            // 0 = baseline; +X% = improvement; -X% = decline. Works for any
+            // sign — when base is negative (e.g. DJT operating income), a
+            // larger loss correctly plots as more negative, not more positive.
+            var base = data[0].value;
+            if (!base) return;
+            var absBase = Math.abs(base);
+            var rebased = data.map(function (p) {
+                return { time: p.date, value: ((p.value - base) / absBase) * 100 };
+            });
+            var color = m.color || SERIES_COLORS[i % SERIES_COLORS.length];
+            var s = c.addSeries(LightweightCharts.LineSeries, {
+                color: color,
+                lineWidth: 2,
+                priceFormat: { type: 'custom', formatter: function (v) { return (v >= 0 ? '+' : '') + v.toFixed(1) + '%'; }, minMove: 0.1 },
+            });
+            s.setData(rebased);
+            seriesByID[m.id] = s;
+            if (!firstSeries) firstSeries = s;
+        });
+        // Add a baseline at 0 to make "no change" visible.
+        if (firstSeries) {
+            firstSeries.createPriceLine({ price: 0, color: '#444', lineWidth: 1, lineStyle: 1, axisLabelVisible: false });
+        }
+        c.timeScale().fitContent();
+
+        // Track the crosshair so 'h' can drop a horizontal line at the hovered price.
+        c.subscribeCrosshairMove(function (param) {
+            if (!param || !firstSeries) { lastCrosshairValue = null; return; }
+            var v = param.seriesData && param.seriesData.get && param.seriesData.get(firstSeries);
+            if (v && typeof v.value === 'number') {
+                lastCrosshairValue = v.value;
+            }
+        });
+
+        renderLegend();
+    }
+
+    // Drop a horizontal price line at the last crosshair value (or midpoint if
+    // the user hasn't hovered the chart yet). Press 'h' again to add another.
+    window._ideasDrawHline = function () {
+        if (!chart || !firstSeries) return;
+        var price = lastCrosshairValue;
+        if (price == null) {
+            // Default to the mid of the visible price range so the line is on screen.
+            var range = firstSeries.priceScale ? firstSeries.priceScale().priceRange() : null;
+            price = range ? (range.minValue + range.maxValue) / 2 : 100;
+        }
+        var line = firstSeries.createPriceLine({
+            price: price,
+            color: '#ff8800',
+            lineWidth: 1,
+            lineStyle: 2, // dashed
+            axisLabelVisible: true,
+            title: price.toFixed(1),
+        });
+        priceLines.push(line);
+    };
+
+    window._ideasClearLines = function () {
+        if (!firstSeries) return;
+        priceLines.forEach(function (line) { try { firstSeries.removePriceLine(line); } catch (e) {} });
+        priceLines = [];
+    };
+
+    // ── Metric add / remove ──
+
+    function ensureSketch() {
+        if (currentSketch && currentSketch.id) return Promise.resolve(currentSketch);
+        // Lazy-create the default sketch on first :add so we have a place to persist to.
+        return fetch('/api/sketches', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: 'Untitled' }),
+        }).then(function (r) { return r.json(); })
+        .then(function (resp) {
+            return fetch('/api/sketches/' + resp.id).then(function (r) { return r.json(); });
+        }).then(function (sk) {
+            currentSketch = sk;
+            localStorage.setItem('stocktopus-last-sketch', String(sk.id));
+            history.replaceState({ view: 'ideas', sketchId: String(sk.id) }, '', '/ideas/' + sk.id);
+            return sk;
+        });
+    }
+
+    function addMetric(parsed) {
+        return ensureSketch().then(function (sk) {
+            var color = SERIES_COLORS[(sk.metrics || []).length % SERIES_COLORS.length];
+            var body = { kind: parsed.kind, identifier: parsed.identifier, label: parsed.label || parsed.identifier, color: color };
+            return fetch('/api/sketches/' + sk.id + '/metrics', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            }).then(function (r) { return r.ok ? r.json() : Promise.reject(r); })
+            .then(function () { return loadSketches(); })
+            .then(function () { return loadSketch(sk.id); });
+        });
+    }
+
+    function removeMetric(metricId) {
+        if (!currentSketch || !currentSketch.id) return;
+        fetch('/api/sketches/' + currentSketch.id + '/metrics/' + metricId, { method: 'DELETE' })
+            .then(function () { return loadSketch(currentSketch.id); });
+    }
+
+    // ── :add parser — exposed for terminal.js ──
+    //
+    //   :add AAPL              → {kind:'price', identifier:'AAPL'}
+    //   :add AAPL.revenue      → {kind:'financial', identifier:'AAPL.revenue'}
+    //   :add GCUSD             → {kind:'commodity', identifier:'GCUSD'}    (heuristic)
+    //   :add EURUSD            → {kind:'forex', identifier:'EURUSD'}
+    //   :add BTCUSD            → {kind:'crypto', identifier:'BTCUSD'}
+    //   :add (with selectedSecurity) → uses the picker's symbol as price
+    //
+    function parseAddArg(arg, fallbackSymbol) {
+        var raw = (arg || '').trim();
+        if (!raw) {
+            if (!fallbackSymbol) return null;
+            return { kind: 'price', identifier: fallbackSymbol, label: fallbackSymbol };
+        }
+        // Tickers can contain periods (BRK.A, BRK.B, GOOG.L), so split on the
+        // *rightmost* dot — everything after is the FMP field name (camelCase,
+        // case-sensitive). Examples:
+        //   AAPL.revenue              → AAPL + revenue
+        //   BRK.A.researchExpenses    → BRK.A + researchExpenses
+        var dot = raw.lastIndexOf('.');
+        if (dot > 0 && dot < raw.length - 1) {
+            var sym = raw.substring(0, dot).toUpperCase();
+            var field = raw.substring(dot + 1); // preserve case
+            return { kind: 'financial', identifier: sym + '.' + field, label: sym + ' ' + field };
+        }
+        var s = raw.toUpperCase();
+        // Heuristic classification by suffix:
+        //   USD-suffixed crypto (BTCUSD, ETHUSD), forex pairs (EURUSD, GBPUSD),
+        //   commodity codes (GCUSD, CLUSD, SIUSD). No clean way to tell — try
+        //   commodity for known codes, forex for currency pairs, otherwise stock.
+        var commodityPrefixes = ['GC','SI','CL','NG','HG','PL','PA','BZ','HO','RB','ZC','ZW','ZS','KC','SB','CC','CT'];
+        var forexCurrencies = ['USD','EUR','GBP','JPY','AUD','CAD','CHF','CNY','HKD','NZD','SEK','NOK','SGD','MXN'];
+        if (s.length === 5 && s.endsWith('USD')) {
+            var prefix = s.substring(0, s.length - 3);
+            if (commodityPrefixes.indexOf(prefix) >= 0) {
+                return { kind: 'commodity', identifier: s, label: s };
+            }
+        }
+        if (s.length === 6) {
+            var a = s.substring(0, 3), b = s.substring(3);
+            if (forexCurrencies.indexOf(a) >= 0 && forexCurrencies.indexOf(b) >= 0) {
+                return { kind: 'forex', identifier: s, label: a + '/' + b };
+            }
+            // Crypto pairs like BTCUSD, ETHUSD, SOLUSD — three-letter base + USD/USDT
+            if (b === 'USD' || b === 'EUR') {
+                return { kind: 'crypto', identifier: s, label: s };
+            }
+        }
+        return { kind: 'price', identifier: s, label: s };
+    }
+
+
+    // ── Public hooks ──
+    window._ideasAdd = function (arg, fallbackSymbol, toSketchName) {
+        var parsed = parseAddArg(arg, fallbackSymbol);
+        if (!parsed) return Promise.reject(new Error('no symbol'));
+        // Wait for initial loadSketches/loadSketch to finish so we don't race
+        // the default-sketchpad render against ensureSketch's POST.
+        return initPromise.then(function () {
+            if (toSketchName) {
+                var target = matchSketchByName(toSketchName);
+                if (target) {
+                    // Add to the named sketch (might be different from current)
+                    return addMetricToSketch(target.id, parsed).then(function () {
+                        return navigateToSketch(String(target.id));
+                    });
+                }
+                // Fall through if no name matched — silent: just add to current.
+            }
+            return addMetric(parsed);
+        });
+    };
+
+    function matchSketchByName(name) {
+        var lower = name.toLowerCase();
+        var exact = sketches.find(function (sk) { return sk.name.toLowerCase() === lower; });
+        if (exact) return exact;
+        return sketches.find(function (sk) { return sk.name.toLowerCase().indexOf(lower) === 0; });
+    }
+
+    function addMetricToSketch(sketchID, parsed) {
+        var color = SERIES_COLORS[Math.floor(Math.random() * SERIES_COLORS.length)];
+        var body = { kind: parsed.kind, identifier: parsed.identifier, label: parsed.label || parsed.identifier, color: color };
+        return fetch('/api/sketches/' + sketchID + '/metrics', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        }).then(function (r) { return r.ok ? r.json() : Promise.reject(r); });
+    }
+
+    window._ideasIsActive = function () {
+        return document.getElementById('ideas-chart-host') != null;
+    };
+
+    // Used by terminal.js to autocomplete ":add ... to <sketch>" — exposes the
+    // current sketches list (excluding the in-memory default scratchpad).
+    window._ideasGetSketches = function () {
+        return (sketches || []).slice();
+    };
+
+    // ── Vim navigation through the sketches sidebar (j/k, Enter to load) ──
+    window._ideasMoveList = function (dir) {
+        var items = Array.from(document.querySelectorAll('#ideas-list .ideas-list-item'));
+        if (!items.length) return;
+        if (dir === 'j') listSelectedIdx = Math.min(listSelectedIdx + 1, items.length - 1);
+        else if (dir === 'k') listSelectedIdx = Math.max(listSelectedIdx - 1, 0);
+        items.forEach(function (el, i) { el.classList.toggle('vim-selected', i === listSelectedIdx); });
+        if (items[listSelectedIdx]) items[listSelectedIdx].scrollIntoView({ block: 'nearest' });
+    };
+    window._ideasActivateList = function () {
+        var items = Array.from(document.querySelectorAll('#ideas-list .ideas-list-item'));
+        if (listSelectedIdx >= 0 && listSelectedIdx < items.length) {
+            navigateToSketch(items[listSelectedIdx].dataset.sketchId);
+        }
+    };
+
+    window._ideasSave = function (name) {
+        return ensureSketch().then(function (sk) {
+            var newName = (name || '').trim() || sk.name || 'Untitled';
+            return fetch('/api/sketches/' + sk.id, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: newName }),
+            }).then(function () {
+                currentSketch.name = newName;
+                renderSketch();
+                return loadSketches();
+            });
+        });
+    };
+
+    // ── Init ──
+
+    // Notes textarea — debounced save to avoid hammering the server on each keystroke.
+    var notesSaveTimer = null;
+    var notesEl = document.getElementById('ideas-notes-textarea');
+    if (notesEl) {
+        notesEl.addEventListener('input', function () {
+            clearTimeout(notesSaveTimer);
+            notesSaveTimer = setTimeout(function () {
+                if (!currentSketch || !currentSketch.id) return; // can't persist on default scratchpad
+                fetch('/api/sketches/' + currentSketch.id + '/notes', {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ notes: notesEl.value }),
+                });
+                if (currentSketch) currentSketch.notes = notesEl.value;
+            }, 600);
+        });
+    }
+
+    var initPromise = loadSketches().then(function () {
+        return loadSketch(initialSketchID);
+    });
+})();

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -2493,3 +2493,274 @@ li.kp-row::before {
     text-align: center;
 }
 .kp-link:hover { color: var(--orange); }
+
+/* ── Ideas / Sketchpad ── */
+
+.ideas-layout {
+    display: flex;
+    height: 100%;
+    flex: 1;
+    min-height: 0;
+}
+
+.terminal-content[data-view="ideas"] {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    padding: 0;
+}
+
+.ideas-sidebar {
+    width: 240px;
+    flex-shrink: 0;
+    background: var(--bg-secondary);
+    border-right: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    font-size: 12px;
+}
+
+.ideas-sidebar-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-primary);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    font-size: 11px;
+}
+
+.ideas-sidebar-meta {
+    color: var(--text-muted);
+    font-weight: normal;
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 10px;
+}
+
+.ideas-list {
+    list-style: none;
+    margin: 0;
+    padding: 4px 0;
+    flex: 1;
+    overflow-y: auto;
+}
+
+.ideas-list-item {
+    display: flex;
+    flex-direction: column;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--bg-tertiary);
+    cursor: pointer;
+}
+
+.ideas-list-item:hover {
+    background: var(--bg-tertiary);
+}
+
+.ideas-list-item.active {
+    background: var(--bg-tertiary);
+    border-left: 2px solid var(--orange);
+    padding-left: 10px;
+}
+
+.ideas-list-name {
+    color: var(--text-primary);
+    font-weight: 500;
+}
+
+.ideas-list-meta {
+    color: var(--text-muted);
+    font-size: 10px;
+    margin-top: 2px;
+}
+
+.ideas-sidebar-footer {
+    padding: 8px 12px;
+    border-top: 1px solid var(--border);
+    color: var(--text-muted);
+    font-size: 10px;
+}
+
+.ideas-hint kbd {
+    display: inline-block;
+    padding: 1px 4px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    color: var(--orange);
+    font-family: var(--font-mono);
+    font-size: 10px;
+}
+
+.ideas-main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding: 16px;
+    min-width: 0;
+}
+
+.ideas-header {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+
+.ideas-title {
+    margin: 0;
+    font-size: 14px;
+    color: var(--text-primary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.ideas-meta {
+    color: var(--text-muted);
+    font-size: 11px;
+}
+
+.ideas-chart-host {
+    flex: 1;
+    min-height: 0;
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    overflow: hidden;
+    position: relative;
+}
+
+#ideas-chart-host a[href*="tradingview"] {
+    display: none !important;
+}
+
+.ideas-legend {
+    margin-top: 8px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 12px;
+}
+
+.ideas-legend-row {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    background: var(--bg-tertiary);
+    font-size: 11px;
+}
+
+.ideas-legend-swatch {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 1px;
+}
+
+.ideas-legend-label {
+    color: var(--text-primary);
+    font-weight: 500;
+}
+
+.ideas-legend-val {
+    color: var(--text-secondary);
+}
+
+.ideas-legend-pct {
+    color: var(--text-muted);
+}
+
+.ideas-legend-del {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 14px;
+    padding: 0 2px;
+    line-height: 1;
+}
+.ideas-legend-del:hover { color: var(--red); }
+
+.ideas-empty {
+    display: none;
+    margin-top: 16px;
+    padding: 24px;
+    border: 1px dashed var(--border);
+    border-radius: 2px;
+    color: var(--text-secondary);
+    text-align: center;
+}
+
+.ideas-empty p { margin: 0 0 8px; }
+.ideas-empty .empty-hint {
+    color: var(--text-muted);
+    font-size: 11px;
+}
+.ideas-empty kbd {
+    display: inline-block;
+    padding: 1px 6px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    color: var(--orange);
+    font-family: var(--font-mono);
+    font-size: 11px;
+}
+
+.ideas-notes {
+    width: 280px;
+    flex-shrink: 0;
+    background: var(--bg-secondary);
+    border-left: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+}
+
+.ideas-notes-header {
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-primary);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    font-size: 11px;
+}
+
+.ideas-notes-textarea {
+    flex: 1;
+    padding: 12px;
+    background: transparent;
+    border: none;
+    outline: none;
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    line-height: 1.6;
+    resize: none;
+}
+
+.ideas-notes-textarea::placeholder {
+    color: var(--text-muted);
+}
+
+.ideas-list-item.vim-selected {
+    background: var(--bg-tertiary);
+    border-left: 2px solid var(--blue);
+    padding-left: 10px;
+}
+
+.ideas-legend-row-err {
+    border-color: #3a1a1a;
+    background: rgba(58, 26, 26, 0.4);
+}
+.ideas-legend-err {
+    color: var(--red);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -32,6 +32,7 @@ window.onerror = function (msg, src, line, col, err) {
         info:       { path: '/security/{symbol}', needsSecurity: true, usage: 'info <SECURITY>',     desc: 'deep-dive company fundamentals for SECURITY' },
         news:       { path: '/news',            needsSecurity: false, usage: 'news [SECURITY]',     desc: 'market news — optionally filter by security', optionalSecurity: true },
         ei:         { path: '/indices',          needsSecurity: false, usage: 'ei',                  desc: 'equity indices — global market overview' },
+        ideas:      { path: '/ideas',           needsSecurity: false, usage: 'ideas',               desc: 'sketchpad — comparative graphs across metrics' },
         screener:   { path: '/screener',        needsSecurity: false, usage: 'screener',            desc: 'filter and scan stocks by criteria' },
         debug:      { path: '/debug',           needsSecurity: false, usage: 'debug',               desc: 'live server log console' },
         analyze:    { path: '/security/{symbol}#ai', needsSecurity: true, usage: 'analyze <SECURITY>',  desc: 'run deep multi-agent trading analysis', aliases: ['az'] },
@@ -80,12 +81,18 @@ window.onerror = function (msg, src, line, col, err) {
             path = path.replace('{symbol}', resolved);
             setSecurity(resolved);
         }
+        // Caller-supplied explicit path wins over the COMMANDS template. Used
+        // by executeIdeasAdd to land on /ideas/{lastId} instead of the default.
+        if (opts.path) {
+            path = opts.path;
+        }
 
-        // Preserve the current URL hash (sub-tab state) when going back via popstate;
-        // the browser already restored it before firing popstate, but our explicit
-        // pushPath would clobber it. For forward navigation we always start clean.
-        if (opts.fromHistory && location.hash) {
-            path = path + location.hash;
+        // When going back via popstate the browser has already restored the
+        // exact URL (including any sub-resource id like /ideas/5 or hash like
+        // #financials-income). Use that directly so we don't lose the id by
+        // re-templating cmd.path.
+        if (opts.fromHistory) {
+            path = location.pathname + location.search + location.hash;
         }
 
         // Handle optional security (e.g. news MSFT)
@@ -105,14 +112,18 @@ window.onerror = function (msg, src, line, col, err) {
             container.dataset.view = command;
             currentView = command;
 
-            // Execute any <script> tags in the loaded fragment (in order)
+            // Execute any <script> tags in the loaded fragment (in order).
+            // Copy *all* attributes so things like data-sketch-id come through to
+            // the script — otherwise document.currentScript.dataset is empty.
             var scripts = Array.from(container.querySelectorAll('script'));
             (function loadNext(i) {
                 if (i >= scripts.length) return;
                 var old = scripts[i];
                 var s = document.createElement('script');
+                for (var a = 0; a < old.attributes.length; a++) {
+                    s.setAttribute(old.attributes[a].name, old.attributes[a].value);
+                }
                 if (old.src) {
-                    s.src = old.src;
                     s.onload = function () { loadNext(i + 1); };
                     s.onerror = function () { loadNext(i + 1); };
                 } else {
@@ -941,6 +952,14 @@ window.onerror = function (msg, src, line, col, err) {
                     if (item.dataset.watchlistName) {
                         input.value = ':watch ' + item.dataset.watchlistName;
                         hideCmdDropdown();
+                    } else if (item.dataset.field) {
+                        input.value = ':add ' + item.dataset.sym + '.' + item.dataset.field;
+                        hideCmdDropdown();
+                    } else if (item.dataset.sketchName) {
+                        var existing = input.value;
+                        var toI = existing.toLowerCase().lastIndexOf(' to ');
+                        input.value = (toI > 0 ? existing.substring(0, toI + 4) : existing.replace(/\s+$/, '') + ' to ') + item.dataset.sketchName;
+                        hideCmdDropdown();
                     } else if (item.dataset.symbol) {
                         input.value = item.dataset.cmd + ' ' + item.dataset.symbol;
                     } else {
@@ -952,6 +971,34 @@ window.onerror = function (msg, src, line, col, err) {
                 // If dropdown is visible and a watchlist option is highlighted, execute the watch.
                 if (!dropdown.classList.contains('hidden') && cmdDropdownIndex >= 0 && items[cmdDropdownIndex]) {
                     var item = items[cmdDropdownIndex];
+                    if (item.dataset.field) {
+                        // :add SYM.<field> — execute right away
+                        hideCmdDropdown();
+                        commandHistory.push(':add ' + item.dataset.sym + '.' + item.dataset.field);
+                        historyIndex = commandHistory.length;
+                        input.value = '';
+                        enterNormalMode();
+                        executeIdeasAdd(item.dataset.sym + '.' + item.dataset.field, '');
+                        return;
+                    }
+                    if (item.dataset.sketchName) {
+                        // ":add <metric> to <sketch>" — combine current input + selection then execute
+                        var existing = input.value;
+                        var toIE = existing.toLowerCase().lastIndexOf(' to ');
+                        var withTo = (toIE > 0 ? existing.substring(0, toIE + 4) : existing.replace(/\s+$/, '') + ' to ') + item.dataset.sketchName;
+                        var afterColon = withTo.charAt(0) === ':' ? withTo.substring(1) : withTo;
+                        var addArg2 = afterColon.toLowerCase().startsWith('add ') ? afterColon.substring(4) : afterColon;
+                        var toI2 = addArg2.toLowerCase().lastIndexOf(' to ');
+                        var metric2 = toI2 > 0 ? addArg2.substring(0, toI2).trim() : addArg2.trim();
+                        var sketch2 = toI2 > 0 ? addArg2.substring(toI2 + 4).trim() : '';
+                        hideCmdDropdown();
+                        commandHistory.push(withTo);
+                        historyIndex = commandHistory.length;
+                        input.value = '';
+                        enterNormalMode();
+                        executeIdeasAdd(metric2, sketch2);
+                        return;
+                    }
                     if (item.dataset.watchlistName) {
                         hideCmdDropdown();
                         executeWatchCommand(parseInt(item.dataset.watchlistId, 10), item.dataset.watchlistName);
@@ -1040,6 +1087,42 @@ window.onerror = function (msg, src, line, col, err) {
                         if (wlName) createWatchlist(wlName);
                         input.value = '';
                         enterNormalMode();
+                        return;
+                    }
+
+                    // :add <metric> [to <sketch>] — push a metric onto a sketchpad.
+                    // Navigates to /ideas first if not already there.
+                    if (colonLower === 'add' || colonLower.startsWith('add ')) {
+                        var addArgRaw = colonCmd.substring(3).trim();
+                        var toIdx = addArgRaw.toLowerCase().lastIndexOf(' to ');
+                        var addMetric = addArgRaw, addToSketch = '';
+                        if (toIdx > 0) {
+                            addMetric = addArgRaw.substring(0, toIdx).trim();
+                            addToSketch = addArgRaw.substring(toIdx + 4).trim();
+                        }
+                        input.value = '';
+                        hideCmdDropdown();
+                        enterNormalMode();
+                        executeIdeasAdd(addMetric, addToSketch);
+                        return;
+                    }
+
+                    // :save <name> — name + persist the current sketch
+                    if (colonLower === 'save' || colonLower.startsWith('save ')) {
+                        var saveName = colonCmd.substring(4).trim();
+                        input.value = '';
+                        hideCmdDropdown();
+                        enterNormalMode();
+                        if (window._ideasSave) window._ideasSave(saveName);
+                        return;
+                    }
+
+                    // :cl — clear horizontal price lines on the sketchpad chart
+                    if (colonLower === 'cl' || colonLower === 'clear') {
+                        input.value = '';
+                        hideCmdDropdown();
+                        enterNormalMode();
+                        if (window._ideasClearLines) window._ideasClearLines();
                         return;
                     }
 
@@ -1142,6 +1225,34 @@ window.onerror = function (msg, src, line, col, err) {
         input.focus();
     }
 
+    // Polls until ideas.js init has populated _ideasAdd. Used by the :add
+    // handler to avoid a flat 100ms setTimeout race against the ideas init.
+    function whenIdeasReady(fn) {
+        var tries = 0;
+        (function check() {
+            if (window._ideasAdd) { fn(); return; }
+            if (++tries > 40) return; // ~2s ceiling
+            setTimeout(check, 50);
+        })();
+    }
+
+    // Common path for "execute :add <metric> [to <sketch>]" — used both by
+    // typed Enter and by Enter on a dropdown selection. When run from a
+    // foreign page (not /ideas), resume the last-used sketch instead of
+    // dropping the user onto the default scratchpad.
+    function executeIdeasAdd(metric, toSketch) {
+        var fallback = selectedSecurity || '';
+        if (currentView !== 'ideas') {
+            var lastId = localStorage.getItem('stocktopus-last-sketch');
+            var ideasPath = lastId ? '/ideas/' + lastId : '/ideas';
+            navigate('ideas', '', { path: ideasPath }).then(function () {
+                whenIdeasReady(function () { window._ideasAdd(metric, fallback, toSketch); });
+            });
+        } else if (window._ideasAdd) {
+            window._ideasAdd(metric, fallback, toSketch);
+        }
+    }
+
     function hideCmdDropdown() {
         var dropdown = document.getElementById('cmd-dropdown');
         dropdown.classList.add('hidden');
@@ -1169,6 +1280,27 @@ window.onerror = function (msg, src, line, col, err) {
                 clearTimeout(searchTimer);
                 var query = afterColonLower === 'watch' ? '' : afterColon.substring(6);
                 renderCmdWatchlistDropdown(query);
+                return;
+            }
+
+            // :add <metric> [to <sketch>] — autocomplete fields after a dot,
+            // and saved sketches after " to ".
+            if (afterColonLower.startsWith('add ')) {
+                clearTimeout(searchTimer);
+                var addArg = afterColon.substring(4); // preserve case
+                var toIdx = addArg.toLowerCase().lastIndexOf(' to ');
+                if (toIdx >= 0) {
+                    var sketchPrefix = addArg.substring(toIdx + 4);
+                    renderCmdSketchDropdown(sketchPrefix);
+                    return;
+                }
+                var dotIdx = addArg.lastIndexOf('.');
+                if (dotIdx > 0 && dotIdx < addArg.length) {
+                    var fieldPrefix = addArg.substring(dotIdx + 1);
+                    renderCmdFieldDropdown(addArg.substring(0, dotIdx), fieldPrefix);
+                    return;
+                }
+                hideCmdDropdown();
                 return;
             }
         }
@@ -1278,6 +1410,100 @@ window.onerror = function (msg, src, line, col, err) {
         return { type: 'symbol', symbol: arg.toUpperCase() };
     }
 
+    // Field list for :add SYMBOL.<prefix> autocomplete. Mirrors the rows we
+    // render on the Financials tab. Extending: add the new field name here.
+    var FIN_FIELDS = [
+        // Income
+        'revenue', 'costOfRevenue', 'grossProfit', 'researchAndDevelopmentExpenses',
+        'sellingGeneralAndAdministrativeExpenses', 'operatingIncome', 'interestExpense',
+        'incomeBeforeTax', 'incomeTaxExpense', 'ebitda', 'netIncome', 'eps',
+        // Balance
+        'totalAssets', 'totalCurrentAssets', 'cashAndCashEquivalents', 'shortTermInvestments',
+        'netReceivables', 'inventory', 'goodwill', 'intangibleAssets', 'totalLiabilities',
+        'totalCurrentLiabilities', 'shortTermDebt', 'longTermDebt', 'totalDebt',
+        'totalStockholdersEquity', 'retainedEarnings',
+        // Cash flow
+        'operatingCashFlow', 'depreciationAndAmortization', 'stockBasedCompensation',
+        'accountsReceivables', 'accountsPayables', 'netCashUsedForInvestingActivities',
+        'netCashUsedProvidedByFinancingActivities', 'debtRepayment', 'capitalExpenditure',
+        'freeCashFlow', 'netChangeInCash', 'dividendsPaid', 'commonStockRepurchased',
+    ];
+
+    function renderCmdFieldDropdown(symPart, fieldPrefix) {
+        var dropdown = document.getElementById('cmd-dropdown');
+        var p = (fieldPrefix || '').toLowerCase();
+        var matches = FIN_FIELDS.filter(function (f) {
+            return !p || f.toLowerCase().indexOf(p) >= 0;
+        });
+        // Prefix matches first
+        matches.sort(function (a, b) {
+            var ap = a.toLowerCase().indexOf(p) === 0 ? 0 : 1;
+            var bp = b.toLowerCase().indexOf(p) === 0 ? 0 : 1;
+            return ap - bp;
+        });
+        if (!matches.length) { hideCmdDropdown(); return; }
+        var symLabel = (symPart || 'SYMBOL').toUpperCase();
+        dropdown.innerHTML = matches.slice(0, 12).map(function (f) {
+            return '<div class="cmd-option cmd-field-option" data-cmd="add" data-sym="' + escapeHtml(symLabel) + '" data-field="' + escapeHtml(f) + '">'
+                + '<span class="cmd-option-usage">add ' + escapeHtml(symLabel) + '.' + escapeHtml(f) + '</span>'
+                + '<span class="cmd-option-desc">project ' + escapeHtml(f) + ' onto current sketch</span>'
+                + '</div>';
+        }).join('');
+        dropdown.classList.remove('hidden');
+        cmdDropdownIndex = -1;
+
+        dropdown.querySelectorAll('.cmd-field-option').forEach(function (el) {
+            el.onmousedown = function (e) {
+                e.preventDefault();
+                var input = document.getElementById('cmd-input');
+                input.value = ':add ' + el.dataset.sym + '.' + el.dataset.field;
+                hideCmdDropdown();
+                input.focus();
+                input.setSelectionRange(input.value.length, input.value.length);
+            };
+        });
+    }
+
+    function renderCmdSketchDropdown(prefix) {
+        var dropdown = document.getElementById('cmd-dropdown');
+        var sketches = (window._ideasGetSketches && window._ideasGetSketches()) || [];
+        var p = (prefix || '').toLowerCase();
+        var matches = sketches.filter(function (sk) {
+            return !p || (sk.name || '').toLowerCase().indexOf(p) >= 0;
+        });
+        if (!matches.length) {
+            dropdown.innerHTML = '<div class="cmd-option cmd-option-empty">No saved sketch matches "' + escapeHtml(prefix) + '"</div>';
+            dropdown.classList.remove('hidden');
+            cmdDropdownIndex = -1;
+            return;
+        }
+        dropdown.innerHTML = matches.slice(0, 12).map(function (sk) {
+            return '<div class="cmd-option cmd-sketch-option" data-sketch-name="' + escapeHtml(sk.name) + '">'
+                + '<span class="cmd-option-usage">to ' + escapeHtml(sk.name) + '</span>'
+                + '<span class="cmd-option-desc">add to that saved sketch</span>'
+                + '</div>';
+        }).join('');
+        dropdown.classList.remove('hidden');
+        cmdDropdownIndex = -1;
+
+        dropdown.querySelectorAll('.cmd-sketch-option').forEach(function (el) {
+            el.onmousedown = function (e) {
+                e.preventDefault();
+                var input = document.getElementById('cmd-input');
+                var existing = input.value;
+                var toIdx = existing.toLowerCase().lastIndexOf(' to ');
+                if (toIdx > 0) {
+                    input.value = existing.substring(0, toIdx + 4) + el.dataset.sketchName;
+                } else {
+                    input.value = existing.replace(/\s+$/, '') + ' to ' + el.dataset.sketchName;
+                }
+                hideCmdDropdown();
+                input.focus();
+                input.setSelectionRange(input.value.length, input.value.length);
+            };
+        });
+    }
+
     function renderCmdSecurityDropdown(results, cmdName) {
         var dropdown = document.getElementById('cmd-dropdown');
         // Guard against stale debounced fires that come back after the user has
@@ -1359,6 +1585,16 @@ window.onerror = function (msg, src, line, col, err) {
     // ── Per-View Vim Handlers ──
 
     var vimHandlers = {
+        ideas: {
+            move: function (dir) {
+                if (dir === 'j' || dir === 'k') {
+                    if (window._ideasMoveList) window._ideasMoveList(dir);
+                }
+            },
+            activate: function () {
+                if (window._ideasActivateList) window._ideasActivateList();
+            },
+        },
         watchlist: {
             getItems: function () {
                 // Only visible rows (filtered by active watchlist)
@@ -1877,6 +2113,34 @@ window.onerror = function (msg, src, line, col, err) {
                     }
                 }
                 return;
+            case '\\':
+                // Drop a horizontal price line on the sketchpad chart at the last
+                // hovered crosshair value (or midpoint if the user hasn't hovered).
+                if (currentView === 'ideas' && window._ideasDrawHline) {
+                    e.preventDefault();
+                    window._ideasDrawHline();
+                }
+                return;
+            case 'a':
+                // 'a' on a highlighted Financials row prefills :add SYMBOL.field
+                // in the command bar so the user can confirm + send to the sketchpad.
+                if (handler && handler.isFinTab && handler.isFinTab()) {
+                    var rows = window._finGetRows ? window._finGetRows() : [];
+                    var idx = window._finGetSelectedRow ? window._finGetSelectedRow() : -1;
+                    if (idx >= 0 && idx < rows.length) {
+                        var row = rows[idx];
+                        var key = row.dataset.finKey || '';
+                        // Skip calculated rows (margins) — they're not raw fields the sketch can fetch.
+                        if (row.dataset.finFormat === 'calc' || !key || key.indexOf('/') >= 0) return;
+                        if (!selectedSecurity) return;
+                        e.preventDefault();
+                        var cmdInput = document.getElementById('cmd-input');
+                        cmdInput.value = ':add ' + selectedSecurity + '.' + key;
+                        cmdInput.focus();
+                        cmdInput.setSelectionRange(cmdInput.value.length, cmdInput.value.length);
+                    }
+                }
+                return;
             case '1': case '2': case '3': case '4': case '5': case '6': case '7':
                 if (handler && handler.jumpToTab) {
                     e.preventDefault();
@@ -2242,9 +2506,9 @@ window.onerror = function (msg, src, line, col, err) {
             var from = new Date(Date.now() - 7 * 86400000).toISOString().slice(0, 10);
             var to = new Date().toISOString().slice(0, 10);
             fetch('/api/chart/eod/' + encodeURIComponent(sym) + '?from=' + from + '&to=' + to)
-                .then(function (r) { return r.json(); })
+                .then(function (r) { return r.ok ? r.json() : null; })
                 .then(function (eod) {
-                    if (!eod || eod.length < 1) return;
+                    if (!Array.isArray(eod) || eod.length < 1) return;
                     var latest = eod[eod.length - 1];
                     var prev = eod.length > 1 ? eod[eod.length - 2] : latest;
                     var chg = latest.close - prev.close;
@@ -2292,9 +2556,9 @@ window.onerror = function (msg, src, line, col, err) {
             from.setMonth(from.getMonth() - 6);
             var to = new Date();
             fetch('/api/chart/eod/' + symbol + '?from=' + from.toISOString().slice(0, 10) + '&to=' + to.toISOString().slice(0, 10))
-                .then(function (r) { return r.json(); })
+                .then(function (r) { return r.ok ? r.json() : null; })
                 .then(function (data) {
-                    if (!data || data.length < 2) return;
+                    if (!Array.isArray(data) || data.length < 2) return;
                     var first = data[0].close;
                     var last = data[data.length - 1].close;
                     var color = last >= first ? '#00cc66' : '#ff4444';

--- a/internal/server/templates/ideas.html
+++ b/internal/server/templates/ideas.html
@@ -1,0 +1,36 @@
+{{template "layout" .}}
+{{define "content"}}
+<div class="ideas-layout">
+    <aside class="ideas-sidebar" id="ideas-sidebar">
+        <div class="ideas-sidebar-header">
+            <span>Sketches</span>
+            <span class="ideas-sidebar-meta" id="ideas-sketch-count"></span>
+        </div>
+        <ul class="ideas-list" id="ideas-list">
+            <li class="empty-state">Loading…</li>
+        </ul>
+        <div class="ideas-sidebar-footer">
+            <span class="ideas-hint"><kbd>:save</kbd> to name &amp; persist</span>
+        </div>
+    </aside>
+    <section class="ideas-main">
+        <div class="ideas-header">
+            <h2 class="ideas-title" id="ideas-title">Default Sketchpad</h2>
+            <span class="ideas-meta" id="ideas-meta">no metrics yet</span>
+        </div>
+        <div id="ideas-chart-host" class="ideas-chart-host"></div>
+        <div id="ideas-legend" class="ideas-legend"></div>
+        <div id="ideas-empty" class="ideas-empty">
+            <p>No metrics on this sketch yet.</p>
+            <p class="empty-hint">Add one with <kbd>:add AAPL</kbd>, <kbd>:add AAPL.revenue</kbd>, <kbd>:add GCUSD</kbd> (gold), <kbd>:add EURUSD</kbd>, <kbd>:add BTCUSD</kbd> …</p>
+            <p class="empty-hint">From the Financials tab, press <kbd>a</kbd> on a highlighted row to prefill <kbd>:add SYMBOL.field</kbd>.</p>
+            <p class="empty-hint"><kbd>\</kbd> drops a horizontal line at the crosshair, <kbd>:cl</kbd> clears them, <kbd>:save NAME</kbd> persists the current sketch.</p>
+        </div>
+    </section>
+    <aside class="ideas-notes" id="ideas-notes-panel">
+        <div class="ideas-notes-header">Notes</div>
+        <textarea id="ideas-notes-textarea" class="ideas-notes-textarea" placeholder="Free-form notes for this sketch — saved automatically."></textarea>
+    </aside>
+</div>
+<script src="/static/ideas.js?v={{.AssetVersion}}" data-sketch-id="{{.SketchID}}"></script>
+{{end}}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -162,6 +162,39 @@ func (s *Store) migrate() error {
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		);
 		CREATE INDEX IF NOT EXISTS idx_people_symbol ON key_people(symbol);
+
+		CREATE TABLE IF NOT EXISTS users (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			handle TEXT NOT NULL UNIQUE,
+			display_name TEXT NOT NULL DEFAULT '',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
+
+		-- Single global user for now — every sketch belongs to this row.
+		-- Refactored to per-user later by adding more rows + auth.
+		INSERT OR IGNORE INTO users (id, handle, display_name) VALUES (1, 'global', 'Global');
+
+		CREATE TABLE IF NOT EXISTS sketches (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			owner_id INTEGER NOT NULL DEFAULT 1,
+			name TEXT NOT NULL DEFAULT '',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (owner_id) REFERENCES users(id)
+		);
+		CREATE INDEX IF NOT EXISTS idx_sketches_owner ON sketches(owner_id);
+
+		CREATE TABLE IF NOT EXISTS sketch_metrics (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			sketch_id INTEGER NOT NULL,
+			kind TEXT NOT NULL,        -- 'price' | 'financial' | 'commodity' | 'forex' | 'crypto' | 'index'
+			identifier TEXT NOT NULL,  -- 'AAPL' | 'AAPL.revenue' | 'GCUSD' | 'EURUSD' | 'BTCUSD' | 'SPX'
+			label TEXT NOT NULL DEFAULT '',
+			color TEXT NOT NULL DEFAULT '',
+			position INTEGER NOT NULL DEFAULT 0,
+			FOREIGN KEY (sketch_id) REFERENCES sketches(id) ON DELETE CASCADE
+		);
+		CREATE INDEX IF NOT EXISTS idx_sketch_metrics_sketch ON sketch_metrics(sketch_id);
 	`)
 	if err != nil {
 		return err
@@ -189,6 +222,10 @@ func (s *Store) migrate() error {
 		return err
 	}
 	if _, err := s.db.Exec(`ALTER TABLE key_people ADD COLUMN form_type TEXT DEFAULT ''`); err != nil &&
+		!strings.Contains(err.Error(), "duplicate column") {
+		return err
+	}
+	if _, err := s.db.Exec(`ALTER TABLE sketches ADD COLUMN notes TEXT NOT NULL DEFAULT ''`); err != nil &&
 		!strings.Contains(err.Error(), "duplicate column") {
 		return err
 	}
@@ -810,4 +847,124 @@ func (s *Store) GetKeyPeople(symbol string) ([]KeyPerson, error) {
 		people = append(people, p)
 	}
 	return people, nil
+}
+
+// ── Ideas Sketchpad ──────────────────────────────────────────────────────────
+
+// SketchMetric is one series in a sketch — a metric to plot alongside others.
+type SketchMetric struct {
+	ID         int64  `json:"id"`
+	SketchID   int64  `json:"sketchId"`
+	Kind       string `json:"kind"`       // 'price' | 'financial' | 'commodity' | 'forex' | 'crypto' | 'index'
+	Identifier string `json:"identifier"` // 'AAPL' | 'AAPL.revenue' | 'GCUSD' | 'EURUSD' | 'BTCUSD' | 'SPX'
+	Label      string `json:"label"`
+	Color      string `json:"color"`
+	Position   int    `json:"position"`
+}
+
+// Sketch is a saved comparison chart — a named bag of metrics owned by a user.
+type Sketch struct {
+	ID        int64          `json:"id"`
+	OwnerID   int64          `json:"ownerId"`
+	Name      string         `json:"name"`
+	Notes     string         `json:"notes"`
+	CreatedAt time.Time      `json:"createdAt"`
+	UpdatedAt time.Time      `json:"updatedAt"`
+	Metrics   []SketchMetric `json:"metrics"`
+}
+
+// CreateSketch inserts a new sketch (typically empty) and returns its id.
+func (s *Store) CreateSketch(ownerID int64, name string) (int64, error) {
+	if ownerID == 0 {
+		ownerID = 1
+	}
+	res, err := s.db.Exec(`INSERT INTO sketches (owner_id, name) VALUES (?, ?)`, ownerID, name)
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// RenameSketch updates an existing sketch's name and bumps updated_at.
+func (s *Store) RenameSketch(id int64, name string) error {
+	_, err := s.db.Exec(`UPDATE sketches SET name = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, name, id)
+	return err
+}
+
+// UpdateSketchNotes saves the free-text notes panel for a sketch.
+func (s *Store) UpdateSketchNotes(id int64, notes string) error {
+	_, err := s.db.Exec(`UPDATE sketches SET notes = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, notes, id)
+	return err
+}
+
+// DeleteSketch removes a sketch and (cascade) its metrics.
+func (s *Store) DeleteSketch(id int64) error {
+	_, err := s.db.Exec(`DELETE FROM sketches WHERE id = ?`, id)
+	return err
+}
+
+// ListSketches returns all sketches for an owner, newest first.
+func (s *Store) ListSketches(ownerID int64) ([]Sketch, error) {
+	if ownerID == 0 {
+		ownerID = 1
+	}
+	rows, err := s.db.Query(`SELECT id, owner_id, name, COALESCE(notes, ''), created_at, updated_at FROM sketches WHERE owner_id = ? ORDER BY updated_at DESC`, ownerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Sketch
+	for rows.Next() {
+		var sk Sketch
+		if err := rows.Scan(&sk.ID, &sk.OwnerID, &sk.Name, &sk.Notes, &sk.CreatedAt, &sk.UpdatedAt); err != nil {
+			continue
+		}
+		out = append(out, sk)
+	}
+	return out, nil
+}
+
+// GetSketch returns a single sketch with its metrics in position order.
+func (s *Store) GetSketch(id int64) (*Sketch, error) {
+	row := s.db.QueryRow(`SELECT id, owner_id, name, COALESCE(notes, ''), created_at, updated_at FROM sketches WHERE id = ?`, id)
+	var sk Sketch
+	if err := row.Scan(&sk.ID, &sk.OwnerID, &sk.Name, &sk.Notes, &sk.CreatedAt, &sk.UpdatedAt); err != nil {
+		return nil, err
+	}
+	mrows, err := s.db.Query(`SELECT id, sketch_id, kind, identifier, label, color, position FROM sketch_metrics WHERE sketch_id = ? ORDER BY position ASC, id ASC`, id)
+	if err != nil {
+		return nil, err
+	}
+	defer mrows.Close()
+	for mrows.Next() {
+		var m SketchMetric
+		if err := mrows.Scan(&m.ID, &m.SketchID, &m.Kind, &m.Identifier, &m.Label, &m.Color, &m.Position); err == nil {
+			sk.Metrics = append(sk.Metrics, m)
+		}
+	}
+	return &sk, nil
+}
+
+// AddSketchMetric appends a metric to a sketch. Position defaults to current count.
+func (s *Store) AddSketchMetric(m SketchMetric) (int64, error) {
+	if m.Position == 0 {
+		var n int
+		_ = s.db.QueryRow(`SELECT COUNT(*) FROM sketch_metrics WHERE sketch_id = ?`, m.SketchID).Scan(&n)
+		m.Position = n
+	}
+	res, err := s.db.Exec(
+		`INSERT INTO sketch_metrics (sketch_id, kind, identifier, label, color, position) VALUES (?, ?, ?, ?, ?, ?)`,
+		m.SketchID, m.Kind, m.Identifier, m.Label, m.Color, m.Position,
+	)
+	if err != nil {
+		return 0, err
+	}
+	_, _ = s.db.Exec(`UPDATE sketches SET updated_at = CURRENT_TIMESTAMP WHERE id = ?`, m.SketchID)
+	return res.LastInsertId()
+}
+
+// RemoveSketchMetric drops a metric row by id.
+func (s *Store) RemoveSketchMetric(id int64) error {
+	_, err := s.db.Exec(`DELETE FROM sketch_metrics WHERE id = ?`, id)
+	return err
 }


### PR DESCRIPTION
## Summary

A new \`/ideas\` page where you can plot multiple metrics on the same chart rebased to "% change from start", so vastly different series (stock prices, financial fields, commodities, forex, crypto) become directly comparable. Sketches are persisted as named bags of metrics owned by a single \`global\` user (designed to refactor cleanly to per-user later).

Built towards the use case of comparing macro / cross-asset thought experiments — "how has the price of oil affected this stock's debt", "how does CPI track against this sector's revenue growth", etc.

### Backend
- New tables: \`users\` (seeded with id=1 'global'), \`sketches\`, \`sketch_metrics\`, plus a \`notes\` column on \`sketches\`.
- CRUD routes: \`GET/POST /api/sketches\`, \`GET/PATCH/DELETE /api/sketches/{id}\`, \`POST/DELETE /api/sketches/{id}/metrics[/{metricId}]\`, \`PUT /api/sketches/{id}/notes\`.
- Generic \`GET /api/historical/{kind}/{symbol}\` that fronts FMP's EOD-light endpoint uniformly for stocks/commodities/forex/crypto/indices and delegates to the income/balance/cashflow statement endpoints for \`kind=financial\`.
- The \`ticker.field\` split is **rightmost-dot** so tickers with periods (\`BRK.A\`, \`GOOG.L\`) keep working; the field portion is case-preserved so camelCase FMP fields like \`researchAndDevelopmentExpenses\` are not mangled.
- 4xx/5xx responses surface as red **"premium FMP plan required"** / **"symbol not found"** pills in the legend instead of silently rendering nothing.

### Frontend
- Three-column layout: sketches sidebar, chart + legend, notes textarea (debounced auto-save).
- Up to 3 series shown; each plotted as \`((value - base) / |base|) * 100\`. Crucially this preserves direction for any sign — DJT's growing operating loss now charts as clearly negative instead of optically positive (the original "rebase to 100" math hid the sign because both numerator and denominator were negative).
- Faint baseline at 0% anchors "no change" visually.

### Command-bar integration
- \`:add SYMBOL\` adds a price series.
- \`:add SYMBOL.field\` projects a financial field per fiscal year.
- \`:add SYMBOL.<prefix>\` opens autocomplete of canonical FMP statement fields (revenue, grossProfit, totalAssets, ebitda, …).
- \`:add metric to <prefix>\` autocompletes saved sketch names so you can target a specific one without first navigating to it.
- \`:save NAME\` persists the active scratchpad as a named sketch.
- \`:cl\` clears horizontal price lines.
- \`\\\` drops a horizontal price line at the crosshair value.
- \`a\` on a highlighted Financials row prefills \`:add SYMBOL.field\` in the cmd bar.

### UX polish
- Vim \`j\`/\`k\` navigates the sketches sidebar, Enter loads the selected sketch.
- \`:add\` from a foreign page resumes the user's **last-used sketch** (tracked in localStorage) instead of dumping them onto the default scratchpad and creating a new one every time.
- TradingView attribution logo hidden on this chart too.

### Plumbing fixes folded in
- Fragment script loader now copies **all attributes** to the replacement \`<script>\` element, so things like \`data-sketch-id\` propagate to \`document.currentScript.dataset\`. Was being lost, leaving \`initialSketchID\` undefined after popstate.
- \`navigate()\` accepts \`opts.path\` so callers can land on a specific sub-resource URL when the COMMANDS template doesn't match.
- popstate-driven \`navigate()\` reads \`location.pathname\` instead of re-templating \`cmd.path\`, so \`/ideas/5\` isn't lost when the user presses \`-\`.
- Hardened the company-panel sparkline + cpanel EOD fetch with \`Array.isArray\` guards — a 4xx error response (which the server serializes as \`{"error": ...}\`) no longer crashes JS on \`data[0].close\`.

Migrations are idempotent — safe on existing DBs.

## Test plan
- [x] \`make build\`
- [x] \`make test\`
- [x] \`make smoke\`
- [ ] \`/ideas\` opens with empty default scratchpad
- [x] \`:add AAPL\` plots Apple's price as % change
- [x] \`:add EURUSD\` plots a forex pair correctly
- [x] \`:add CLUSD\` (commodity) shows "premium FMP plan required" pill (free tier)
- [x] \`:add AAPL.revenue\`, \`:add DJT.operatingIncome\` plot correctly with sign preserved
- [x] \`:add SYMBOL.\` shows field autocomplete; Tab fills, Enter executes
- [x] \`:add metric to <prefix>\` autocompletes saved sketches
- [x] \`:save Macro Watch\` names the sketch; sidebar updates
- [x] j/k navigate the sidebar, Enter loads
- [x] \`a\` on a highlighted Financials row prefills \`:add SYMBOL.field\`
- [x] Notes textarea auto-saves; reload preserves text
- [x] \`-\` from /graph/AAPL returns to /ideas/{lastId} with full state
- [x] \`\\\` drops a price line at the crosshair; \`:cl\` clears

## Deferred to follow-ups (in ideas.md)
- #13 Attach analyst/news panels to a sketch's notes
- #14 Non-statement fields (\`marketcap\`, \`beta\`, ratios) in \`:add\`
- #15 Economic indicators as a metric kind (interest rates, CPI, unemployment)