### PR TITLE
feat: vim QoL on /ideas + watchlist row ops + dedup WS subscriptions

### DIFF
--- a/internal/server/static/ideas.js
+++ b/internal/server/static/ideas.js
@@ -470,21 +470,125 @@
         return (sketches || []).slice();
     };
 
-    // ── Vim navigation through the sketches sidebar (j/k, Enter to load) ──
-    window._ideasMoveList = function (dir) {
-        var items = Array.from(document.querySelectorAll('#ideas-list .ideas-list-item'));
-        if (!items.length) return;
-        if (dir === 'j') listSelectedIdx = Math.min(listSelectedIdx + 1, items.length - 1);
-        else if (dir === 'k') listSelectedIdx = Math.max(listSelectedIdx - 1, 0);
-        items.forEach(function (el, i) { el.classList.toggle('vim-selected', i === listSelectedIdx); });
-        if (items[listSelectedIdx]) items[listSelectedIdx].scrollIntoView({ block: 'nearest' });
-    };
-    window._ideasActivateList = function () {
-        var items = Array.from(document.querySelectorAll('#ideas-list .ideas-list-item'));
-        if (listSelectedIdx >= 0 && listSelectedIdx < items.length) {
-            navigateToSketch(items[listSelectedIdx].dataset.sketchId);
+    // ── Three-pane vim navigation: list ↔ chart ↔ notes ──
+    //
+    // Pane state machine:
+    //   focus = 'list'  → j/k navigate sketches sidebar; Enter loads
+    //   focus = 'chart' → j/k navigate metrics in the legend; d removes
+    //   focus = 'notes' → l from chart focuses the textarea (insert mode);
+    //                     Esc returns to 'notes' state in normal mode
+    //   h/l moves between panes; visual outline highlights the active one.
+    var paneFocus = 'list';
+    var metricSelectedIdx = -1;
+
+    function highlightPane() {
+        document.getElementById('ideas-sidebar').classList.toggle('pane-focused', paneFocus === 'list');
+        document.getElementById('ideas-main').classList.toggle('pane-focused', paneFocus === 'chart');
+        var notesPanel = document.getElementById('ideas-notes-panel');
+        if (notesPanel) notesPanel.classList.toggle('pane-focused', paneFocus === 'notes');
+    }
+
+    function getMetricRows() {
+        return Array.from(document.querySelectorAll('#ideas-legend .ideas-legend-row'));
+    }
+    function selectMetric(i) {
+        var rows = getMetricRows();
+        if (!rows.length) { metricSelectedIdx = -1; return; }
+        metricSelectedIdx = Math.max(0, Math.min(i, rows.length - 1));
+        rows.forEach(function (el, idx) { el.classList.toggle('vim-selected', idx === metricSelectedIdx); });
+    }
+    function clearMetricSelection() {
+        getMetricRows().forEach(function (el) { el.classList.remove('vim-selected'); });
+        metricSelectedIdx = -1;
+    }
+
+    window._ideasMove = function (dir) {
+        if (dir === 'h' || dir === 'l') {
+            // Cross-pane move
+            var order = ['list', 'chart', 'notes'];
+            var idx = order.indexOf(paneFocus);
+            if (dir === 'l') idx = Math.min(idx + 1, order.length - 1);
+            else idx = Math.max(idx - 1, 0);
+            var newFocus = order[idx];
+            if (newFocus === paneFocus) return;
+            paneFocus = newFocus;
+            // Keep selections intact when leaving — re-highlight on entry.
+            if (paneFocus === 'chart') {
+                if (metricSelectedIdx < 0) selectMetric(0);
+                else selectMetric(metricSelectedIdx);
+            } else {
+                clearMetricSelection();
+            }
+            if (paneFocus === 'notes') {
+                var ta = document.getElementById('ideas-notes-textarea');
+                if (ta) ta.focus();
+            }
+            highlightPane();
+            return;
+        }
+        if (dir === 'j' || dir === 'k') {
+            if (paneFocus === 'list') {
+                var items = Array.from(document.querySelectorAll('#ideas-list .ideas-list-item'));
+                if (!items.length) return;
+                if (dir === 'j') listSelectedIdx = Math.min(listSelectedIdx + 1, items.length - 1);
+                else listSelectedIdx = Math.max(listSelectedIdx - 1, 0);
+                items.forEach(function (el, i) { el.classList.toggle('vim-selected', i === listSelectedIdx); });
+                if (items[listSelectedIdx]) items[listSelectedIdx].scrollIntoView({ block: 'nearest' });
+            } else if (paneFocus === 'chart') {
+                var rows = getMetricRows();
+                if (!rows.length) return;
+                var next = dir === 'j' ? metricSelectedIdx + 1 : metricSelectedIdx - 1;
+                selectMetric(next);
+            }
+            // 'notes' pane intentionally ignores j/k — let the textarea handle keys
+            // when focused (insert mode), or do nothing in normal mode.
         }
     };
+
+    window._ideasActivate = function () {
+        if (paneFocus === 'list') {
+            var items = Array.from(document.querySelectorAll('#ideas-list .ideas-list-item'));
+            if (listSelectedIdx >= 0 && listSelectedIdx < items.length) {
+                navigateToSketch(items[listSelectedIdx].dataset.sketchId);
+            }
+        }
+        // chart/notes have no Enter action right now — chart 'd' deletes,
+        // notes is text-edit only.
+    };
+
+    window._ideasDeleteSelected = function () {
+        if (paneFocus !== 'chart') return false;
+        var rows = getMetricRows();
+        if (metricSelectedIdx < 0 || metricSelectedIdx >= rows.length) return false;
+        var metricId = parseInt(rows[metricSelectedIdx].dataset.metricId, 10);
+        if (!metricId) return false;
+        // Drop selection so the next render doesn't try to re-highlight a missing row
+        var keepIdx = metricSelectedIdx;
+        clearMetricSelection();
+        removeMetric(metricId);
+        // After re-render, snap selection to the row that took the deleted slot
+        // (or the new last row if the deleted one was last).
+        setTimeout(function () {
+            var newRows = getMetricRows();
+            if (!newRows.length) return;
+            selectMetric(Math.min(keepIdx, newRows.length - 1));
+        }, 100);
+        return true;
+    };
+
+    window._ideasGetPaneFocus = function () { return paneFocus; };
+
+    window._ideasToggleHelp = function () {
+        var el = document.getElementById('ideas-help');
+        if (el) el.classList.toggle('hidden');
+    };
+
+    // Expose the legacy single-pane fns for backward compat with terminal.js
+    window._ideasMoveList = function (dir) { window._ideasMove(dir); };
+    window._ideasActivateList = function () { window._ideasActivate(); };
+
+    // Initial visual state
+    highlightPane();
 
     window._ideasSave = function (name) {
         return ensureSketch().then(function (sk) {

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -2823,3 +2823,55 @@ li.kp-row::before {
     border-bottom: none;
     padding-top: 6px;
 }
+
+/* Ideas — three-pane vim navigation */
+
+.ideas-sidebar.pane-focused,
+.ideas-main.pane-focused,
+.ideas-notes.pane-focused {
+    box-shadow: inset 0 0 0 1px var(--orange);
+}
+
+.ideas-help {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin: 6px 0 12px;
+    padding: 8px 10px;
+    border: 1px dashed var(--border);
+    border-radius: 2px;
+    background: var(--bg-tertiary);
+    font-size: 11px;
+    color: var(--text-secondary);
+}
+
+.ideas-help.hidden { display: none; }
+
+.ideas-help-row { line-height: 1.6; }
+
+.ideas-help kbd {
+    display: inline-block;
+    padding: 1px 6px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    color: var(--orange);
+    font-family: var(--font-mono);
+    font-size: 10px;
+}
+
+.ideas-help-toggle {
+    margin-left: 6px;
+    color: var(--text-muted);
+    font-weight: bold;
+    cursor: help;
+    padding: 0 6px;
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    font-size: 10px;
+}
+
+.ideas-legend-row.vim-selected {
+    border-color: var(--orange);
+    box-shadow: 0 0 0 1px var(--orange);
+}

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -195,12 +195,13 @@ window.onerror = function (msg, src, line, col, err) {
         ws.onopen = function () {
             wsRetryDelay = 1000; // reset on successful connect
             setConnStatus(true);
+            // subscribedSecurities is the single source of truth for which
+            // quote topics this client cares about (loadWatchlists feeds it
+            // every watchlist symbol via subscribeSecurity). One frame per
+            // unique symbol — no duplicates.
             subscribedSecurities.forEach(function (sym) {
                 ws.send(JSON.stringify({ type: 'subscribe', topic: 'quote:' + sym }));
             });
-            // Resubscribe watchlist symbols
-            resubscribeWatchlists();
-            // Resubscribe to active news topic
             if (newsCurrentTopic) {
                 ws.send(JSON.stringify({ type: 'subscribe', topic: newsCurrentTopic }));
             }
@@ -239,6 +240,7 @@ window.onerror = function (msg, src, line, col, err) {
 
     var watchlistData = []; // cached watchlist data
     var activeWatchlistId = parseInt(localStorage.getItem('stocktopus-watchlist-id') || '0');
+    var watchlistBuffer = ''; // last symbol cut via 'd' on a watchlist row, ready to paste with 'p'
 
     function initWatchlist() {
         const form = document.getElementById('add-security-form');
@@ -353,18 +355,6 @@ window.onerror = function (msg, src, line, col, err) {
             .catch(function () {});
     }
 
-    function resubscribeWatchlists() {
-        if (watchlistData.length > 0) {
-            watchlistData.forEach(function (wl) {
-                (wl.symbols || []).forEach(function (sym) {
-                    if (ws && ws.readyState === WebSocket.OPEN) {
-                        ws.send(JSON.stringify({ type: 'subscribe', topic: 'quote:' + sym }));
-                    }
-                });
-            });
-        }
-    }
-
     function renderWatchlistTabs() {
         var tabContainer = document.getElementById('watchlist-tabs');
         if (!tabContainer) return;
@@ -407,21 +397,46 @@ window.onerror = function (msg, src, line, col, err) {
 
         var activeWl = watchlistData.find(function (wl) { return wl.id === activeWatchlistId; });
         var activeSymbols = activeWl && activeWl.symbols ? activeWl.symbols : [];
+        var activeColor = activeWl ? activeWl.color : '#ff8800';
 
-        // Show/hide rows based on active watchlist
+        // Show/hide rows based on active watchlist + paint borders with the active
+        // list's color (so a symbol that lives in multiple lists picks up the
+        // currently-viewed list's tone, not whichever list it was first added to).
         var visibleCount = 0;
         tbody.querySelectorAll('tr').forEach(function (row) {
             var sym = row.querySelector('[data-symbol]');
             var symbol = sym ? sym.dataset.symbol : '';
             var inList = activeSymbols.indexOf(symbol) >= 0;
             row.style.display = inList ? '' : 'none';
-            if (inList) visibleCount++;
+            if (inList) {
+                row.style.borderLeft = '3px solid ' + activeColor;
+                visibleCount++;
+            }
         });
 
         if (empty) {
             empty.style.display = visibleCount > 0 ? 'none' : '';
             empty.textContent = visibleCount > 0 ? '' : 'No securities in this watchlist — use :watch to add';
         }
+    }
+
+    // Refresh the entire watchlist view after a mutation (delete / paste / copy).
+    // Pulls fresh metadata, re-renders tabs, then re-fetches quotes which
+    // repaint borders per the active list and hide rows that no longer fit.
+    function refreshWatchlistView() {
+        return fetch('/api/watchlists')
+            .then(function (r) { return r.json(); })
+            .then(function (lists) {
+                watchlistData = lists || [];
+                renderWatchlistTabs();
+                renderWatchlistPicker();
+                // Rebuild the row set from scratch so symbols removed from every
+                // watchlist drop out of the table entirely instead of lingering.
+                var tbody = document.getElementById('quote-body');
+                if (tbody) tbody.innerHTML = '';
+                fetchWatchlistQuotes();
+            })
+            .catch(function () {});
     }
 
     function getActiveWatchlistId() {
@@ -451,6 +466,7 @@ window.onerror = function (msg, src, line, col, err) {
     }
 
     function subscribeSecurity(sec) {
+        if (subscribedSecurities.has(sec)) return; // already subscribed for this client
         subscribedSecurities.add(sec);
         if (ws && ws.readyState === WebSocket.OPEN) {
             ws.send(JSON.stringify({ type: 'subscribe', topic: 'quote:' + sec }));
@@ -1166,6 +1182,8 @@ window.onerror = function (msg, src, line, col, err) {
                     hideCmdDropdown();
                     e.stopPropagation();
                 }
+                // Cancel any pending y/p row-op mode so the next :watch starts fresh.
+                clearWatchOp();
             } else if (e.key === 'ArrowUp' && dropdown.classList.contains('hidden')) {
                 e.preventDefault();
                 if (historyIndex > 0) {
@@ -1340,6 +1358,30 @@ window.onerror = function (msg, src, line, col, err) {
         renderCmdDropdown(matches);
     }
 
+    // Stashed when y/p on a watchlist row opens the picker. The :watch dropdown
+    // and Enter handler read this to decide whether to copy (leave in source)
+    // or move (also delete from source).
+    var watchOpMode = null;       // null | 'copy' | 'move'
+    var watchOpSourceSymbol = ''; // the row symbol that triggered y/p
+    var watchOpSourceListId = 0;  // active watchlist id at the time
+
+    function openWatchPicker(mode, symbol) {
+        watchOpMode = mode;
+        watchOpSourceSymbol = symbol;
+        watchOpSourceListId = getActiveWatchlistId();
+        var input = document.getElementById('cmd-input');
+        input.value = ':watch ';
+        input.focus();
+        input.setSelectionRange(input.value.length, input.value.length);
+        renderCmdWatchlistDropdown('');
+    }
+
+    function clearWatchOp() {
+        watchOpMode = null;
+        watchOpSourceSymbol = '';
+        watchOpSourceListId = 0;
+    }
+
     function renderCmdWatchlistDropdown(query) {
         var dropdown = document.getElementById('cmd-dropdown');
         var input = document.getElementById('cmd-input');
@@ -1355,7 +1397,11 @@ window.onerror = function (msg, src, line, col, err) {
             return 0;
         });
 
-        var sym = selectedSecurity || '';
+        // Mode determines what the row description reads as. y/p stash sets
+        // mode='copy'/'move' and watchOpSourceSymbol; default is 'add' which
+        // uses the picker's selected security.
+        var sym = watchOpMode ? watchOpSourceSymbol : (selectedSecurity || '');
+        var verb = watchOpMode === 'copy' ? 'copy' : (watchOpMode === 'move' ? 'move' : 'add');
         var noSymLabel = 'no security selected — press s first';
 
         if (matches.length === 0) {
@@ -1366,9 +1412,9 @@ window.onerror = function (msg, src, line, col, err) {
         }
 
         dropdown.innerHTML = matches.map(function (wl) {
-            var desc = sym ? 'add ' + sym + ' to ' + wl.name + ' watchlist' : noSymLabel;
+            var desc = sym ? verb + ' ' + sym + ' to ' + wl.name + ' watchlist' : noSymLabel;
             return '<div class="cmd-option cmd-watchlist-option" data-watchlist-id="' + wl.id + '" data-watchlist-name="' + escapeHtml(wl.name) + '">'
-                + '<span class="cmd-option-usage" style="color:' + escapeHtml(wl.color || '#ff8800') + '">watch ' + escapeHtml(wl.name) + '</span>'
+                + '<span class="cmd-option-usage" style="color:' + escapeHtml(wl.color || '#ff8800') + '">' + escapeHtml(verb) + ' ' + escapeHtml(wl.name) + '</span>'
                 + '<span class="cmd-option-desc">' + escapeHtml(desc) + '</span>'
                 + '</div>';
         }).join('');
@@ -1386,8 +1432,31 @@ window.onerror = function (msg, src, line, col, err) {
         });
     }
 
-    // Add the picker's currently-selected security to the named watchlist.
+    // Execute a watchlist command per current mode:
+    //   default → add picker selection to <name>
+    //   copy    → add the source row's symbol to <name>, leave it in source
+    //   move    → add to <name>, then remove from source
     function executeWatchCommand(watchlistId, watchlistName) {
+        // y/p modes use the stashed source symbol, not the picker selection.
+        if (watchOpMode === 'copy' || watchOpMode === 'move') {
+            var sym = watchOpSourceSymbol;
+            var srcId = watchOpSourceListId;
+            var mode = watchOpMode;
+            addToWatchlist(watchlistId, sym);
+            subscribeSecurity(sym);
+            if (mode === 'move' && srcId && srcId !== watchlistId) {
+                fetch('/api/watchlists/' + srcId + '/symbols/' + encodeURIComponent(sym), { method: 'DELETE' })
+                    .then(function () { refreshWatchlistView(); });
+                flashError('Moved ' + sym + ' to ' + watchlistName);
+            } else {
+                flashError((mode === 'copy' ? 'Copied ' : 'Added ') + sym + ' to ' + watchlistName);
+                // Repaint borders + quote rows so the symbol picks up the destination
+                // list's color when the user switches to that tab.
+                if (currentView === 'watchlist') refreshWatchlistView();
+            }
+            clearWatchOp();
+            return true;
+        }
         if (!selectedSecurity) {
             flashError('No security selected — press s first');
             return false;
@@ -1395,6 +1464,7 @@ window.onerror = function (msg, src, line, col, err) {
         addToWatchlist(watchlistId, selectedSecurity);
         subscribeSecurity(selectedSecurity);
         flashError('Added ' + selectedSecurity + ' to ' + watchlistName);
+        if (currentView === 'watchlist') refreshWatchlistView();
         return true;
     }
 
@@ -1587,12 +1657,16 @@ window.onerror = function (msg, src, line, col, err) {
     var vimHandlers = {
         ideas: {
             move: function (dir) {
-                if (dir === 'j' || dir === 'k') {
-                    if (window._ideasMoveList) window._ideasMoveList(dir);
-                }
+                if (window._ideasMove) window._ideasMove(dir);
             },
             activate: function () {
-                if (window._ideasActivateList) window._ideasActivateList();
+                if (window._ideasActivate) window._ideasActivate();
+            },
+            deleteSelected: function () {
+                return window._ideasDeleteSelected ? window._ideasDeleteSelected() : false;
+            },
+            toggleHelp: function () {
+                if (window._ideasToggleHelp) window._ideasToggleHelp();
             },
         },
         watchlist: {
@@ -1643,7 +1717,56 @@ window.onerror = function (msg, src, line, col, err) {
                     onViewLeave(currentView);
                     navigate('graph', sym.dataset.symbol);
                 }
-            }
+            },
+            // ── Vim row ops (idea #12) ──
+            //
+            // Vim-faithful cut/paste model:
+            //   d → cut (delete from source list, store symbol in buffer)
+            //   p → paste from buffer to the *current* watchlist
+            //   y → yank to another list via picker (does not delete source);
+            //       on confirm the dest list re-renders so the new color sticks
+            _selectedSymbol: function () {
+                var items = this.getItems();
+                if (vimSelectedIndex < 0 || vimSelectedIndex >= items.length) return null;
+                var el = items[vimSelectedIndex].querySelector('[data-symbol]');
+                return el ? el.dataset.symbol : null;
+            },
+            deleteSelected: function () {
+                var sym = this._selectedSymbol();
+                if (!sym) return false;
+                var wlId = getActiveWatchlistId();
+                fetch('/api/watchlists/' + wlId + '/symbols/' + encodeURIComponent(sym), { method: 'DELETE' })
+                    .then(function () {
+                        watchlistBuffer = sym;
+                        flashError('Cut ' + sym + ' — press p to paste into another watchlist');
+                        refreshWatchlistView();
+                    })
+                    .catch(function () { flashError('Remove failed'); });
+                return true;
+            },
+            yankSelected: function () {
+                var sym = this._selectedSymbol();
+                if (!sym) return false;
+                openWatchPicker('copy', sym);
+                return true;
+            },
+            pasteSelected: function () {
+                if (!watchlistBuffer) {
+                    flashError('Buffer empty — d on a row to cut first');
+                    return true; // consume the keypress so we don't fall through
+                }
+                var sym = watchlistBuffer;
+                var dest = getActiveWatchlistId();
+                addToWatchlist(dest, sym);
+                subscribeSecurity(sym);
+                watchlistBuffer = '';
+                var name = (watchlistData.find(function (wl) { return wl.id === dest; }) || {}).name || 'watchlist';
+                flashError('Pasted ' + sym + ' into ' + name);
+                // addToWatchlist already calls loadWatchlists internally, but it
+                // doesn't repaint quote rows. Force a full refresh.
+                refreshWatchlistView();
+                return true;
+            },
         },
         graph: {
             move: function (dir) {
@@ -2084,7 +2207,22 @@ window.onerror = function (msg, src, line, col, err) {
                 return;
             case '?':
                 e.preventDefault();
+                // Per-view help toggles; falls back to the security-info help.
+                if (handler && handler.toggleHelp) { handler.toggleHelp(); return; }
                 if (window._infoToggleHelp) window._infoToggleHelp();
+                return;
+            case 'd':
+                // View-level delete: ideas removes the focused metric, watchlist
+                // removes the selected symbol from the active list (idea #12).
+                if (handler && handler.deleteSelected) {
+                    if (handler.deleteSelected()) e.preventDefault();
+                }
+                return;
+            case 'y':
+                // Watchlist: copy selected symbol to another list (idea #12).
+                if (handler && handler.yankSelected) {
+                    if (handler.yankSelected()) e.preventDefault();
+                }
                 return;
             case 'i':
                 if (handler && handler.sectorNav && handler.isSectorTab && handler.isSectorTab()) { e.preventDefault(); handler.sectorNav('info'); return; }
@@ -2111,6 +2249,11 @@ window.onerror = function (msg, src, line, col, err) {
                     } else if (window._finOpenChart) {
                         window._finOpenChart();
                     }
+                    return;
+                }
+                // Watchlist: move (paste) selected symbol to another list (idea #12).
+                if (handler && handler.pasteSelected) {
+                    if (handler.pasteSelected()) e.preventDefault();
                 }
                 return;
             case '\\':

--- a/internal/server/templates/ideas.html
+++ b/internal/server/templates/ideas.html
@@ -13,18 +13,22 @@
             <span class="ideas-hint"><kbd>:save</kbd> to name &amp; persist</span>
         </div>
     </aside>
-    <section class="ideas-main">
+    <section class="ideas-main" id="ideas-main">
         <div class="ideas-header">
             <h2 class="ideas-title" id="ideas-title">Default Sketchpad</h2>
             <span class="ideas-meta" id="ideas-meta">no metrics yet</span>
+            <span class="ideas-help-toggle" id="ideas-help-toggle" title="Press ? to toggle">?</span>
+        </div>
+        <div id="ideas-help" class="ideas-help hidden">
+            <span class="ideas-help-row"><kbd>:add AAPL</kbd> · <kbd>:add AAPL.revenue</kbd> · <kbd>:add GCUSD</kbd> · <kbd>:add EURUSD</kbd> · <kbd>:add BTCUSD</kbd></span>
+            <span class="ideas-help-row">Financials tab → <kbd>a</kbd> on a highlighted row prefills <kbd>:add SYMBOL.field</kbd></span>
+            <span class="ideas-help-row"><kbd>h</kbd>/<kbd>l</kbd> switch panes (list ↔ chart ↔ notes) · <kbd>j</kbd>/<kbd>k</kbd> within pane · <kbd>d</kbd> on a metric removes it · <kbd>\</kbd> drops a price line · <kbd>:cl</kbd> clears lines · <kbd>:save NAME</kbd></span>
         </div>
         <div id="ideas-chart-host" class="ideas-chart-host"></div>
         <div id="ideas-legend" class="ideas-legend"></div>
         <div id="ideas-empty" class="ideas-empty">
             <p>No metrics on this sketch yet.</p>
-            <p class="empty-hint">Add one with <kbd>:add AAPL</kbd>, <kbd>:add AAPL.revenue</kbd>, <kbd>:add GCUSD</kbd> (gold), <kbd>:add EURUSD</kbd>, <kbd>:add BTCUSD</kbd> …</p>
-            <p class="empty-hint">From the Financials tab, press <kbd>a</kbd> on a highlighted row to prefill <kbd>:add SYMBOL.field</kbd>.</p>
-            <p class="empty-hint"><kbd>\</kbd> drops a horizontal line at the crosshair, <kbd>:cl</kbd> clears them, <kbd>:save NAME</kbd> persists the current sketch.</p>
+            <p class="empty-hint">Press <kbd>?</kbd> to see the keybindings.</p>
         </div>
     </section>
     <aside class="ideas-notes" id="ideas-notes-panel">


### PR DESCRIPTION
## Summary

Three quality-of-life wins in one PR:

1. **`/ideas` three-pane vim navigation** — \`h\`/\`l\` cycles list ↔ chart ↔ notes; \`j\`/\`k\` walks within the focused pane; \`d\` on a focused metric removes it; \`?\` toggles a compact help banner.
2. **Watchlist row ops (idea #12)** — \`d\` cuts a symbol into a buffer, \`p\` pastes it into whichever watchlist you're currently viewing, \`y\` opens the \`:watch\` picker in copy mode. Classic vim semantics; UI refreshes immediately after every mutation.
3. **WS subscription dedup** — a symbol in N watchlists triggers one subscribe frame, not N. Removed the redundant \`resubscribeWatchlists()\` reconnect path.

### `/ideas` vim navigation

- Three-pane focus state: \`list\` (default) ↔ \`chart\` ↔ \`notes\`. Active pane gets an orange inset outline so you always know where you are.
- \`h\`/\`l\` switches panes. From \`chart\` → \`l\` focuses the notes textarea (auto insert mode); Esc returns to normal mode keeping pane focus.
- \`j\`/\`k\` is pane-specific:
  - **list**: walks sketches; Enter loads
  - **chart**: highlights metric rows in the legend
  - **notes**: ignored in normal mode (textarea handles keys when focused)
- \`d\` in the chart pane removes the highlighted metric. Selection snaps to the row that took the slot, so a chain of deletes works without re-pressing \`j\`.
- \`?\` now toggles a compact help banner inline below the title (was buried inside the empty-state, only visible when no metrics).
- Legend rows that match the focused metric show the same orange-outline selection treatment used elsewhere in the app.

### Watchlist row ops (idea #12) — vim cut/paste

Replaces the picker-based model with vim-faithful semantics:

- **\`d\`** on a highlighted row: DELETE from the active list, store the symbol in \`watchlistBuffer\`. Flash: \`Cut AAPL — press p to paste into another watchlist\`.
- **\`p\`** in any watchlist: paste the buffered symbol into the current list and clear the buffer. Flash: \`Pasted AAPL into Tech\`. The chain \`d\` → switch tabs → \`p\` is the canonical move-via-buffer.
- **\`y\`** on a row: opens the \`:watch\` picker in **copy** mode (source keeps the symbol, dest gets it). Picker rows now read \`copy AAPL to Tech watchlist\` instead of the generic \`add\`.

### Color fix

\`filterWatchlistView\` now paints \`border-left\` with the **active list's** color rather than the first list a symbol was added to. So copying \`AAPL\` from Default (orange) to Tech (blue) correctly shows blue when the Tech tab is active.

### Refresh fix

All three row ops route through a new \`refreshWatchlistView()\` that rebuilds the row table + refetches quotes + repaints colors after every mutation. Was bug-prone before because \`loadWatchlists()\` only refreshed the metadata, not the rendered rows.

### WS subscription dedup

- \`subscribeSecurity()\` now bails early when the symbol is already in \`subscribedSecurities\`. A symbol in \`[Default, Tech, Energy]\` results in **one** subscribe frame, not three.
- Deleted \`resubscribeWatchlists()\` entirely. It iterated watchlists × symbols on every WS reconnect and double-sent everything that was already in \`subscribedSecurities.forEach()\` (which the reconnect handler also iterates). Single source of truth now.
- Wire frames per reconnect: was up to \`(M + sum-of-list-sizes)\`, now \`M\` (M = unique symbols across all watchlists).

## Test plan
- [x] \`make build\`
- [x] \`make test\`
- [x] \`make smoke\`
- [ ] On \`/ideas\`: \`?\` toggles inline help; \`h\`/\`l\` cycles panes with visible focus outline
- [ ] In chart pane: \`j\`/\`k\` walks legend; \`d\` removes; selection snaps cleanly
- [ ] In notes pane: textarea focuses on entry, Esc returns to normal mode
- [ ] On \`/watchlist\`: \`d\` cuts (table updates immediately, flash hints at \`p\`); switch tab; \`p\` pastes (color matches new tab)
- [ ] \`y\` opens picker reading "copy AAPL to <name> watchlist"; selecting a list copies + repaints
- [ ] In dev tools network tab: a symbol in 3 watchlists triggers one \`subscribe\` frame on connect, not three