### PR TITLE
feat: overview redesign, sketch autocomplete polish, reader vim nav, focus-ring fix

### DIFF
--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -229,8 +229,8 @@
 
             var html = '<div class="info-overview">';
 
-            // Key stats grid
-            html += '<div class="info-grid">';
+            // ── Top: dense Key Indicators block (8 wide × 2 rows) ──
+            html += '<div class="info-grid info-grid-dense">';
             html += stat('Market Cap', fmt(profile.marketCap));
             html += stat('P/E (TTM)', ratios.priceToEarningsRatioTTM ? ratios.priceToEarningsRatioTTM.toFixed(2) : '—');
             html += stat('EPS (TTM)', profile.eps ? profile.eps.toFixed(2) : '—');
@@ -239,10 +239,6 @@
             html += stat('52W Range', profile.range || '—');
             html += stat('Volume', fmt(profile.volume));
             html += stat('Avg Volume', fmt(profile.averageVolume));
-            html += '</div>';
-
-            // Metrics grid
-            html += '<div class="info-grid">';
             html += stat('EV/EBITDA', metrics.evToEBITDA ? metrics.evToEBITDA.toFixed(2) : '—');
             html += stat('EV/Sales', metrics.evToSales ? metrics.evToSales.toFixed(2) : '—');
             html += stat('Current Ratio', ratios.currentRatioTTM ? ratios.currentRatioTTM.toFixed(2) : '—');
@@ -253,23 +249,12 @@
             html += stat('P/B', ratios.priceToBookRatioTTM ? ratios.priceToBookRatioTTM.toFixed(2) : '—');
             html += '</div>';
 
-            // Company info
-            html += '<div class="info-company">';
-            html += '<div class="info-company-meta">';
-            html += '<span>' + esc(profile.sector) + ' / ' + esc(profile.industry) + '</span>';
-            html += '<span>CEO: ' + esc(profile.ceo) + '</span>';
-            html += '<span>' + esc(profile.fullTimeEmployees) + ' employees</span>';
-            html += '<span>' + esc(profile.exchange) + '</span>';
-            if (profile.website) html += '<span><a href="' + esc(profile.website) + '" target="_blank" rel="noopener">' + esc(profile.website) + '</a></span>';
-            html += '</div>';
-            if (profile.description) {
-                var desc = profile.description;
-                html += '<p class="info-description">' + esc(desc) + '</p>';
-            }
-            html += '</div>';
+            // ── Below: Key People (left) + Company description (right) ──
+            html += '<div class="info-overview-top">';
 
-            // Key People — dedup by name+title across forms (form4 / 10-K / DEF 14A)
-            // and show a compact strip. Full timeline still lives on the SEC tab.
+            // Left: Key People — dedup across forms (form4 / 10-K / DEF 14A);
+            // single row per person so longer titles aren't truncated.
+            html += '<div class="info-overview-left">';
             if (people && people.length) {
                 var seenKP = {};
                 var dedup = people.filter(function (p) {
@@ -278,30 +263,50 @@
                     seenKP[key] = true;
                     return true;
                 });
-                // Officers first, then directors, alphabetical within
                 dedup.sort(function (a, b) {
                     var aOfficer = (a.eventType === 'director') ? 1 : 0;
                     var bOfficer = (b.eventType === 'director') ? 1 : 0;
                     if (aOfficer !== bOfficer) return aOfficer - bOfficer;
                     return (a.name || '').localeCompare(b.name || '');
                 });
-                var top = dedup.slice(0, 12);
-                html += '<div class="info-people">';
+                var top = dedup.slice(0, 14);
                 html += '<div class="info-people-header">Key People <span class="info-people-meta">' + dedup.length + ' on file · <a href="/security/' + esc(symbol) + '#sec" class="info-people-more">timeline →</a></span></div>';
-                html += '<div class="info-people-grid">';
+                html += '<ul class="info-people-list">';
                 top.forEach(function (p) {
                     var roleClass = 'kp-event-' + (p.eventType || 'other');
-                    html += '<div class="info-people-row">';
+                    html += '<li class="info-people-row">';
                     html += '<span class="kp-event ' + roleClass + '">' + esc(p.eventType || 'officer') + '</span>';
                     html += '<span class="info-people-name">' + esc(p.name) + '</span>';
                     html += '<span class="info-people-title">' + esc(p.title || '') + '</span>';
-                    html += '</div>';
+                    html += '</li>';
                 });
                 if (dedup.length > top.length) {
-                    html += '<div class="info-people-row info-people-more-row"><a href="/security/' + esc(symbol) + '#sec">+ ' + (dedup.length - top.length) + ' more on the SEC tab</a></div>';
+                    html += '<li class="info-people-more-row"><a href="/security/' + esc(symbol) + '#sec">+ ' + (dedup.length - top.length) + ' more on the SEC tab</a></li>';
                 }
-                html += '</div></div>';
+                html += '</ul>';
+            } else {
+                html += '<div class="info-people-header">Key People</div>';
+                html += '<p class="empty-state info-people-empty">No leadership data extracted yet.</p>';
             }
+            html += '</div>';
+
+            // Right: Company description + meta
+            html += '<div class="info-overview-right">';
+            html += '<div class="info-overview-meta">';
+            if (profile.sector || profile.industry) {
+                html += '<span class="info-overview-meta-item">' + esc(profile.sector || '') + (profile.industry ? ' / ' + esc(profile.industry) : '') + '</span>';
+            }
+            if (profile.ceo) html += '<span class="info-overview-meta-item">CEO: ' + esc(profile.ceo) + '</span>';
+            if (profile.fullTimeEmployees) html += '<span class="info-overview-meta-item">' + esc(profile.fullTimeEmployees) + ' employees</span>';
+            if (profile.exchange) html += '<span class="info-overview-meta-item">' + esc(profile.exchange) + '</span>';
+            if (profile.website) html += '<span class="info-overview-meta-item"><a href="' + esc(profile.website) + '" target="_blank" rel="noopener">' + esc(profile.website) + '</a></span>';
+            html += '</div>';
+            if (profile.description) {
+                html += '<p class="info-description">' + esc(profile.description) + '</p>';
+            }
+            html += '</div>';
+
+            html += '</div>'; // close info-overview-top
 
             html += '</div>';
             container.innerHTML = html;
@@ -709,31 +714,78 @@
 
     // ── News (reuse existing pattern) ──
 
-    function loadNews() {
-        container.innerHTML = '<p class="empty-state">Loading...</p>';
+    // ── News tab — sub-tabs mirror the /news page, scoped to this security ──
 
-        fetch('/api/news/press-releases?symbol=' + symbol + '&limit=20')
-            .then(function (r) { return r.json(); })
+    var NEWS_CATS = [
+        { key: 'press-releases', label: 'Press Releases' },
+        { key: 'articles',       label: 'Articles' },
+        { key: 'stock',          label: 'Stock' },
+        { key: 'crypto',         label: 'Crypto' },
+        { key: 'forex',          label: 'Forex' },
+        { key: 'general',        label: 'General' },
+    ];
+    var newsCurrent = 'press-releases'; // remembered across re-entries
+
+    function loadNews() {
+        var subHtml = '<div class="info-sub-tabs" id="news-sub-tabs">';
+        NEWS_CATS.forEach(function (c) {
+            var active = c.key === newsCurrent ? ' active' : '';
+            subHtml += '<button class="info-sub-tab' + active + '" data-cat="' + c.key + '">'
+                + c.label + '</button>';
+        });
+        subHtml += '</div><div id="news-cards-host" class="news-cards-host"></div>';
+        container.innerHTML = subHtml;
+
+        container.querySelectorAll('#news-sub-tabs .info-sub-tab').forEach(function (btn) {
+            btn.onclick = function () {
+                container.querySelectorAll('#news-sub-tabs .info-sub-tab').forEach(function (b) { b.classList.remove('active'); });
+                btn.classList.add('active');
+                newsCurrent = btn.dataset.cat;
+                loadNewsCategory(newsCurrent);
+            };
+        });
+
+        loadNewsCategory(newsCurrent);
+    }
+
+    // Expose for the vim sub-tab navigation in terminal.js
+    window._infoNewsSubTabs = function () {
+        return Array.from(document.querySelectorAll('#news-sub-tabs .info-sub-tab'));
+    };
+    window._infoNewsJumpToSub = function (n) {
+        var tabs = window._infoNewsSubTabs();
+        if (n >= 0 && n < tabs.length) tabs[n].click();
+    };
+
+    function loadNewsCategory(category) {
+        var host = document.getElementById('news-cards-host');
+        if (!host) return;
+        host.innerHTML = '<p class="empty-state">Loading...</p>';
+
+        var url = '/api/news/' + category + '?symbol=' + encodeURIComponent(symbol) + '&limit=20';
+        fetch(url)
+            .then(function (r) { return r.ok ? r.json() : []; })
             .then(function (items) {
-                if (!items || items.length === 0) {
-                    container.innerHTML = '<p class="empty-state">No news available for ' + symbol + '</p>';
+                if (!Array.isArray(items) || items.length === 0) {
+                    host.innerHTML = '<p class="empty-state">No ' + esc(category) + ' news for ' + esc(symbol) + '</p>';
                     return;
                 }
-                container.innerHTML = '<div class="news-cards" style="max-height:calc(100vh - 220px)">' +
+                host.innerHTML = '<div class="news-cards" id="info-news-cards">' +
                     items.map(function (item) {
                         var date = item.date ? new Date(item.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : '';
                         var text = item.text || '';
-                        if (text.length > 200) text = text.substring(0, 200) + '...';
+                        var div = document.createElement('div');
+                        div.innerHTML = text;
+                        var plain = div.textContent || div.innerText || '';
+                        if (plain.length > 220) plain = plain.substring(0, 220) + '…';
                         return '<div class="news-card news-unread">'
                             + '<div class="news-card-title"><a href="' + esc(item.url) + '" onclick="event.preventDefault();if(window._openReader)window._openReader(this.href,this.textContent)">' + esc(item.title) + '</a></div>'
-                            + '<div class="news-card-meta"><span>' + esc(item.source) + '</span><span>' + date + '</span></div>'
-                            + '<div class="news-card-text">' + esc(text) + '</div>'
+                            + '<div class="news-card-meta"><span>' + esc(item.source || '') + '</span><span>' + date + '</span></div>'
+                            + '<div class="news-card-text">' + esc(plain) + '</div>'
                             + '</div>';
                     }).join('') + '</div>';
             })
-            .catch(function () {
-                container.innerHTML = '<p class="empty-state">Failed to load news</p>';
-            });
+            .catch(function () { host.innerHTML = '<p class="empty-state">Failed to load news</p>'; });
     }
 
     // ── Sector ──

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -864,9 +864,7 @@ body {
     font-size: 12px;
     color: var(--text-muted);
     line-height: 1.6;
-    max-height: 200px;
-    overflow-y: scroll;
-    padding-right: 8px;
+    margin: 0;
 }
 
 .info-sub-tabs {
@@ -2765,12 +2763,40 @@ li.kp-row::before {
     letter-spacing: 0.3px;
 }
 
-/* Overview Key People strip */
+/* Overview — two-column top split: Key People (left) + Description (right);
+   key indicators sit underneath. */
 
-.info-people {
-    margin-top: 16px;
-    padding-top: 12px;
+.info-overview-top {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+    gap: 24px;
+    margin-bottom: 20px;
+}
+
+.info-overview-left,
+.info-overview-right { min-width: 0; }
+
+.info-overview-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 14px;
+    color: var(--text-secondary);
+    font-size: 11px;
+    margin-bottom: 10px;
+}
+
+.info-overview-meta-item a { color: var(--orange); text-decoration: none; }
+.info-overview-meta-item a:hover { text-decoration: underline; }
+
+.info-indicators-header {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--text-primary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
     border-top: 1px solid var(--border);
+    padding-top: 12px;
+    margin-bottom: 8px;
 }
 
 .info-people-header {
@@ -2799,29 +2825,39 @@ li.kp-row::before {
 .info-people-more:hover,
 .info-people-more-row a:hover { text-decoration: underline; }
 
-.info-people-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 6px 16px;
+.info-people-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
 }
 
 .info-people-row {
     display: grid;
-    grid-template-columns: 64px 130px 1fr;
-    gap: 8px;
-    align-items: center;
+    grid-template-columns: 64px minmax(120px, max-content) 1fr;
+    gap: 10px;
+    align-items: baseline;
     font-size: 11px;
-    padding: 4px 0;
+    padding: 5px 0;
     border-bottom: 1px solid var(--bg-tertiary);
 }
 
 .info-people-name { color: var(--text-primary); font-weight: 500; }
-.info-people-title { color: var(--text-secondary); font-size: 10px; }
+.info-people-title { color: var(--text-secondary); font-size: 11px; line-height: 1.4; }
 
 .info-people-more-row {
-    grid-column: 1 / -1;
     border-bottom: none;
-    padding-top: 6px;
+    padding: 8px 0 0;
+    font-size: 11px;
+}
+
+.info-people-empty {
+    margin: 0;
+    text-align: left;
+    padding: 12px 0;
+}
+
+@media (max-width: 900px) {
+    .info-overview-top { grid-template-columns: 1fr; }
 }
 
 /* Ideas — three-pane vim navigation */
@@ -2874,4 +2910,54 @@ li.kp-row::before {
 .ideas-legend-row.vim-selected {
     border-color: var(--orange);
     box-shadow: 0 0 0 1px var(--orange);
+}
+
+/* Focus ring — selection state for tabs / list rows / cards lives in .active
+   and .vim-selected classes, never in browser-managed :focus. Chrome's click
+   focus on <button> triggers :focus-visible too, so any rule here would leak
+   stale outlines after h/l navigates elsewhere. Just hide it everywhere. */
+
+button, .info-tab, .info-sub-tab, .news-tab, .wl-tab, .ideas-list-item,
+.cmd-option, .security-option, .sec-row, .kp-row, .ideas-legend-row,
+a, [tabindex] {
+    outline: none !important;
+}
+
+/* News reader full-width mode (`z` toggles) — covers the main view area for
+   easier long-form reading. Esc / `z` again returns to side-panel. */
+.article-reader.reader-expanded {
+    width: auto;
+    flex: 1;
+    border-left: none;
+}
+
+/* Security info → News tab — sub-tab cards live inside their own scroll host
+   so the sub-tab row stays anchored at the top. */
+.news-cards-host {
+    margin-top: 8px;
+    max-height: calc(100vh - 240px);
+    overflow-y: auto;
+}
+
+/* Overview — dense 8-wide indicator grid up top */
+.info-grid-dense {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+    gap: 6px;
+    margin-bottom: 16px;
+}
+
+.info-grid-dense .info-stat {
+    padding: 6px 8px;
+}
+.info-grid-dense .info-stat-label { font-size: 9px; }
+.info-grid-dense .info-stat-value { font-size: 13px; }
+
+@media (max-width: 1100px) {
+    .info-grid-dense { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+}
+
+.reader-ticker.vim-selected {
+    border-color: var(--orange);
+    box-shadow: 0 0 0 1px var(--orange);
+    background: var(--bg-tertiary);
 }

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -242,6 +242,19 @@ window.onerror = function (msg, src, line, col, err) {
     var activeWatchlistId = parseInt(localStorage.getItem('stocktopus-watchlist-id') || '0');
     var watchlistBuffer = ''; // last symbol cut via 'd' on a watchlist row, ready to paste with 'p'
 
+    // Cache of saved sketches for cross-page :add autocomplete. Lazy-filled on
+    // first ':add' keystroke so we don't fetch unconditionally on every load.
+    var sketchesData = [];
+    var sketchesLoaded = false;
+    function ensureSketchesLoaded() {
+        if (sketchesLoaded) return Promise.resolve(sketchesData);
+        sketchesLoaded = true;
+        return fetch('/api/sketches')
+            .then(function (r) { return r.ok ? r.json() : []; })
+            .then(function (list) { sketchesData = list || []; return sketchesData; })
+            .catch(function () { return []; });
+    }
+
     function initWatchlist() {
         const form = document.getElementById('add-security-form');
         if (form) {
@@ -997,11 +1010,13 @@ window.onerror = function (msg, src, line, col, err) {
                         executeIdeasAdd(item.dataset.sym + '.' + item.dataset.field, '');
                         return;
                     }
-                    if (item.dataset.sketchName) {
-                        // ":add <metric> to <sketch>" — combine current input + selection then execute
+                    if (item.dataset.sketchName || item.dataset.sketchCreate) {
+                        // ":add <metric> to <sketch>" — combine current input + selection then execute.
+                        // sketchCreate carries the typed name when no existing sketch matched.
+                        var sketchTarget = item.dataset.sketchName || item.dataset.sketchCreate;
                         var existing = input.value;
                         var toIE = existing.toLowerCase().lastIndexOf(' to ');
-                        var withTo = (toIE > 0 ? existing.substring(0, toIE + 4) : existing.replace(/\s+$/, '') + ' to ') + item.dataset.sketchName;
+                        var withTo = (toIE > 0 ? existing.substring(0, toIE + 4) : existing.replace(/\s+$/, '') + ' to ') + sketchTarget;
                         var afterColon = withTo.charAt(0) === ':' ? withTo.substring(1) : withTo;
                         var addArg2 = afterColon.toLowerCase().startsWith('add ') ? afterColon.substring(4) : afterColon;
                         var toI2 = addArg2.toLowerCase().lastIndexOf(' to ');
@@ -1254,12 +1269,88 @@ window.onerror = function (msg, src, line, col, err) {
         })();
     }
 
-    // Common path for "execute :add <metric> [to <sketch>]" — used both by
-    // typed Enter and by Enter on a dropdown selection. When run from a
-    // foreign page (not /ideas), resume the last-used sketch instead of
-    // dropping the user onto the default scratchpad.
+    // Mirror of ideas.js's parseAddArg, kept in sync. Used when executing :add
+    // from a foreign page where ideas.js isn't loaded.
+    var SERIES_COLORS_FALLBACK = ['#ff8800', '#4499ff', '#00cc66', '#bb88ff', '#ccaa00'];
+    function parseAddArgRemote(arg, fallbackSymbol) {
+        var raw = (arg || '').trim();
+        if (!raw) {
+            if (!fallbackSymbol) return null;
+            return { kind: 'price', identifier: fallbackSymbol, label: fallbackSymbol };
+        }
+        var dot = raw.lastIndexOf('.');
+        if (dot > 0 && dot < raw.length - 1) {
+            var sym = raw.substring(0, dot).toUpperCase();
+            var field = raw.substring(dot + 1);
+            return { kind: 'financial', identifier: sym + '.' + field, label: sym + ' ' + field };
+        }
+        var s = raw.toUpperCase();
+        var commodityPrefixes = ['GC','SI','CL','NG','HG','PL','PA','BZ','HO','RB','ZC','ZW','ZS','KC','SB','CC','CT'];
+        var forexCurrencies = ['USD','EUR','GBP','JPY','AUD','CAD','CHF','CNY','HKD','NZD','SEK','NOK','SGD','MXN'];
+        if (s.length === 5 && s.endsWith('USD')) {
+            var prefix = s.substring(0, 2);
+            if (commodityPrefixes.indexOf(prefix) >= 0) return { kind: 'commodity', identifier: s, label: s };
+        }
+        if (s.length === 6) {
+            var a = s.substring(0, 3), b = s.substring(3);
+            if (forexCurrencies.indexOf(a) >= 0 && forexCurrencies.indexOf(b) >= 0) return { kind: 'forex', identifier: s, label: a + '/' + b };
+            if (b === 'USD' || b === 'EUR') return { kind: 'crypto', identifier: s, label: s };
+        }
+        return { kind: 'price', identifier: s, label: s };
+    }
+
+    // Add a parsed metric to a sketch by id. Picks a colour by current count
+    // so the destination sketch's series stay visually distinct.
+    function postMetricToSketch(sketchID, parsed, count) {
+        var color = SERIES_COLORS_FALLBACK[(count || 0) % SERIES_COLORS_FALLBACK.length];
+        var body = { kind: parsed.kind, identifier: parsed.identifier, label: parsed.label || parsed.identifier, color: color };
+        return fetch('/api/sketches/' + sketchID + '/metrics', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+    }
+
+    // Foreign-page :add path. Find or create the named sketch, append the
+    // metric, and stay on the current page so the user can keep adding.
+    function executeIdeasAddRemote(metric, fallback, sketchName) {
+        var parsed = parseAddArgRemote(metric, fallback);
+        if (!parsed) { flashError('No symbol given'); return; }
+        ensureSketchesLoaded().then(function () {
+            var lower = sketchName.toLowerCase();
+            var match = sketchesData.find(function (sk) { return sk.name.toLowerCase() === lower; });
+            if (!match) match = sketchesData.find(function (sk) { return sk.name.toLowerCase().indexOf(lower) === 0; });
+            if (match) {
+                postMetricToSketch(match.id, parsed, (match.metrics || []).length)
+                    .then(function () { flashError('Added ' + parsed.label + ' to ' + match.name); });
+                return;
+            }
+            // Not found: create the sketch with the typed name then add.
+            fetch('/api/sketches', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: sketchName }),
+            }).then(function (r) { return r.json(); })
+            .then(function (resp) { return postMetricToSketch(resp.id, parsed, 0); })
+            .then(function () {
+                flashError('Idea "' + sketchName + '" created — added ' + parsed.label);
+                // Refresh the local cache so subsequent :add tos see it
+                sketchesLoaded = false;
+                ensureSketchesLoaded();
+            });
+        });
+    }
+
+    // Common path for "execute :add <metric> [to <sketch>]". When the user
+    // names a target sketch with `to`, stay on the current page and post via
+    // the API. When no target is given, navigate them onto /ideas (the
+    // last-used sketch) so they see what they just added.
     function executeIdeasAdd(metric, toSketch) {
         var fallback = selectedSecurity || '';
+        if (toSketch) {
+            executeIdeasAddRemote(metric, fallback, toSketch);
+            return;
+        }
         if (currentView !== 'ideas') {
             var lastId = localStorage.getItem('stocktopus-last-sketch');
             var ideasPath = lastId ? '/ideas/' + lastId : '/ideas';
@@ -1284,8 +1375,11 @@ window.onerror = function (msg, src, line, col, err) {
     }
 
     function filterAndShowCommands(value) {
-        var raw = value.trim();
-        var parts = raw.split(/\s+/);
+        // Only trim leading whitespace — keep trailing because we use it as a
+        // signal: ":add SYMBOL.field to " (with trailing space) means "user
+        // just finished typing 'to', show the sketch list with no prefix".
+        var raw = (value || '').replace(/^\s+/, '');
+        var parts = raw.trim().split(/\s+/);
         var cmdPart = parts[0].toLowerCase();
 
         // :watch <prefix> — autocomplete watchlist names (adds selectedSecurity to that list)
@@ -1302,11 +1396,18 @@ window.onerror = function (msg, src, line, col, err) {
             }
 
             // :add <metric> [to <sketch>] — autocomplete fields after a dot,
-            // and saved sketches after " to ".
+            // and saved sketches after " to " or " to" at the end.
             if (afterColonLower.startsWith('add ')) {
                 clearTimeout(searchTimer);
                 var addArg = afterColon.substring(4); // preserve case
-                var toIdx = addArg.toLowerCase().lastIndexOf(' to ');
+                var lower = addArg.toLowerCase();
+                var toIdx = lower.lastIndexOf(' to ');
+                // Also catch the user mid-typing, before the trailing space lands:
+                // ":add AAPL.revenue to" → empty prefix, show all sketches.
+                if (toIdx < 0 && (lower.endsWith(' to') || lower === 'to')) {
+                    renderCmdSketchDropdown('');
+                    return;
+                }
                 if (toIdx >= 0) {
                     var sketchPrefix = addArg.substring(toIdx + 4);
                     renderCmdSketchDropdown(sketchPrefix);
@@ -1536,18 +1637,40 @@ window.onerror = function (msg, src, line, col, err) {
 
     function renderCmdSketchDropdown(prefix) {
         var dropdown = document.getElementById('cmd-dropdown');
-        var sketches = (window._ideasGetSketches && window._ideasGetSketches()) || [];
+        // Prefer the live ideas.js cache if we're on /ideas, otherwise the
+        // terminal-level cache. ensureSketchesLoaded fills the latter on first
+        // `:add` keystroke and re-renders when it lands.
+        var sketches;
+        if (window._ideasGetSketches) {
+            sketches = window._ideasGetSketches();
+        } else if (sketchesLoaded) {
+            sketches = sketchesData;
+        } else {
+            ensureSketchesLoaded().then(function () { renderCmdSketchDropdown(prefix); });
+            sketches = [];
+        }
         var p = (prefix || '').toLowerCase();
         var matches = sketches.filter(function (sk) {
             return !p || (sk.name || '').toLowerCase().indexOf(p) >= 0;
         });
+        // No matches and the user typed a prefix: hint that Enter creates a new
+        // sketch with that name (idea-create path, B3).
         if (!matches.length) {
-            dropdown.innerHTML = '<div class="cmd-option cmd-option-empty">No saved sketch matches "' + escapeHtml(prefix) + '"</div>';
+            if (p) {
+                dropdown.innerHTML = '<div class="cmd-option cmd-sketch-create-option" data-sketch-create="' + escapeHtml(prefix) + '">'
+                    + '<span class="cmd-option-usage">create "' + escapeHtml(prefix) + '"</span>'
+                    + '<span class="cmd-option-desc">no match — Enter creates this sketch and adds the metric</span>'
+                    + '</div>';
+            } else {
+                dropdown.innerHTML = '<div class="cmd-option cmd-option-empty">No saved sketches yet — Enter creates one with this name</div>';
+            }
             dropdown.classList.remove('hidden');
             cmdDropdownIndex = -1;
             return;
         }
-        dropdown.innerHTML = matches.slice(0, 12).map(function (sk) {
+        // 5-recent cap when no prefix typed; loosens when filtering.
+        var cap = p ? 12 : 5;
+        dropdown.innerHTML = matches.slice(0, cap).map(function (sk) {
             return '<div class="cmd-option cmd-sketch-option" data-sketch-name="' + escapeHtml(sk.name) + '">'
                 + '<span class="cmd-option-usage">to ' + escapeHtml(sk.name) + '</span>'
                 + '<span class="cmd-option-desc">add to that saved sketch</span>'
@@ -1836,6 +1959,7 @@ window.onerror = function (msg, src, line, col, err) {
                 var tab = this.getActiveTab();
                 if (tab === 'financials') return window._infoFinSubTabs && window._infoFinSubTabs().length > 0;
                 if (tab === 'sec') return this.getSECSubTabs().length > 0;
+                if (tab === 'news') return window._infoNewsSubTabs && window._infoNewsSubTabs().length > 0;
                 return false;
             },
             getSECSubTabs: function () {
@@ -1982,7 +2106,10 @@ window.onerror = function (msg, src, line, col, err) {
                 }
                 if (dir === 'h' || dir === 'l') {
                     if (this._focus === 'sub' && hasSub) {
-                        var subTabs = this.isSECTab() ? this.getSECSubTabs() : (window._infoFinSubTabs ? window._infoFinSubTabs() : []);
+                        var subTabs;
+                        if (this.isSECTab()) subTabs = this.getSECSubTabs();
+                        else if (this.isNewsTab() && window._infoNewsSubTabs) subTabs = window._infoNewsSubTabs();
+                        else subTabs = window._infoFinSubTabs ? window._infoFinSubTabs() : [];
                         var activeIdx = subTabs.findIndex(function (t) { return t.classList.contains('active'); });
                         if (dir === 'l') activeIdx = Math.min(activeIdx + 1, subTabs.length - 1);
                         else activeIdx = Math.max(activeIdx - 1, 0);
@@ -2006,9 +2133,11 @@ window.onerror = function (msg, src, line, col, err) {
                 var mainTabs = document.getElementById('info-tabs');
                 var finSubTabs = document.getElementById('fin-sub-tabs');
                 var secSubTabs = document.getElementById('sec-filters');
+                var newsSubTabs = document.getElementById('news-sub-tabs');
                 if (mainTabs) mainTabs.classList.toggle('tab-row-focused', this._focus === 'main');
                 if (finSubTabs) finSubTabs.classList.toggle('tab-row-focused', this._focus === 'sub');
                 if (secSubTabs) secSubTabs.classList.toggle('tab-row-focused', this._focus === 'sub');
+                if (newsSubTabs) newsSubTabs.classList.toggle('tab-row-focused', this._focus === 'sub');
             },
             jumpToTab: function (n) {
                 this._focus = 'main';
@@ -2016,11 +2145,12 @@ window.onerror = function (msg, src, line, col, err) {
                 this._highlightFocus();
             },
             jumpToSubTab: function (n) {
-                if (this.hasSubTabs() && window._infoFinJumpToSub) {
-                    this._focus = 'sub';
-                    window._infoFinJumpToSub(n);
-                    this._highlightFocus();
-                }
+                if (!this.hasSubTabs()) return;
+                this._focus = 'sub';
+                // Route per active tab — different sub-tab universes per tab.
+                if (this.isNewsTab() && window._infoNewsJumpToSub) window._infoNewsJumpToSub(n);
+                else if (window._infoFinJumpToSub) window._infoFinJumpToSub(n);
+                this._highlightFocus();
             },
             refresh: function () {
                 if (window._infoRefresh) window._infoRefresh();
@@ -2190,10 +2320,25 @@ window.onerror = function (msg, src, line, col, err) {
             case 'k':
             case 'l':
                 e.preventDefault();
+                // When the article-reader slide-in is open, capture nav keys so
+                // we don't move the underlying tabs. j scrolls the reader; once
+                // the body is scrolled to the bottom, j/k cycle through the
+                // ticker chips at the foot of the article. k unwinds back to
+                // scrolling. h/l also cycle chips when in chip-selection mode.
+                var readerEl = document.getElementById('article-reader');
+                if (readerEl && !readerEl.classList.contains('hidden')) {
+                    handleReaderNav(e.key);
+                    return;
+                }
                 if (handler && handler.move) handler.move(e.key);
                 return;
             case 'Enter':
                 e.preventDefault();
+                // Reader chip activation takes priority when a chip is selected.
+                if (window._readerInChipMode && window._readerInChipMode()) {
+                    if (window._readerActivate) window._readerActivate();
+                    return;
+                }
                 if (handler && handler.activate) handler.activate();
                 return;
             case 'g':
@@ -2262,6 +2407,15 @@ window.onerror = function (msg, src, line, col, err) {
                 if (currentView === 'ideas' && window._ideasDrawHline) {
                     e.preventDefault();
                     window._ideasDrawHline();
+                }
+                return;
+            case 'z':
+                // Toggle the reader between its slide-in width and full-width
+                // expanded mode (more comfortable reading).
+                var rdr = document.getElementById('article-reader');
+                if (rdr && !rdr.classList.contains('hidden')) {
+                    e.preventDefault();
+                    rdr.classList.toggle('reader-expanded');
                 }
                 return;
             case 'a':
@@ -2528,8 +2682,77 @@ window.onerror = function (msg, src, line, col, err) {
         var reader = document.getElementById('article-reader');
         if (!reader) return;
         if (window._finCloseChart) window._finCloseChart();
+        reader.classList.remove('reader-expanded');
         reader.classList.add('hidden');
+        readerChipIdx = -1;
     };
+
+    // ── Reader keyboard navigation ──
+    //
+    // Two modes inside the open reader, switched implicitly:
+    //   1. scroll  → j/k scroll the body; h/l absorbed
+    //   2. chip    → j/k/h/l move selection across the ticker chips at the
+    //                bottom; Enter navigates to /security/<symbol>; further
+    //                k off the first chip drops back to scroll mode.
+    // Transition: once the body is at-bottom, the first j enters chip mode.
+    var readerChipIdx = -1;
+
+    function getReaderChips() {
+        return Array.from(document.querySelectorAll('#article-reader .reader-ticker'));
+    }
+    function highlightChip(idx) {
+        var chips = getReaderChips();
+        if (!chips.length) return;
+        idx = Math.max(0, Math.min(idx, chips.length - 1));
+        readerChipIdx = idx;
+        chips.forEach(function (el, i) { el.classList.toggle('vim-selected', i === idx); });
+        chips[idx].scrollIntoView({ block: 'nearest' });
+    }
+    function clearChipSelection() {
+        getReaderChips().forEach(function (el) { el.classList.remove('vim-selected'); });
+        readerChipIdx = -1;
+    }
+    function handleReaderNav(key) {
+        var body = document.getElementById('reader-body');
+        if (!body) return;
+        var chips = getReaderChips();
+        var atBottom = body.scrollTop + body.clientHeight >= body.scrollHeight - 4;
+
+        if (readerChipIdx >= 0) {
+            // chip mode
+            if (key === 'j' || key === 'l') { highlightChip(readerChipIdx + 1); return; }
+            if (key === 'k') {
+                if (readerChipIdx === 0) {
+                    clearChipSelection();
+                    body.scrollBy({ top: -80, behavior: 'smooth' });
+                } else {
+                    highlightChip(readerChipIdx - 1);
+                }
+                return;
+            }
+            if (key === 'h') { highlightChip(readerChipIdx - 1); return; }
+            return;
+        }
+        // scroll mode
+        if (key === 'j') {
+            if (atBottom && chips.length) { highlightChip(0); return; }
+            body.scrollBy({ top: 80, behavior: 'smooth' });
+            return;
+        }
+        if (key === 'k') { body.scrollBy({ top: -80, behavior: 'smooth' }); return; }
+        // h/l absorbed in scroll mode (no main-tab nav)
+    }
+    function activateReaderChip() {
+        var chips = getReaderChips();
+        if (readerChipIdx < 0 || readerChipIdx >= chips.length) return false;
+        var chip = chips[readerChipIdx];
+        // The chip's onclick already calls _navigateToSecurity — fire it.
+        chip.click();
+        return true;
+    }
+    // Expose so the keydown handler can dispatch Enter to chip activation.
+    window._readerActivate = activateReaderChip;
+    window._readerInChipMode = function () { return readerChipIdx >= 0; };
 
     // ── Browser History ──
 
@@ -2742,6 +2965,15 @@ window.onerror = function (msg, src, line, col, err) {
         onViewEnter(currentView);
         updateClock();
         setInterval(updateClock, 1000);
+
+        // Mouse clicks on buttons leave them DOM-focused, which Chrome paints
+        // as :focus-visible — leaks an orange outline that lingers after h/l
+        // navigates elsewhere. Blur immediately so selection state is purely
+        // class-driven (.active / .vim-selected).
+        document.addEventListener('click', function (e) {
+            var btn = e.target.closest('button, [tabindex]');
+            if (btn) btn.blur();
+        });
 
         // Set initial history state
         history.replaceState({ view: currentView, security: selectedSecurity }, '');


### PR DESCRIPTION
## Summary

A QoL batch ahead of the Thursday demo: tightens the Overview layout, fixes the sketch autocomplete, adds proper vim navigation inside the news reader, and kills the lingering orange focus outline after mouse clicks.

### A. Overview redesign
- Dense 8×2 Key Indicators grid stretches across the top so all 16 stats fit without dominating the page.
- Below that: 2-column split — **Key People** (left, single row per person so longer titles aren't truncated) and the **company description** (right). Description flows with the page rather than scrolling inside its own panel.
- Responsive: 4-wide grid on narrower screens.

### B. Ideas / sketchpad UX
- `:add SYMBOL.field to ` (trailing space) now shows the top 5 recently-updated sketches with no further typing. Was broken by a `raw.trim()` that stripped the trailing space, so `' to '` never matched. Now ltrim-only, plus a fallback that triggers on `' to'` while the user's still mid-typing.
- `:add SYMBOL.field to <unknown>` detects "no match" and offers a **create** row in the dropdown — Enter creates the sketch and adds the metric in one go. Flash: `Idea "X" created — added Y`.
- `:add … to <name>` from a foreign page (financials, graph, etc.) now **stays on the current page** and posts in the background. Tap `a` on a row, hit Enter, repeat — without bouncing back and forth to `/ideas`.
- Sketches list cached lazily in `terminal.js` so cross-page autocomplete works without forcing `ideas.js` to load.

### C. Security news tab
- Sub-tab bar replicates the `/news` categories (Press Releases / Articles / Stock / Crypto / Forex / General) with the same blue active-underline. All sub-tabs filter to the current symbol.
- Plugs into the existing main → sub → content vim focus layer (`h`/`l` switches sub-tabs, `j` drops into the cards).

### D. News reader vim navigation
- Reader open: `j`/`k` scroll the reader body. Once the body is at the bottom, the next `j` snaps selection to the first ticker chip in the related-securities row.
- `j`/`l` cycle chips forward, `k`/`h` cycle back. `k` off the first chip drops selection and resumes scrolling up.
- **Enter** on a selected chip navigates to `/security/<symbol>` via the existing onclick.
- `z` toggles the reader between slide-in width and full-width expanded mode for comfortable reading. Esc closes and resets state.
- `h`/`l` absorbed by the reader while it's open — never moves the underlying tabs out from under the user.

### E. Focus-ring fix
- Mouse-clicking a `<button>` leaves it DOM-focused, which Chrome paints as `:focus-visible` — the orange outline lingered even after `h`/`l` moved selection elsewhere.
- Now `blur()` on click globally for any `<button>` or `[tabindex]`, so the only visual selection state is the `.active` / `.vim-selected` class.
- `outline: none !important` also kills any browser-managed focus paint.

## Test plan
- [x] `make build`
- [x] `make test`
- [x] `make smoke`
- [x] `/security/AAPL` Overview: 16 stats fit in two rows; description fills its column; people list is single-column with full titles
- [x] On `/security/GOOG` financials → press `a` on a row → cmd bar shows `:add GOOG.field` → type ` to ` → top 5 sketches appear
- [x] Type `:add GOOG.revenue to NewIdeaName` → Enter creates sketch + adds metric, flash confirms, page **stays on financials**
- [x] Open a news article → reader appears → `j` scrolls → at-bottom `j` selects first chip → Enter navigates to `/security/<chip>`
- [x] `z` expands reader to full-width; `z` again or Esc returns to slide-in
- [x] Click any tab with mouse → no orange outline lingers after `h`/`l` moves elsewhere