### PR TITLE
fix(ideas): unify selection colour + server-side palette rotation

### DIFF
--- a/internal/server/ideas.go
+++ b/internal/server/ideas.go
@@ -133,6 +133,25 @@ func (s *Server) handleDeleteSketch(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// seriesPalette mirrors the JS SERIES_COLORS rotation. Used to pick a colour
+// for a new metric that isn't already in the sketch — keeps lines visually
+// distinct without making the client do the bookkeeping.
+var seriesPalette = []string{"#ff8800", "#4499ff", "#00cc66", "#bb88ff", "#ccaa00"}
+
+func pickUnusedColor(existing []store.SketchMetric) string {
+	used := make(map[string]bool, len(existing))
+	for _, m := range existing {
+		used[strings.ToLower(m.Color)] = true
+	}
+	for _, c := range seriesPalette {
+		if !used[strings.ToLower(c)] {
+			return c
+		}
+	}
+	// All five used — wrap around by count
+	return seriesPalette[len(existing)%len(seriesPalette)]
+}
+
 func (s *Server) handleAddSketchMetric(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
@@ -146,6 +165,16 @@ func (s *Server) handleAddSketchMetric(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	m.SketchID = id
+	if strings.TrimSpace(m.Color) == "" {
+		// Server-side colour assignment so foreign-page :add paths (which
+		// don't know the sketch's current metric list) still produce
+		// distinct lines on the chart.
+		if existing, gerr := s.store.GetSketch(id); gerr == nil && existing != nil {
+			m.Color = pickUnusedColor(existing.Metrics)
+		} else {
+			m.Color = seriesPalette[0]
+		}
+	}
 	if m.Kind == "" || m.Identifier == "" {
 		http.Error(w, "kind and identifier required", http.StatusBadRequest)
 		return

--- a/internal/server/static/ideas.js
+++ b/internal/server/static/ideas.js
@@ -351,8 +351,9 @@
 
     function addMetric(parsed) {
         return ensureSketch().then(function (sk) {
-            var color = SERIES_COLORS[(sk.metrics || []).length % SERIES_COLORS.length];
-            var body = { kind: parsed.kind, identifier: parsed.identifier, label: parsed.label || parsed.identifier, color: color };
+            // Leave color empty so the server picks an unused palette entry —
+            // single source of truth for colour selection.
+            var body = { kind: parsed.kind, identifier: parsed.identifier, label: parsed.label || parsed.identifier };
             return fetch('/api/sketches/' + sk.id + '/metrics', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -451,8 +452,7 @@
     }
 
     function addMetricToSketch(sketchID, parsed) {
-        var color = SERIES_COLORS[Math.floor(Math.random() * SERIES_COLORS.length)];
-        var body = { kind: parsed.kind, identifier: parsed.identifier, label: parsed.label || parsed.identifier, color: color };
+        var body = { kind: parsed.kind, identifier: parsed.identifier, label: parsed.label || parsed.identifier };
         return fetch('/api/sketches/' + sketchID + '/metrics', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -2542,7 +2542,9 @@ li.kp-row::before {
 .ideas-list {
     list-style: none;
     margin: 0;
-    padding: 4px 0;
+    /* clear both edges of the sidebar's pane-focused inset outline so item
+       borders + backgrounds don't paint over it. */
+    padding: 4px 4px;
     flex: 1;
     overflow-y: auto;
 }
@@ -2551,6 +2553,9 @@ li.kp-row::before {
     display: flex;
     flex-direction: column;
     padding: 8px 12px;
+    /* reserve the 2px indicator stripe always so content doesn't shift when
+       an item becomes active or vim-selected. */
+    border-left: 2px solid transparent;
     border-bottom: 1px solid var(--bg-tertiary);
     cursor: pointer;
 }
@@ -2559,10 +2564,13 @@ li.kp-row::before {
     background: var(--bg-tertiary);
 }
 
-.ideas-list-item.active {
+/* Both "this sketch is loaded" (.active) and "vim cursor is here"
+   (.vim-selected) share the same blue treatment — the chart title is the
+   source of truth for which is loaded, and consistency reads cleaner. */
+.ideas-list-item.active,
+.ideas-list-item.vim-selected {
     background: var(--bg-tertiary);
-    border-left: 2px solid var(--orange);
-    padding-left: 10px;
+    border-left-color: var(--blue);
 }
 
 .ideas-list-name {
@@ -2744,12 +2752,6 @@ li.kp-row::before {
 
 .ideas-notes-textarea::placeholder {
     color: var(--text-muted);
-}
-
-.ideas-list-item.vim-selected {
-    background: var(--bg-tertiary);
-    border-left: 2px solid var(--blue);
-    padding-left: 10px;
 }
 
 .ideas-legend-row-err {

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -1299,11 +1299,12 @@ window.onerror = function (msg, src, line, col, err) {
         return { kind: 'price', identifier: s, label: s };
     }
 
-    // Add a parsed metric to a sketch by id. Picks a colour by current count
-    // so the destination sketch's series stay visually distinct.
-    function postMetricToSketch(sketchID, parsed, count) {
-        var color = SERIES_COLORS_FALLBACK[(count || 0) % SERIES_COLORS_FALLBACK.length];
-        var body = { kind: parsed.kind, identifier: parsed.identifier, label: parsed.label || parsed.identifier, color: color };
+    // Add a parsed metric to a sketch by id. Colour is left empty so the
+    // server can pick an unused one — the foreign-page path doesn't know the
+    // sketch's current metric list, so client-side rotation would always
+    // hand out the first palette colour.
+    function postMetricToSketch(sketchID, parsed) {
+        var body = { kind: parsed.kind, identifier: parsed.identifier, label: parsed.label || parsed.identifier };
         return fetch('/api/sketches/' + sketchID + '/metrics', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -1321,7 +1322,7 @@ window.onerror = function (msg, src, line, col, err) {
             var match = sketchesData.find(function (sk) { return sk.name.toLowerCase() === lower; });
             if (!match) match = sketchesData.find(function (sk) { return sk.name.toLowerCase().indexOf(lower) === 0; });
             if (match) {
-                postMetricToSketch(match.id, parsed, (match.metrics || []).length)
+                postMetricToSketch(match.id, parsed)
                     .then(function () { flashError('Added ' + parsed.label + ' to ' + match.name); });
                 return;
             }
@@ -1331,7 +1332,7 @@ window.onerror = function (msg, src, line, col, err) {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ name: sketchName }),
             }).then(function (r) { return r.json(); })
-            .then(function (resp) { return postMetricToSketch(resp.id, parsed, 0); })
+            .then(function (resp) { return postMetricToSketch(resp.id, parsed); })
             .then(function () {
                 flashError('Idea "' + sketchName + '" created — added ' + parsed.label);
                 // Refresh the local cache so subsequent :add tos see it


### PR DESCRIPTION
## Summary
- Sidebar selection on `/ideas` now uses the same blue indicator for both the loaded sketch (`.active`) and the vim cursor (`.vim-selected`) — previously mouse-click and direct navigation painted orange while j/k painted blue, which read as two different states.
- `.ideas-list` gained 4px right padding (was left-only) and items now reserve a 2px transparent indicator stripe, so the selection border + background can't paint over the panel's pane-focused inset outline and content doesn't shift on selection.
- Server picks an unused palette colour in `handleAddSketchMetric` when the client posts an empty colour. Foreign-page `:add` (e.g. from financials) doesn't know the destination sketch's existing metrics, so client-side rotation always handed out the first palette entry — both client paths now defer to the server for a single source of truth.

## Test plan
- [x] `make test` green
- [x] `make smoke` green
- [x] Navigate directly to `/ideas/6` — selected row shows blue stripe (not orange)
- [x] Mouse-click a sketch — blue stripe (matches j/k cursor)
- [x] j/k between sketches — no content shift, stripe stays blue
- [x] Pane-focused outline visible on both sides of the sidebar without item paint-over
- [x] `:add netIncome` from financials adds a line in a colour distinct from existing series