### PR TITLE
feat(economics): /economics page with FRED catalog + FMP calendar + sketchpad economic kind

### DIFF
--- a/cmd/stocktopus/main.go
+++ b/cmd/stocktopus/main.go
@@ -13,6 +13,7 @@ import (
 
 	"stocktopus/internal/agent"
 	"stocktopus/internal/agent/trading"
+	"stocktopus/internal/fred"
 	"stocktopus/internal/hub"
 	"stocktopus/internal/news"
 	"stocktopus/internal/newspoller"
@@ -192,6 +193,12 @@ func main() {
 		go sp.Run(appCtx)
 	}
 
+	// FRED client + prefetcher. Disabled (gracefully) if FRED_API_KEY is unset.
+	fredClient := fred.New(os.Getenv("FRED_API_KEY"))
+	if st != nil {
+		go fred.NewPrefetcher(fredClient, st, logger, 30*time.Minute).Run(appCtx)
+	}
+
 	h.SetSubscriptionHandler(composite)
 
 	// Trading analysis pipeline (multi-agent, button-triggered)
@@ -221,7 +228,7 @@ func main() {
 		slog.Info("trading pipeline ready", "model", analystModel)
 	}
 
-	srv, err := server.New(server.Config{Port: 8080, Host: "localhost"}, h, debug, poll, newsClient, pipeline, tradingPipeline, st, logger)
+	srv, err := server.New(server.Config{Port: 8080, Host: "localhost"}, h, debug, poll, newsClient, fredClient, pipeline, tradingPipeline, st, logger)
 	if err != nil {
 		slog.Error("failed to create server", "error", err)
 		os.Exit(1)

--- a/ideas.md
+++ b/ideas.md
@@ -1,0 +1,294 @@
+### 1. Vim Navigation on Financial Statements
+
+**User Story:** As a keyboard-centric user, I want to use Vim navigation keys (`j` and `k`) on the Financials view, so that I can quickly scroll through balance sheets, income statements, and cash flow panels without using a mouse.
+**Acceptance Criteria:**
+
+* [ ] Pressing `j` moves the active row highlight down.
+* [ ] Pressing `k` moves the active row highlight up.
+* [ ] The highlighted state is visually distinct.
+* [ ] This behavior works consistently across the Balance Sheet, Income Statement, and Cash Flow panels.
+* [ ] Navigation respects panel boundaries (does not scroll off the data table).
+
+### 2. Multi-Metric Comparative Graphing (Epic)
+
+**User Story:** As a financial analyst, I want a dedicated comparative graphing tool with a "sketch pad" and save functionality, so that I can visually compare vastly different security metrics, indices, and commodities in a single, legible view.
+**Acceptance Criteria:**
+
+* [ ] Users can add a selected security property (e.g., Total Assets) to a "sketch pad" comparative graph.
+* [ ] Users can add multiple distinct value types to the same chart (balance sheet items, other security prices, indices, forex, commodities).
+* [ ] The chart automatically scales or uses multiple/normalized Y-axes so vastly different metrics (e.g., billions vs. hundreds) remain visible and legible on the same graph.
+* [ ] Users can save the default sketch pad as a named comparison chart.
+* [ ] Saved charts can be pinned to a specific security/company for future access.
+* [ ] **All** functions (adding metrics, saving, pinning) are fully accessible via keyboard/terminal commands.
+
+#### Notes 
+
+1. The path should be /ideas  <- which will be the default sketchpad, we will eventually build this out to include other data and notes, but that's not for now.  ideas/<some id or title> will take me to a specific idea comparison graph.   Comparison graphs are a function of the ideas page.    
+2. At the moment these are global, but let's scope them to a 'global' user concept so that we can refactor later towards user specific ideas.   Don't tie them to the symbol .
+3. This is broader work, I want to be able to see such throught experiments sucha s 'how has the price of oil affected the stock price of x, or the debt of x or any other financial data of x'
+4. data sources 
+
+FMP again
+
+Commodities
+https://financialmodelingprep.com/stable/commodities-list?apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe 
+https://financialmodelingprep.com/stable/quote?symbol=GCUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/quote-short?symbol=GCUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/historical-price-eod/light?symbol=GCUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/historical-price-eod/full?symbol=GCUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/historical-chart/1min?symbol=GCUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/historical-chart/5min?symbol=GCUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/historical-chart/1hour?symbol=GCUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+
+Forex
+
+https://financialmodelingprep.com/stable/forex-list?apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/quote?symbol=EURUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://site.financialmodelingprep.com/playground
+https://financialmodelingprep.com/stable/historical-price-eod/light?symbol=EURUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/historical-price-eod/full?symbol=EURUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/historical-chart/1min?symbol=EURUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/historical-chart/5min?symbol=EURUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/historical-chart/1hour?symbol=EURUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+
+Crypto
+https://financialmodelingprep.com/stable/cryptocurrency-list?apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/quote?symbol=BTCUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/quote-short?symbol=BTCUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/historical-price-eod/light?symbol=BTCUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/historical-price-eod/full?symbol=BTCUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/historical-chart/1min?symbol=BTCUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/historical-chart/5min?symbol=BTCUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+https://financialmodelingprep.com/stable/historical-chart/1hour?symbol=BTCUSD&apikey=b5PjWSJfLjZhOvnRLFJoWD3MekJoE2xe
+
+5. Time range, it would be good if we could select, but I dont see how that would work against yearly financial data, maybe stick to 5 years for now. Unless you ahve a better idea. 
+
+
+### 3. Financials Preview Chart Slide-in
+
+**User Story:** As an analyst, I want to press `p` to preview a selected financial line item as a chart, so that I can visualize historical trends without leaving the main Financials page.
+**Acceptance Criteria:**
+
+* [ ] When a row on the Financials page is highlighted, pressing `p` triggers a slide-in window.
+* [ ] The slide-in window displays a line chart of the historical data for the selected metric.
+* [ ] The UX and animation of the slide-in window exactly match the existing "news reader" panel.
+* [ ] Pressing `p` (or `Esc`) toggles/closes the slide-in window.
+
+### 4. Global History Navigation via `-` Key
+
+**User Story:** As a user, I want to press the `-` key to return to my previous page and tab state, so that I can rapidly navigate my recent history without losing context.
+**Acceptance Criteria:**
+
+* [ ] Pressing `-` universally triggers a "go back" action to the previous view.
+* [ ] Returning to a previous page successfully restores the exact tab that was active at the time.
+**Technical Notes:**
+* Implement this utilizing the browser's native History API.
+* Ensure tab states are managed via HATEOAS/URL parameters so the history stack inherently knows which tab was open.
+
+#### Notes 
+
+1. no, the vim navigation is used between tabs, - is only used if I jump to a new page via navigation or the command bar, I want to be able to get 'back' to where I was.   Say I jump to news <symbol> but I'm on the /ideas sketchpad, I want to read the news, then quickly jump back to to the sketchpad.  
+2. I dont' udnerstand the question, did the above example help ? 
+3. hash-bashed I think, as long as it works with sub-tabs as well.
+
+
+### 5. Streamlined Watchlist Addition
+
+**User Story:** As a user, I want a highly visible command menu option to add a security to a watchlist, so that I don't have to remember complex steps to track a company.
+**Acceptance Criteria:**
+
+* [ ] The main command menu includes a clear "Add to Watchlist" command.
+* [ ] Selecting this command prompts for (or automatically adds) the currently viewed security to the user's active watchlist.
+
+#### Watchlists already exists 
+http://localhost:8080/watchlist
+
+I'd like to be able to add a currently selected symbol to the watchlist, I think we added this already but i can't remmber how to do it, and speed and efficiency is the goal here,  
+
+If I have a selected security in the symbol picker, I ant to press Escape, then see the command bar and type watch then it auto completes with Watch <name of watchlist> so that I can select which watchlist to add it to
+
+### 6. Vim Navigation for Deep Analysis Execution
+
+**User Story:** As a keyboard-centric user, I want to be able to focus and trigger the "Run Deep Analysis" button using normal mode Vim bindings, so that I can initiate analysis seamlessly.
+**Acceptance Criteria:**
+
+* [ ] The "Run Deep Analysis" button is focusable via `j`/`k` navigation in normal mode.
+* [ ] When the button is focused/highlighted, pressing `Return` (`Enter`) executes the analysis.
+
+### 7. Remove Execution Time Noise
+
+**User Story:** As a user reviewing AI analysis, I want the "time the analysis took" metric removed from the UI, so that my view is less cluttered with irrelevant system noise.
+**Acceptance Criteria:**
+
+* [ ] Remove the execution/processing time text from the AI Analysis page DOM.
+
+### 8. Trading Phase 3 — Trader Agent Proposal Generation
+
+**User Story:** As the system orchestrator, I want a Trader Agent to convert an Investment Plan verdict into a concrete Trading Proposal, so that subjective analyses are turned into actionable market orders.
+**Acceptance Criteria:**
+
+* [ ] The Trader Agent successfully ingests the `InvestmentPlan` (bull/bear verdict).
+* [ ] The Agent generates a standardized `TraderProposal` data object.
+* [ ] The `TraderProposal` must include: `action`, `reasoning`, `entry_price`, `stop_loss`, and `position_size`.
+
+#### Notes 
+1. let's do this work as a separate piece after we finish this, I haven't thought about this deeply enough. 
+
+### 9. Trading Phase 4 — 3-Way Risk Debate & PM Approval
+
+**User Story:** As the system orchestrator, I want a generated trading proposal to be debated by three distinct risk personas and finalized by a Portfolio Manager agent, so that automated trades undergo rigorous risk assessment before execution.
+**Acceptance Criteria:**
+
+* [ ] A workflow is triggered where three AI personas (Aggressive, Conservative, Neutral) independently analyze and argue the `TraderProposal`.
+* [ ] The output of this debate is ingested by a final "Portfolio Manager" agent.
+* [ ] The Portfolio Manager agent issues a final Go/No-Go decision based on the debate logic
+
+##### Notes
+
+Let's think about portfolio  management as a separate piece, i want to study what the current bloombergterminal does, please start a research agent to find out.  
+
+### 10. SEC Key People Timeline UI
+
+**User Story:** As a fundamental analyst, I want to view a chronological timeline of executive changes on the SEC page, so that I can easily track leadership turnover and stability.
+**Acceptance Criteria:**
+
+* [ ] A new "Key People" sub-tab is added to the SEC page.
+* [ ] The tab queries the existing `key_people` background table.
+* [ ] Data is rendered in the UI as a clear, readable chronological timeline of executive changes.
+
+### 11. Insider-derived Key People (Form 4 XML)
+
+**User Story:** As a fundamental analyst, I want the Key People list to populate within seconds of opening the SEC tab on a security I haven't viewed before, so that I'm not waiting on minute-long LLM extractions to see who runs the company.
+**Acceptance Criteria:**
+
+* [ ] Recent Form 3/4/5 XML filings are downloaded and parsed (no LLM) to seed `key_people` with directors and officers.
+* [ ] Each row records: name, title, role (director / officer / both), filing date, source URL.
+* [ ] Existing DEF 14A and 10-K LLM extraction runs in the background after the Form 4 seed and enriches the list (e.g. "Lead Independent Director" titles, non-insider directors).
+* [ ] No regression in current data quality — Form 4 entries dedup against LLM-derived entries by name+title.
+
+**Technical Notes:**
+
+* Forms 3/4/5 are schema'd XML — no scraping. Each filing has `<reportingOwner>` with `<reportingOwnerRelationship>` containing `isDirector`, `isOfficer`, `officerTitle`, `isTenPercentOwner` fields.
+* New fetch path: list Form 4s from FMP (or SEC submissions API), grab the `.xml` not the `.htm`, unmarshal into a Go struct, write straight to `key_people`.
+* Most current directors and officers will appear because they're required to file Form 4 on every transaction (and Form 3 on appointment).
+* `edgartools` (Python) does this already if we want a reference implementation — but a small Go XML unmarshaller is probably <100 lines.
+
+### 12. Vim row operations on the watchlist page (`d` / `y` / `p`)
+
+**User Story:** As a keyboard-centric user managing my watchlists, I want to select a row on the watchlist page and use vim-style operations to remove, copy, or move that security between watchlists, so that I can curate lists without ever touching the mouse.
+**Acceptance Criteria:**
+
+* [ ] A row on the watchlist page is selectable via existing `j`/`k` navigation (highlight visually distinct).
+* [ ] Pressing `d` on a selected row removes that security from the *current* watchlist (the one being viewed). Confirmation flash on success; idempotent if the symbol isn't there.
+* [ ] Pressing `y` on a selected row opens the existing `:watch <name>` autocomplete dropdown pre-populated for "copy mode" — selecting a target watchlist adds the symbol to that list while *leaving it in the source list*.
+* [ ] Pressing `p` on a selected row opens the same autocomplete in "move mode" — selecting a target adds it to the destination *and* removes it from the source as a single action.
+* [ ] All three operations work on the keyboard alone — no mouse required (per the vim-first-class-citizen rule).
+* [ ] Selection is preserved across the source list re-render after `d` or `p` (highlight the row that took the deleted row's slot, or the new last row if the deleted row was last).
+
+**Technical Notes:**
+
+* Reuse `renderCmdWatchlistDropdown(query)` from PR #46 with a mode flag (`copy` / `move`) so the description text and the executed action differ. Mode is held in a closure variable scoped to the cmd-bar invocation.
+* `d` already maps to nothing on the watchlist view in the keydown switch — easy to wire.
+* For `y` / `p`: focus the cmd input pre-filled with `:watch ` and stash the source row + mode for the eventual selection.
+* Backend already exposes `DELETE /api/watchlists/{id}/symbols/{symbol}` from earlier work — no new endpoints needed.
+
+### 13. Attach panels to a sketch (notes linking)
+
+**User Story:** As an analyst building an investment thesis, I want to attach analyst result panels, news article links, and free text from anywhere in the app to the notes panel of a specific idea/sketch, so that all the evidence supporting one thought experiment lives in one place.
+**Acceptance Criteria:**
+
+* [ ] On any AI analyst result panel (Technical, Fundamentals, News, Sentiment, Research Verdict), an "attach to idea" affordance — keyboard-first, e.g. `A` while focused on the panel — opens an autocomplete picker of saved sketches.
+* [ ] On any news card / article reader / SEC filing row, the same `A` keybinding works.
+* [ ] Selecting a sketch appends a structured reference to that sketch's notes panel: `[2026-05-10] {kind}: {title} — {url-or-snippet}`.
+* [ ] References in the notes panel become clickable — clicking opens the original (article reader, AI panel, etc.) without leaving `/ideas`.
+* [ ] Free text typed directly in the notes textarea continues to be persisted as-is (existing behavior).
+
+**Technical Notes:**
+
+* The notes column is plain TEXT today. Could stay as Markdown-ish text with a renderer pass, or move to a structured `sketch_attachments` table for clickability. Markdown-with-links is faster to ship; structured table is cleaner long-term.
+* The `_ideasGetSketches()` window helper from PR #48 already exposes the sketch list — reuse for the picker dropdown.
+* Reuse the article-reader slide-in panel for opening attached articles, same as elsewhere.
+
+### 15. Economics page (v1 — US via FRED)
+
+**User Story:** As an investor reasoning about how macro shaped a security's path, I want a dedicated `/economics` page modelled on Bloomberg's ECO / ECST / ECWB triad, plus the ability to chart any economic indicator alongside prices and financial metrics on the sketchpad, so I can visually correlate macro shocks with company performance.
+**Acceptance Criteria:**
+
+* [ ] `/economics` page with two tabs — `Calendar` (ECO-style upcoming releases + recent actuals, columns: Date · Time · Country · Event · Importance · Prior · Survey · Actual · Surprise) and `Catalog` (ECST-style browser of curated indicators by category with sparkline preview).
+* [ ] Both tabs are vim-navigable: `h/l` between tabs, `j/k` between rows, `Enter` opens chart preview (Catalog) or release detail (Calendar).
+* [ ] `:add unrate`, `:add cpi`, `:add fedfunds`, `:add dgs10`, etc. autocomplete from the curated FRED catalog.
+* [ ] Selected indicators plot on the same rebased % change chart as prices and financial fields.
+* [ ] Series labels in the legend read humanly (e.g. "U.S. Unemployment Rate", "10Y Treasury Yield") not the raw FRED code.
+
+**Technical Notes:**
+
+* Data sources: FRED API for historical indicator time series (US-only, ~30 curated FRED IDs: UNRATE, CPIAUCSL, GDPC1, DGS10, FEDFUNDS, etc.). FMP `/stable/economic-calendar` for the release calendar (date, prior, estimate, actual, country, importance).
+* New `internal/fred/` client. New `economic_series` SQLite table with frequency-aware TTLs (daily series refresh every 6h, monthly every 3 days, quarterly every week). Background prefetcher primes the curated set at boot.
+* New `kind: 'economic'` on sketch metrics, routed through the historical handler.
+* Catalog organised by category bucket: Rates · Inflation · Growth · Labor · Housing · Consumer · Trade.
+
+### 16. Economics page (v2 — international via DBnomics)
+
+**User Story:** As a global macro investor, I want the same economics page to surface ECB, Bank of England, Bundesbank, Banque de France, OECD, IMF, and World Bank indicators alongside the US series, so I can think about non-US monetary policy and cross-country comparisons.
+**Acceptance Criteria:**
+
+* [ ] Catalog gains a country pivot (US default, switch to EU / UK / DE / FR / JP / G7).
+* [ ] Curated set extends to: ECB main refi rate, Eurozone HICP, BoE bank rate, UK CPI, Bundesbank yields, IFO sentiment, INSEE business confidence, OECD CLI, IMF WEO indicators.
+* [ ] Calendar tab adds non-US release events (FMP economic calendar already covers most majors — verify coverage gap first).
+
+**Technical Notes:**
+
+* New `internal/dbnomics/` client wrapping `https://api.db.nomics.world/v22/series/{provider}/{dataset}/{code}?observations=1`. Covers FED, BEA, BLS, ECB, BOE, BUBA, BDF, INSEE, DESTATIS, OECD, IMF, WB, EUROSTAT.
+* Note: FRED itself is no longer hosted on DBnomics (provider removed) — that's why v1 uses FRED direct. DBnomics is purely for international expansion.
+* Each provider has its own series ID convention — catalog needs a `(provider, dataset, series_code)` tuple per entry. Hand-curate the international additions; don't try to expose the full 1.7B-series DBnomics universe.
+* Stretch: ECWB-style transforms (YoY, MoM, MA, lead/lag, log) as keystrokes on a charted economic series.
+
+### 14. Non-statement fields in `:add` (marketcap, beta, etc.)
+
+**User Story:** As a sketchpad user, I want to plot company metadata fields like `marketcap`, `beta`, `peRatio`, and `dividendYield` over time on the comparison chart, so that I can compare these alongside prices and statement fields.
+**Acceptance Criteria:**
+
+* [ ] `:add AAPL.marketcap` autocompletes alongside the income/balance/cashflow fields.
+* [ ] The historical endpoint accepts a "metadata" kind (or extends `financial`) to project these fields per period.
+* [ ] Extracted values are charted on the existing rebased-to-100 line.
+
+**Technical Notes:**
+
+* FMP exposes these via separate endpoints: `/stable/key-metrics` (historical key metrics: peRatio, marketCap, etc.), `/stable/ratios` (priceToBookRatio, dividendYield, …), `/stable/profile` (single-snapshot beta, sector, mktCap).
+* For point-in-time fields (beta from /profile), only one data point is available — show as a horizontal price line rather than a series, OR fall back to the most recent value across the chart range.
+* Field-list autocomplete in `terminal.js` (`FIN_FIELDS`) needs a second tier: "key-metric fields" + "ratio fields" alongside statement fields. Could hit a discovery endpoint at startup that returns the canonical field list per kind, so we don't hardcode.
+
+### 17. Migrate the ideas backlog to GitHub Issues
+
+**User Story:** As the project maintainer, I want this markdown backlog tracked as GitHub Issues with labels and milestones, so that work-in-flight is visible from the PR side, ranking is mutable without diff churn, and assistants can link PRs to closing issues.
+**Acceptance Criteria:**
+
+* [ ] One GitHub Issue per current `ideas.md` entry (titles match the section heading, body = the section content).
+* [ ] A `backlog` label applied to all migrated issues plus one of `feature` / `chore` / `bug` based on the entry's nature.
+* [ ] Issues that map to deferred phases (Trading #8/#9, Economics v2 #16) get a milestone (`Phase 3`, `Phase 4`, `Economics v2`).
+* [ ] Already-shipped entries (Vim navigation #1, sketchpad #2, Financials slide-in #3, Watchlist `:watch` add #5, etc.) are closed immediately with a comment linking the PR that delivered them.
+* [ ] `ideas.md` is removed from the repo once migration is verified — single source of truth.
+
+**Technical Notes:**
+
+* `gh issue create --title ... --body-file <(awk ...) --label backlog,feature` from a small migration script. Don't paste by hand.
+* For the shipped entries, `gh issue close <N> --comment "Shipped in #54"` after creation.
+* Worth a dry run into a fork or a `backlog/*` label-prefixed batch before mass-creating in the real repo.
+
+### 18. Delete an idea with `d` from the sidebar
+
+**User Story:** As a sketchpad user pruning experiments, I want to press `d` on the highlighted idea in the `/ideas` sidebar to delete it, so I can clear out stale comparisons without reaching for the mouse.
+**Acceptance Criteria:**
+
+* [ ] On `/ideas`, with the sidebar pane focused and an idea highlighted via `j`/`k`, pressing `d` deletes that sketch.
+* [ ] The deleted row is removed from the sidebar; the cursor stays on the same index (now pointing at what was the row below), or moves up if it was the last row.
+* [ ] If the deleted sketch is the currently-loaded one, the chart pane clears and the next sketch in the list loads — or the empty state if no sketches remain.
+* [ ] No mouse-only confirm dialog. A flash like "Deleted <name>" in the cmd-bar status is enough; the action is reversible only by re-creating, so don't paper over the destructive shape with friction.
+
+**Technical Notes:**
+
+* `DELETE /api/sketches/{id}` already exists from earlier work — no new endpoint.
+* Extend `vimHandlers.ideas.deleteSelected` (it currently returns false on the sidebar pane and only handles the metric-row delete). Add a branch: if the focused pane is the sidebar, call the sketch-delete path; if it's the chart, keep the existing metric-delete behaviour.
+* Mirror the watchlist `d` pattern (idea #12) — same look + flash message style.
+
+

--- a/internal/fred/catalog.go
+++ b/internal/fred/catalog.go
@@ -1,0 +1,184 @@
+package fred
+
+// Curated catalog — the ~30 indicators surfaced on /economics and acceptable as
+// `:add <code>` on sketches. Categories mirror Bloomberg's ECST buckets.
+//
+// Frequencies determine cache TTLs (see ttl.go). Keep the catalog small —
+// users who want anything else can extend it later, and FRED's 800k-series
+// universe is a search problem, not a curation problem.
+
+// CatalogEntry is one curated indicator. The user-facing handle is
+// `{Country}.{Code}` (e.g. US.UNRATE) so v2 can add EZ.HICP / UK.CPI /
+// BUBA.X without colliding. Country is ISO 3166-1 alpha-2 (special-case "EZ"
+// for the Eurozone aggregate).
+type CatalogEntry struct {
+	Country     string `json:"country"`     // ISO-2 (US, EZ, UK, …)
+	Code        string `json:"code"`        // FRED series ID — also the suffix of the public handle
+	Provider    string `json:"provider"`    // Data source label, e.g. "FRED · Federal Reserve". Surfaced on the drill-down screen.
+	CentralBank string `json:"centralBank"` // Human label for the central bank list ("Federal Reserve (United States)")
+	Name        string `json:"name"`        // Human label for the legend ("U.S. Unemployment Rate")
+	Category    string `json:"category"`    // Rates · Inflation · Growth · Labor · Housing · Consumer · Trade
+	Frequency   string `json:"frequency"`   // D / W / M / Q / A — informational; client also stores what FRED reports
+	Units       string `json:"units"`       // Short units ("%", "Index", "$bn")
+}
+
+// Identifier returns the public handle "Country.Code" (e.g. "US.UNRATE").
+func (e CatalogEntry) Identifier() string { return e.Country + "." + e.Code }
+
+// usEntry is a tiny shim so the catalog reads cleanly — every row in v1 is
+// Federal Reserve / United States, so we factor that boilerplate out.
+func usEntry(code, name, category, freq, units string) CatalogEntry {
+	return CatalogEntry{
+		Country:     "US",
+		Code:        code,
+		Provider:    "FRED",
+		CentralBank: "Federal Reserve (United States)",
+		Name:        name,
+		Category:    category,
+		Frequency:   freq,
+		Units:       units,
+	}
+}
+
+var Catalog = []CatalogEntry{
+	// Rates & Monetary
+	usEntry("FEDFUNDS", "Federal Funds Effective Rate", "Rates", "M", "%"),
+	usEntry("DFF", "Federal Funds Rate (Daily)", "Rates", "D", "%"),
+	usEntry("DGS10", "10-Year Treasury Constant Maturity", "Rates", "D", "%"),
+	usEntry("DGS2", "2-Year Treasury Constant Maturity", "Rates", "D", "%"),
+	usEntry("T10Y2Y", "10Y–2Y Treasury Spread", "Rates", "D", "%"),
+	usEntry("SOFR", "Secured Overnight Financing Rate", "Rates", "D", "%"),
+	usEntry("WALCL", "Fed Balance Sheet (Total Assets)", "Rates", "W", "$M"),
+	usEntry("M2SL", "M2 Money Supply", "Rates", "M", "$B"),
+
+	// Inflation
+	usEntry("CPIAUCSL", "Consumer Price Index (All Items)", "Inflation", "M", "Index"),
+	usEntry("CPILFESL", "Core CPI (Less Food & Energy)", "Inflation", "M", "Index"),
+	usEntry("PCEPI", "PCE Price Index", "Inflation", "M", "Index"),
+	usEntry("PCEPILFE", "Core PCE Price Index", "Inflation", "M", "Index"),
+	usEntry("PPIACO", "Producer Price Index (All Commodities)", "Inflation", "M", "Index"),
+	usEntry("T5YIE", "5-Year Breakeven Inflation Rate", "Inflation", "D", "%"),
+
+	// Growth
+	usEntry("GDPC1", "Real GDP", "Growth", "Q", "$B"),
+	usEntry("GDP", "Nominal GDP", "Growth", "Q", "$B"),
+	usEntry("INDPRO", "Industrial Production Index", "Growth", "M", "Index"),
+	usEntry("RSAFS", "Retail Sales (Advance)", "Growth", "M", "$M"),
+	usEntry("USSLIND", "Leading Index for the United States", "Growth", "M", "%"),
+
+	// Labor
+	usEntry("UNRATE", "Unemployment Rate", "Labor", "M", "%"),
+	usEntry("PAYEMS", "Total Nonfarm Payrolls", "Labor", "M", "Thousands"),
+	usEntry("ICSA", "Initial Jobless Claims", "Labor", "W", "Persons"),
+	usEntry("CIVPART", "Labor Force Participation Rate", "Labor", "M", "%"),
+	usEntry("AHETPI", "Average Hourly Earnings (Production)", "Labor", "M", "$"),
+
+	// Housing
+	usEntry("HOUST", "Housing Starts", "Housing", "M", "Thousands"),
+	usEntry("PERMIT", "Building Permits", "Housing", "M", "Thousands"),
+	usEntry("MORTGAGE30US", "30-Year Fixed Mortgage Rate", "Housing", "W", "%"),
+	usEntry("CSUSHPISA", "S&P/Case-Shiller U.S. National HPI", "Housing", "M", "Index"),
+
+	// Consumer
+	usEntry("UMCSENT", "U. Michigan Consumer Sentiment", "Consumer", "M", "Index"),
+	usEntry("PSAVERT", "Personal Saving Rate", "Consumer", "M", "%"),
+	usEntry("PCE", "Personal Consumption Expenditures", "Consumer", "M", "$B"),
+
+	// Trade
+	usEntry("BOPGSTB", "Trade Balance: Goods and Services", "Trade", "M", "$M"),
+	usEntry("DTWEXBGS", "Trade-Weighted Dollar Index (Broad)", "Trade", "D", "Index"),
+}
+
+// CentralBank is one row on the catalog's drill-down screen.
+type CentralBank struct {
+	Country     string `json:"country"`     // ISO-2
+	Code        string `json:"code"`        // CentralBank code: "FRED" / "ECB" / "BOE" / "BUBA" — used in URLs
+	Name        string `json:"name"`        // Human-readable, "Federal Reserve (United States)"
+	Description string `json:"description"` // Optional one-liner shown next to the row
+	Indicators  int    `json:"indicators"`  // Number of curated indicators
+}
+
+// CentralBanks returns the deduplicated list of central banks covered by the
+// catalog, sorted by name. Used by the drill-down screen.
+func CentralBanks() []CentralBank {
+	seen := map[string]*CentralBank{}
+	order := []string{}
+	for i := range Catalog {
+		e := &Catalog[i]
+		key := e.Country + "/" + e.Provider
+		cb, ok := seen[key]
+		if !ok {
+			cb = &CentralBank{
+				Country: e.Country,
+				Code:    e.Provider,
+				Name:    e.CentralBank,
+			}
+			seen[key] = cb
+			order = append(order, key)
+		}
+		cb.Indicators++
+	}
+	out := make([]CentralBank, 0, len(order))
+	for _, k := range order {
+		out = append(out, *seen[k])
+	}
+	return out
+}
+
+// IndicatorsByCountry returns the catalog filtered to a single country (ISO-2).
+func IndicatorsByCountry(country string) []CatalogEntry {
+	out := make([]CatalogEntry, 0, len(Catalog))
+	for _, e := range Catalog {
+		if equalFold(e.Country, country) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// LookupCatalog returns the curated entry for an identifier. Accepts either
+// the full "COUNTRY.CODE" handle (US.UNRATE) or a bare code (UNRATE) — the
+// bare form is a v1 convenience that resolves to the first matching entry,
+// since we only have one country for now.
+func LookupCatalog(identifier string) *CatalogEntry {
+	country, code := SplitIdentifier(identifier)
+	for i := range Catalog {
+		if !equalFold(Catalog[i].Code, code) {
+			continue
+		}
+		if country == "" || equalFold(Catalog[i].Country, country) {
+			return &Catalog[i]
+		}
+	}
+	return nil
+}
+
+// SplitIdentifier splits "US.UNRATE" into ("US", "UNRATE"). If there's no
+// dot, country is empty and the whole string is treated as a code.
+func SplitIdentifier(identifier string) (country, code string) {
+	for i := 0; i < len(identifier); i++ {
+		if identifier[i] == '.' {
+			return identifier[:i], identifier[i+1:]
+		}
+	}
+	return "", identifier
+}
+
+func equalFold(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		ca, cb := a[i], b[i]
+		if 'A' <= ca && ca <= 'Z' {
+			ca += 'a' - 'A'
+		}
+		if 'A' <= cb && cb <= 'Z' {
+			cb += 'a' - 'A'
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/fred/client.go
+++ b/internal/fred/client.go
@@ -1,0 +1,152 @@
+// Package fred is a thin client for the St. Louis Fed FRED API.
+//
+// FRED ID conventions are stable, well-known strings (UNRATE, CPIAUCSL,
+// FEDFUNDS, GDPC1, DGS10, …) so we can hand-curate a catalog without
+// worrying about renames. Free key from
+// https://fred.stlouisfed.org/docs/api/api_key.html.
+package fred
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const baseURL = "https://api.stlouisfed.org/fred"
+
+// Observation is one point in a FRED series. FRED returns dates as YYYY-MM-DD
+// and values as strings — "." means missing, anything else parses as float64.
+type Observation struct {
+	Date  string  `json:"date"`
+	Value float64 `json:"value"`
+}
+
+// SeriesMeta is the metadata for a FRED series as returned by /series.
+type SeriesMeta struct {
+	ID                 string `json:"id"`
+	Title              string `json:"title"`
+	FrequencyShort     string `json:"frequency_short"`     // D / W / M / Q / SA / A
+	Units              string `json:"units"`
+	UnitsShort         string `json:"units_short"`
+	SeasonalAdjustment string `json:"seasonal_adjustment_short"`
+	ObservationStart   string `json:"observation_start"`
+	ObservationEnd     string `json:"observation_end"`
+	LastUpdated        string `json:"last_updated"` // "2024-01-05 08:31:02-06"
+	Notes              string `json:"notes,omitempty"`
+}
+
+// Series bundles metadata + observations for a single FRED ID.
+type Series struct {
+	Meta         SeriesMeta    `json:"meta"`
+	Observations []Observation `json:"observations"`
+}
+
+type Client struct {
+	apiKey string
+	http   *http.Client
+}
+
+func New(apiKey string) *Client {
+	return &Client{
+		apiKey: apiKey,
+		http:   &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func (c *Client) HasKey() bool { return c.apiKey != "" }
+
+// GetSeries fetches metadata + full observation history for a series ID.
+func (c *Client) GetSeries(ctx context.Context, seriesID string) (*Series, error) {
+	meta, err := c.getMeta(ctx, seriesID)
+	if err != nil {
+		return nil, err
+	}
+	obs, err := c.getObservations(ctx, seriesID)
+	if err != nil {
+		return nil, err
+	}
+	return &Series{Meta: *meta, Observations: obs}, nil
+}
+
+func (c *Client) getMeta(ctx context.Context, seriesID string) (*SeriesMeta, error) {
+	q := url.Values{
+		"series_id": {seriesID},
+		"api_key":   {c.apiKey},
+		"file_type": {"json"},
+	}
+	body, err := c.fetch(ctx, "/series", q)
+	if err != nil {
+		return nil, err
+	}
+	var wrap struct {
+		Seriess []SeriesMeta `json:"seriess"`
+	}
+	if err := json.Unmarshal(body, &wrap); err != nil {
+		return nil, fmt.Errorf("decode series: %w", err)
+	}
+	if len(wrap.Seriess) == 0 {
+		return nil, fmt.Errorf("series %s not found", seriesID)
+	}
+	return &wrap.Seriess[0], nil
+}
+
+func (c *Client) getObservations(ctx context.Context, seriesID string) ([]Observation, error) {
+	q := url.Values{
+		"series_id":  {seriesID},
+		"api_key":    {c.apiKey},
+		"file_type":  {"json"},
+		"sort_order": {"asc"},
+	}
+	body, err := c.fetch(ctx, "/series/observations", q)
+	if err != nil {
+		return nil, err
+	}
+	var wrap struct {
+		Observations []struct {
+			Date  string `json:"date"`
+			Value string `json:"value"`
+		} `json:"observations"`
+	}
+	if err := json.Unmarshal(body, &wrap); err != nil {
+		return nil, fmt.Errorf("decode observations: %w", err)
+	}
+	out := make([]Observation, 0, len(wrap.Observations))
+	for _, o := range wrap.Observations {
+		// "." is FRED's sentinel for a missing observation — skip rather
+		// than emit NaN, the chart layer doesn't carry a tri-state value.
+		if o.Value == "." || o.Value == "" {
+			continue
+		}
+		v, err := strconv.ParseFloat(o.Value, 64)
+		if err != nil {
+			continue
+		}
+		out = append(out, Observation{Date: o.Date, Value: v})
+	}
+	return out, nil
+}
+
+func (c *Client) fetch(ctx context.Context, endpoint string, params url.Values) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+endpoint+"?"+params.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fred %d: %s", resp.StatusCode, string(body))
+	}
+	return body, nil
+}

--- a/internal/fred/prefetcher.go
+++ b/internal/fred/prefetcher.go
@@ -1,0 +1,108 @@
+package fred
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"stocktopus/internal/store"
+)
+
+// Prefetcher keeps the curated catalog warm in the store. It runs an initial
+// pass on Run, then wakes on a ticker to refresh anything older than its
+// frequency-aware TTL.
+type Prefetcher struct {
+	client   *Client
+	store    *store.Store
+	logger   *slog.Logger
+	interval time.Duration
+}
+
+func NewPrefetcher(client *Client, st *store.Store, logger *slog.Logger, interval time.Duration) *Prefetcher {
+	if interval <= 0 {
+		interval = 30 * time.Minute
+	}
+	return &Prefetcher{
+		client:   client,
+		store:    st,
+		logger:   logger.With("component", "fred-prefetcher"),
+		interval: interval,
+	}
+}
+
+// Run primes the cache at boot and refreshes on every tick. Blocks until ctx
+// is cancelled. If the client has no API key this is a no-op (logged once).
+func (p *Prefetcher) Run(ctx context.Context) {
+	if !p.client.HasKey() {
+		p.logger.Warn("FRED_API_KEY not set — economic series prefetch disabled")
+		return
+	}
+
+	p.logger.Info("fred prefetcher starting", "indicators", len(Catalog), "tick", p.interval)
+	p.refreshAll(ctx)
+
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Info("fred prefetcher stopped")
+			return
+		case <-ticker.C:
+			p.refreshAll(ctx)
+		}
+	}
+}
+
+func (p *Prefetcher) refreshAll(ctx context.Context) {
+	for _, entry := range Catalog {
+		if ctx.Err() != nil {
+			return
+		}
+		// Store keys are the full identifier (US.UNRATE); FRED itself is
+		// queried with the bare code (UNRATE). Future-proofs the cache for
+		// when v2 adds EZ.UNRATE etc. from a different provider.
+		id := entry.Identifier()
+		freq := entry.Frequency
+		if existing, _ := p.store.GetEconomicSeries(id); existing != nil && existing.Frequency != "" {
+			freq = existing.Frequency
+		}
+		if p.store.IsEconomicFresh(id, TTLForFrequency(freq)) {
+			continue
+		}
+
+		fetchCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+		series, err := p.client.GetSeries(fetchCtx, entry.Code)
+		cancel()
+		if err != nil {
+			p.logger.Warn("fred fetch failed", "id", id, "error", err)
+			continue
+		}
+
+		obs := make([]store.EconomicObservation, len(series.Observations))
+		for i, o := range series.Observations {
+			obs[i] = store.EconomicObservation{Date: o.Date, Value: o.Value}
+		}
+		row := &store.EconomicSeries{
+			Code:            id,
+			Title:           coalesce(series.Meta.Title, entry.Name),
+			Category:        entry.Category,
+			Frequency:       coalesce(series.Meta.FrequencyShort, entry.Frequency),
+			Units:           coalesce(series.Meta.UnitsShort, entry.Units),
+			Observations:    obs,
+			SourceUpdatedAt: series.Meta.LastUpdated,
+		}
+		if err := p.store.PutEconomicSeries(row); err != nil {
+			p.logger.Warn("fred store failed", "id", id, "error", err)
+			continue
+		}
+		p.logger.Debug("fred refreshed", "id", id, "points", len(obs))
+	}
+}
+
+func coalesce(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}

--- a/internal/fred/ttl.go
+++ b/internal/fred/ttl.go
@@ -1,0 +1,24 @@
+package fred
+
+import "time"
+
+// TTLForFrequency maps a FRED frequency_short to a cache-freshness window.
+// Picked so the cache returns at the rate the source actually updates:
+// FEDFUNDS moves daily during NYSE hours; GDP arrives once a quarter.
+func TTLForFrequency(freq string) time.Duration {
+	switch freq {
+	case "D":
+		return 6 * time.Hour
+	case "W":
+		return 24 * time.Hour
+	case "M", "SM": // monthly / semi-monthly
+		return 72 * time.Hour
+	case "Q":
+		return 7 * 24 * time.Hour
+	case "A":
+		return 30 * 24 * time.Hour
+	default:
+		// Unknown — refresh daily to be safe.
+		return 24 * time.Hour
+	}
+}

--- a/internal/news/news.go
+++ b/internal/news/news.go
@@ -352,6 +352,20 @@ func (c *Client) GetSECFilings(ctx context.Context, symbol, from, to string) (js
 	return c.fetchJSON(ctx, "/stable/sec-filings-search/symbol", params)
 }
 
+// GetEconomicCalendar fetches economic release events between two dates.
+// Each row carries date (YYYY-MM-DD HH:MM:SS UTC), country (ISO-2), event,
+// previous/estimate/actual, impact (Low/Medium/High), and unit.
+func (c *Client) GetEconomicCalendar(ctx context.Context, from, to string) (json.RawMessage, error) {
+	params := url.Values{}
+	if from != "" {
+		params.Set("from", from)
+	}
+	if to != "" {
+		params.Set("to", to)
+	}
+	return c.fetchJSON(ctx, "/stable/economic-calendar", params)
+}
+
 // GetIntradayChart fetches intraday OHLCV data for a symbol.
 // interval: "1min", "5min", "15min", "30min", "1hour", "4hour"
 func (c *Client) GetIntradayChart(ctx context.Context, symbol, interval, from, to string) ([]model.OHLCV, error) {

--- a/internal/server/economics.go
+++ b/internal/server/economics.go
@@ -1,0 +1,190 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"stocktopus/internal/fred"
+	"stocktopus/internal/store"
+)
+
+// handleEconomics serves the /economics page (calendar + catalog).
+func (s *Server) handleEconomics(w http.ResponseWriter, r *http.Request) {
+	s.renderPage(w, r, "economics.html", map[string]any{
+		"Title":  "Economics",
+		"Active": "economics",
+	})
+}
+
+// handleEconomicsCatalog returns the curated indicator list with the latest
+// observation per code from cache (for sparkline rendering on the catalog tab).
+// The optional ?country=US filter scopes the response to one central bank.
+func (s *Server) handleEconomicsCatalog(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	type row struct {
+		Identifier  string  `json:"identifier"` // "US.UNRATE" — the user-facing handle
+		Country     string  `json:"country"`
+		Code        string  `json:"code"`
+		Name        string  `json:"name"`
+		Category    string  `json:"category"`
+		Frequency   string  `json:"frequency"`
+		Units       string  `json:"units"`
+		LatestDate  string  `json:"latestDate,omitempty"`
+		LatestValue float64 `json:"latestValue,omitempty"`
+		HasCache    bool    `json:"hasCache"`
+	}
+
+	country := strings.ToUpper(r.URL.Query().Get("country"))
+	entries := fred.Catalog
+	if country != "" {
+		entries = fred.IndicatorsByCountry(country)
+	}
+
+	out := make([]row, 0, len(entries))
+	for _, entry := range entries {
+		id := entry.Identifier()
+		r := row{
+			Identifier: id,
+			Country:    entry.Country,
+			Code:       entry.Code,
+			Name:       entry.Name,
+			Category:   entry.Category,
+			Frequency:  entry.Frequency,
+			Units:      entry.Units,
+		}
+		if s.store != nil {
+			if es, _ := s.store.GetEconomicSeries(id); es != nil && len(es.Observations) > 0 {
+				last := es.Observations[len(es.Observations)-1]
+				r.LatestDate = last.Date
+				r.LatestValue = last.Value
+				r.HasCache = true
+				if es.Frequency != "" {
+					r.Frequency = es.Frequency
+				}
+				if es.Units != "" {
+					r.Units = es.Units
+				}
+			}
+		}
+		out = append(out, r)
+	}
+	json.NewEncoder(w).Encode(out)
+}
+
+// handleEconomicsCentralBanks lists the central banks covered by the catalog
+// — the entry point for the catalog drill-down.
+func (s *Server) handleEconomicsCentralBanks(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(fred.CentralBanks())
+}
+
+// handleEconomicsSeries returns a single series — full observations, suitable
+// for chart rendering. Path param is the full identifier ("US.UNRATE"); the
+// older bare-code form is accepted for backwards-compat but resolves against
+// the first matching entry. Cache-through: serves from store if fresh, else
+// hits FRED and persists. 404 if not in the curated catalog.
+func (s *Server) handleEconomicsSeries(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	identifier := strings.ToUpper(r.PathValue("identifier"))
+	entry := fred.LookupCatalog(identifier)
+	if entry == nil {
+		http.Error(w, "unknown series", http.StatusNotFound)
+		return
+	}
+
+	es, err := s.fetchOrLoadSeries(r, entry)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	json.NewEncoder(w).Encode(es)
+}
+
+// serveEconomicSeriesObservations is the chart-layer projection — emits the
+// [{date, value}, ...] shape that the sketchpad historical handler expects,
+// so an `economic` metric kind interleaves with prices and financials cleanly.
+// Path identifier is "COUNTRY.CODE" (e.g. US.UNRATE).
+func (s *Server) serveEconomicSeriesObservations(w http.ResponseWriter, r *http.Request, rawIdentifier string) {
+	identifier := strings.ToUpper(rawIdentifier)
+	entry := fred.LookupCatalog(identifier)
+	if entry == nil {
+		http.Error(w, "unknown economic series", http.StatusNotFound)
+		return
+	}
+	es, err := s.fetchOrLoadSeries(r, entry)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	out := make([]map[string]any, 0, len(es.Observations))
+	for _, o := range es.Observations {
+		out = append(out, map[string]any{"date": o.Date, "value": o.Value})
+	}
+	json.NewEncoder(w).Encode(out)
+}
+
+// fetchOrLoadSeries returns the stored series if fresh, otherwise fetches from
+// FRED, persists, and returns the fresh copy. Cache key is the full
+// identifier (US.UNRATE); FRED itself is queried with the bare entry.Code.
+func (s *Server) fetchOrLoadSeries(r *http.Request, entry *fred.CatalogEntry) (*store.EconomicSeries, error) {
+	if s.store == nil {
+		return nil, httpErr("store unavailable")
+	}
+
+	id := entry.Identifier()
+	cached, _ := s.store.GetEconomicSeries(id)
+	freq := entry.Frequency
+	if cached != nil && cached.Frequency != "" {
+		freq = cached.Frequency
+	}
+	if cached != nil && s.store.IsEconomicFresh(id, fred.TTLForFrequency(freq)) {
+		return cached, nil
+	}
+
+	if s.fred == nil || !s.fred.HasKey() {
+		if cached != nil {
+			return cached, nil
+		}
+		return nil, httpErr("FRED_API_KEY not configured")
+	}
+
+	ctx, cancel := contextWithTimeout(r, 20*time.Second)
+	defer cancel()
+	series, err := s.fred.GetSeries(ctx, entry.Code)
+	if err != nil {
+		if cached != nil {
+			return cached, nil // soft-fail to stale data
+		}
+		return nil, err
+	}
+
+	row := seriesToRow(id, entry, series)
+	if err := s.store.PutEconomicSeries(row); err != nil {
+		s.logger.Warn("economic series put failed", "id", id, "error", err)
+	}
+	return row, nil
+}
+
+// handleEconomicsCalendar proxies the FMP economic calendar for a date window.
+// Defaults to a ±7-day window around today (UTC) so the calendar shows both
+// recent actuals and upcoming releases.
+func (s *Server) handleEconomicsCalendar(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	from := r.URL.Query().Get("from")
+	to := r.URL.Query().Get("to")
+	if from == "" {
+		from = time.Now().UTC().AddDate(0, 0, -7).Format("2006-01-02")
+	}
+	if to == "" {
+		to = time.Now().UTC().AddDate(0, 0, 7).Format("2006-01-02")
+	}
+	raw, err := s.news.GetEconomicCalendar(r.Context(), from, to)
+	if err != nil {
+		http.Error(w, "fmp calendar error", http.StatusBadGateway)
+		return
+	}
+	w.Write(raw)
+}

--- a/internal/server/economics_helpers.go
+++ b/internal/server/economics_helpers.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"stocktopus/internal/fred"
+	"stocktopus/internal/store"
+)
+
+func httpErr(msg string) error { return errors.New(msg) }
+
+func contextWithTimeout(r *http.Request, d time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(r.Context(), d)
+}
+
+// seriesToRow turns a fresh FRED response into the store row, falling back to
+// catalog values for anything FRED didn't provide. id is the full identifier
+// used as the cache key (e.g. "US.UNRATE").
+func seriesToRow(id string, entry *fred.CatalogEntry, series *fred.Series) *store.EconomicSeries {
+	obs := make([]store.EconomicObservation, len(series.Observations))
+	for i, o := range series.Observations {
+		obs[i] = store.EconomicObservation{Date: o.Date, Value: o.Value}
+	}
+	title := series.Meta.Title
+	if title == "" {
+		title = entry.Name
+	}
+	freq := series.Meta.FrequencyShort
+	if freq == "" {
+		freq = entry.Frequency
+	}
+	units := series.Meta.UnitsShort
+	if units == "" {
+		units = entry.Units
+	}
+	return &store.EconomicSeries{
+		Code:            id,
+		Title:           title,
+		Category:        entry.Category,
+		Frequency:       freq,
+		Units:           units,
+		Observations:    obs,
+		SourceUpdatedAt: series.Meta.LastUpdated,
+	}
+}

--- a/internal/server/ideas.go
+++ b/internal/server/ideas.go
@@ -215,6 +215,11 @@ func (s *Server) handleHistorical(w http.ResponseWriter, r *http.Request) {
 	kind := r.PathValue("kind")
 	rawSymbol := r.PathValue("symbol")
 
+	if kind == "economic" {
+		s.serveEconomicSeriesObservations(w, r, rawSymbol)
+		return
+	}
+
 	if kind == "financial" {
 		dot := strings.LastIndex(rawSymbol, ".")
 		if dot <= 0 || dot >= len(rawSymbol)-1 {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,6 +22,7 @@ import (
 
 	"stocktopus/internal/agent"
 	"stocktopus/internal/agent/trading"
+	"stocktopus/internal/fred"
 	"stocktopus/internal/hub"
 	"stocktopus/internal/news"
 	"stocktopus/internal/store"
@@ -58,13 +59,14 @@ type Server struct {
 	debug        *DebugBroadcaster
 	symbols      SymbolLister
 	news         *news.Client
+	fred         *fred.Client
 	pipeline     *agent.Pipeline
 	trading      *trading.TradingPipeline
 	store        *store.Store
 	assetVersion string
 }
 
-func New(cfg Config, h *hub.Hub, debug *DebugBroadcaster, symbols SymbolLister, newsClient *news.Client, pipeline *agent.Pipeline, tp *trading.TradingPipeline, st *store.Store, logger *slog.Logger) (*Server, error) {
+func New(cfg Config, h *hub.Hub, debug *DebugBroadcaster, symbols SymbolLister, newsClient *news.Client, fredClient *fred.Client, pipeline *agent.Pipeline, tp *trading.TradingPipeline, st *store.Store, logger *slog.Logger) (*Server, error) {
 	s := &Server{
 		config:       cfg,
 		logger:       logger,
@@ -75,6 +77,7 @@ func New(cfg Config, h *hub.Hub, debug *DebugBroadcaster, symbols SymbolLister, 
 		trading:      tp,
 		store:        st,
 		news:         newsClient,
+		fred:         fredClient,
 		assetVersion: newAssetVersion(),
 	}
 
@@ -113,7 +116,7 @@ func (s *Server) loadTemplates() error {
 	layoutPath := filepath.Join(templatesDir(), "layout.html")
 	s.pages = make(map[string]*template.Template)
 
-	pageNames := []string{"watchlist", "stock", "security", "screener", "feed", "debug", "news", "indices", "ideas"}
+	pageNames := []string{"watchlist", "stock", "security", "screener", "feed", "debug", "news", "indices", "ideas", "economics", "economic-graph", "financial-graph"}
 	for _, page := range pageNames {
 		pagePath := filepath.Join(templatesDir(), page+".html")
 		t, err := template.ParseFiles(layoutPath, pagePath)
@@ -183,6 +186,12 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("DELETE /api/sketches/{id}/metrics/{metricId}", s.handleRemoveSketchMetric)
 	mux.HandleFunc("GET /api/historical/{kind}/{symbol}", s.handleHistorical)
 
+	// Economics
+	mux.HandleFunc("GET /api/economics/catalog", s.handleEconomicsCatalog)
+	mux.HandleFunc("GET /api/economics/central-banks", s.handleEconomicsCentralBanks)
+	mux.HandleFunc("GET /api/economics/series/{identifier}", s.handleEconomicsSeries)
+	mux.HandleFunc("GET /api/economics/calendar", s.handleEconomicsCalendar)
+
 	// WebSocket
 	mux.HandleFunc("GET /ws", s.handleWebSocket)
 	mux.HandleFunc("GET /ws/debug", s.handleDebugWS)
@@ -199,6 +208,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /indices", s.handleIndicesPage)
 	mux.HandleFunc("GET /ideas", s.handleIdeas)
 	mux.HandleFunc("GET /ideas/{id}", s.handleIdeas)
+	mux.HandleFunc("GET /economics", s.handleEconomics)
 	mux.HandleFunc("GET /debug", s.handleDebug)
 }
 
@@ -223,6 +233,36 @@ func (s *Server) handleWatchlist(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleStock(w http.ResponseWriter, r *http.Request) {
 	symbol := r.PathValue("symbol")
+	// Disambiguate by suffix:
+	//   US.UNRATE       → catalog hit → economic graph
+	//   AAPL.revenue    → lowercase camelCase suffix → financial-field graph
+	//   BRK.A / GOOG.L  → uppercase ticker share class → stock graph
+	if entry := fred.LookupCatalog(strings.ToUpper(symbol)); entry != nil {
+		s.renderPage(w, r, "economic-graph.html", map[string]any{
+			"Title":     entry.Name,
+			"Active":    "graph",
+			"Symbol":    entry.Identifier(),
+			"Name":      entry.Name,
+			"Units":     entry.Units,
+			"Frequency": entry.Frequency,
+		})
+		return
+	}
+	if dot := strings.LastIndex(symbol, "."); dot > 0 && dot < len(symbol)-1 {
+		first := symbol[dot+1]
+		if first >= 'a' && first <= 'z' {
+			sym := strings.ToUpper(symbol[:dot])
+			field := symbol[dot+1:] // preserve camelCase
+			s.renderPage(w, r, "financial-graph.html", map[string]any{
+				"Title":  sym + " " + field,
+				"Active": "graph",
+				"Symbol": sym + "." + field,
+				"Ticker": sym,
+				"Field":  field,
+			})
+			return
+		}
+	}
 	s.renderPage(w, r, "stock.html", map[string]any{
 		"Title":  symbol,
 		"Active": "graph",

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -15,7 +15,7 @@ func testServer(t *testing.T) (*Server, *http.ServeMux) {
 	logger := slog.Default()
 	h := hub.New(logger)
 	debug := NewDebugBroadcaster()
-	srv, err := New(Config{Port: 0}, h, debug, nil, nil, nil, nil, nil, logger)
+	srv, err := New(Config{Port: 0}, h, debug, nil, nil, nil, nil, nil, nil, logger)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}

--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -63,7 +63,7 @@
         return MONTHS[d.getUTCMonth()] + ' ' + d.getUTCDate();
     }
     var chart = LightweightCharts.createChart(container, {
-        layout: { background: { color: '#0a0a0a' }, textColor: '#888888', fontFamily: "'SF Mono','Consolas',monospace", fontSize: 11 },
+        layout: { background: { color: '#0a0a0a' }, textColor: '#888888', fontFamily: "'SF Mono','Consolas',monospace", fontSize: 11, attributionLogo: false },
         grid: { vertLines: { color: '#1a1a1a' }, horzLines: { color: '#1a1a1a' } },
         crosshair: { mode: LightweightCharts.CrosshairMode.Normal, vertLine: { color: '#555', style: 2 }, horzLine: { color: '#555', style: 2 } },
         rightPriceScale: { borderColor: '#2a2a2a', scaleMargins: { top: 0.05, bottom: 0.25 } },

--- a/internal/server/static/economic-graph.js
+++ b/internal/server/static/economic-graph.js
@@ -1,0 +1,91 @@
+// Full-size economic indicator chart at /graph/{identifier}. Sibling to chart.js
+// for OHLC tickers — economic series are line, not candle, and have no
+// intraday/indicator toolbar.
+
+(function () {
+    'use strict';
+
+    var host = document.getElementById('eco-graph-host');
+    if (!host) return;
+    var identifier = host.dataset.identifier;
+    if (!identifier) return;
+
+    var RANGE_YEARS = { '1Y': 1, '5Y': 5, '10Y': 10, 'MAX': 0 };
+    var currentRange = '5Y';
+    var fullSeries = null; // {observations, title, units, ...}
+    var chart = null;
+    var series = null;
+
+    function disposeChart() {
+        if (chart) { try { chart.remove(); } catch (e) {} chart = null; series = null; }
+    }
+
+    function waitForLib(cb) {
+        if (window.LightweightCharts) cb();
+        else setTimeout(function () { waitForLib(cb); }, 100);
+    }
+
+    function fetchSeries() {
+        return fetch('/api/economics/series/' + encodeURIComponent(identifier))
+            .then(function (r) {
+                if (!r.ok) throw new Error('series ' + r.status);
+                return r.json();
+            });
+    }
+
+    function filterToRange(obs, range) {
+        var years = RANGE_YEARS[range] || 0;
+        if (!years) return obs;
+        var cutoff = new Date();
+        cutoff.setFullYear(cutoff.getFullYear() - years);
+        var iso = cutoff.toISOString().slice(0, 10);
+        return obs.filter(function (o) { return o.date >= iso; });
+    }
+
+    function render() {
+        if (!fullSeries) return;
+        var obs = filterToRange(fullSeries.observations || [], currentRange);
+        disposeChart();
+        chart = window.LightweightCharts.createChart(host, {
+            layout: { background: { color: '#0a0a0a' }, textColor: '#888888', fontFamily: "'SF Mono','Consolas',monospace", fontSize: 11, attributionLogo: false },
+            grid: { vertLines: { color: '#1a1a1a' }, horzLines: { color: '#1a1a1a' } },
+            rightPriceScale: { borderColor: '#2a2a2a' },
+            timeScale: { borderColor: '#2a2a2a' },
+            crosshair: { mode: 1 },
+        });
+        series = chart.addSeries(LightweightCharts.LineSeries, { color: '#4499ff', lineWidth: 2 });
+        series.setData(obs.map(function (o) { return { time: o.date, value: o.value }; }));
+        chart.timeScale().fitContent();
+    }
+
+    function setRange(range) {
+        currentRange = range;
+        document.querySelectorAll('#eco-graph-range .chart-range-btn').forEach(function (b) {
+            b.classList.toggle('active', b.dataset.range === range);
+        });
+        render();
+    }
+
+    // ── Wiring ──
+
+    document.querySelectorAll('#eco-graph-range .chart-range-btn').forEach(function (b) {
+        if (b.dataset.default !== undefined) b.classList.add('active');
+        b.addEventListener('click', function () { setRange(b.dataset.range); });
+    });
+
+    waitForLib(function () {
+        fetchSeries()
+            .then(function (es) {
+                fullSeries = es;
+                render();
+            })
+            .catch(function () {
+                host.innerHTML = '<p class="empty-state">Series unavailable. Verify FRED_API_KEY and that the prefetcher has warmed.</p>';
+            });
+    });
+
+    // Re-fit on window resize so the chart fills the viewport.
+    window.addEventListener('resize', function () {
+        if (chart) chart.timeScale().fitContent();
+    });
+})();

--- a/internal/server/static/economics.js
+++ b/internal/server/static/economics.js
@@ -1,0 +1,574 @@
+// /economics page — Calendar (FMP releases) + Catalog (FRED curated, drill
+// down by central bank).
+//
+// Vim model:
+//   h / l       → switch tabs (or go back from indicator list to CB list)
+//   j / k       → row navigation
+//   /           → focus the visible tab's filter input (per-view binding)
+//   a           → prefill :add COUNTRY.CODE in cmd-bar, stay on page
+//   p / g       → slide-in chart preview (5y / full) in the article-reader
+//                 pane shared with financials
+//   Enter       → no-op for now (reserved for future drill-in)
+(function () {
+    // ── State ──
+    var activeTab = 'calendar';
+
+    var calendarRows = [];
+    var calendarFiltered = [];
+    var calendarFilter = '';
+    var calendarImpact = 'all';
+    var calendarIdx = -1;
+
+    // Catalog drill-down state.
+    //   level: 'cb' (central-bank list) | 'indicators' (one CB's indicator list)
+    var catalogLevel = 'cb';
+    var catalogCBs = [];
+    var catalogCBIdx = -1;
+    var catalogCountry = '';
+
+    var catalogRows = [];
+    var catalogFiltered = [];
+    var catalogFilter = '';
+    var catalogIdx = -1;
+
+    function $(id) { return document.getElementById(id); }
+    function escapeHTML(s) {
+        return String(s).replace(/[&<>"']/g, function (c) {
+            return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+        });
+    }
+    function fmt(num, units) {
+        if (num === null || num === undefined || isNaN(num)) return '—';
+        var n = Number(num);
+        var abs = Math.abs(n);
+        var s = abs >= 1000 ? n.toLocaleString(undefined, { maximumFractionDigits: 0 })
+              : abs >= 10   ? n.toFixed(1)
+                            : n.toFixed(2);
+        return units && units !== 'Index' ? s + ' ' + units : s;
+    }
+
+    // ── Tab switching ──
+
+    function switchTab(name) {
+        activeTab = name;
+        document.querySelectorAll('#economics-tabs .economics-tab').forEach(function (btn) {
+            btn.classList.toggle('active', btn.dataset.tab === name);
+        });
+        $('economics-calendar-panel').classList.toggle('hidden', name !== 'calendar');
+        $('economics-catalog-panel').classList.toggle('hidden', name !== 'catalog');
+        applyVimSelection();
+    }
+
+    // ── Calendar filter directive parsing ──
+    //
+    // Tokens prefixed with ':' are *directives*; everything else is free-text
+    // event match. Repeating a directive type keeps the last one (so typing
+    // `:high :low` filters to Low — same UX as a vim mode switch).
+    //
+    //   :high :medium :low :all  → impact filter
+    //   :us :uk :eu :jp …        → country filter (ISO-2)
+    //   free text                → contained in event/country/impact
+
+    function parseCalendarFilter(s) {
+        var impact = null;
+        var country = null;
+        var freeParts = [];
+        s.split(/\s+/).forEach(function (tok) {
+            if (!tok) return;
+            if (tok[0] === ':') {
+                var rest = tok.slice(1).toLowerCase();
+                if (rest === 'high' || rest === 'medium' || rest === 'low' || rest === 'all') {
+                    impact = rest === 'all' ? 'all' : rest.charAt(0).toUpperCase() + rest.slice(1);
+                } else if (rest.length >= 2 && rest.length <= 3) {
+                    country = rest.toUpperCase();
+                }
+            } else {
+                freeParts.push(tok.toLowerCase());
+            }
+        });
+        return { impact: impact, country: country, free: freeParts.join(' ').trim() };
+    }
+
+    // ── Calendar tab ──
+
+    function loadCalendar() {
+        fetch('/api/economics/calendar')
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                calendarRows = Array.isArray(data) ? data : [];
+                var now = new Date();
+                calendarRows.sort(function (a, b) {
+                    var da = new Date(a.date), db = new Date(b.date);
+                    var afut = da >= now, bfut = db >= now;
+                    if (afut !== bfut) return afut ? -1 : 1;
+                    return afut ? da - db : db - da;
+                });
+                renderCalendar();
+            })
+            .catch(function () {
+                $('economics-calendar-body').innerHTML =
+                    '<tr><td colspan="8" class="empty-state">Calendar unavailable.</td></tr>';
+            });
+    }
+
+    function renderCalendar() {
+        var spec = parseCalendarFilter(calendarFilter);
+        // Directive impact overrides the badge selection (latest write wins);
+        // if neither is set, use the badge state.
+        var impact = spec.impact || calendarImpact;
+
+        calendarFiltered = calendarRows.filter(function (r) {
+            if (impact !== 'all' && r.impact !== impact) return false;
+            if (spec.country && (r.country || '').toUpperCase() !== spec.country) return false;
+            if (spec.free) {
+                var hay = ((r.country || '') + ' ' + (r.event || '') + ' ' + (r.impact || '')).toLowerCase();
+                if (hay.indexOf(spec.free) < 0) return false;
+            }
+            return true;
+        });
+
+        // Reflect directive-driven impact in the badge row so the UI doesn't lie.
+        if (spec.impact) {
+            document.querySelectorAll('.economics-badge').forEach(function (b) {
+                b.classList.toggle('active', b.dataset.impact === impact);
+            });
+        }
+
+        var tbody = $('economics-calendar-body');
+        if (calendarFiltered.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="8" class="empty-state">No matching releases.</td></tr>';
+            return;
+        }
+
+        var html = '';
+        for (var i = 0; i < calendarFiltered.length; i++) {
+            var r = calendarFiltered[i];
+            var surprise = '', surpriseClass = '';
+            if (r.actual !== null && r.estimate !== null && !isNaN(r.actual) && !isNaN(r.estimate)) {
+                var d = r.actual - r.estimate;
+                surprise = (d >= 0 ? '+' : '') + d.toFixed(2);
+                surpriseClass = d > 0 ? 'pos' : (d < 0 ? 'neg' : '');
+            }
+            var impactClass = 'impact-' + (r.impact || 'Low').toLowerCase();
+            html += '<tr class="economics-row" data-idx="' + i + '">'
+                + '<td class="economics-date">' + escapeHTML(r.date || '') + '</td>'
+                + '<td class="economics-country">' + escapeHTML(r.country || '') + '</td>'
+                + '<td class="economics-event">' + escapeHTML(r.event || '') + '</td>'
+                + '<td class="economics-impact ' + impactClass + '">' + escapeHTML(r.impact || '') + '</td>'
+                + '<td class="num">' + fmt(r.previous, r.unit) + '</td>'
+                + '<td class="num">' + fmt(r.estimate, r.unit) + '</td>'
+                + '<td class="num">' + fmt(r.actual, r.unit) + '</td>'
+                + '<td class="num ' + surpriseClass + '">' + surprise + '</td>'
+                + '</tr>';
+        }
+        tbody.innerHTML = html;
+        calendarIdx = -1;
+        applyVimSelection();
+    }
+
+    // ── Catalog tab — level 1: central bank list ──
+
+    function loadCentralBanks() {
+        fetch('/api/economics/central-banks')
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                catalogCBs = Array.isArray(data) ? data : [];
+                renderCentralBanks();
+            })
+            .catch(function () {
+                $('economics-cb-list').innerHTML = '<p class="empty-state">Central banks unavailable.</p>';
+            });
+    }
+
+    function renderCentralBanks() {
+        if (catalogCBs.length === 0) {
+            $('economics-cb-list').innerHTML = '<p class="empty-state">No central banks configured.</p>';
+            return;
+        }
+        // Tile layout — sidesteps the table sticky-header tangle entirely
+        // and reads as "pick a central bank" rather than "row 1 of N".
+        var html = '<div class="economics-cb-tiles">';
+        catalogCBs.forEach(function (cb, i) {
+            html += '<button type="button" class="economics-cb-tile economics-row" data-idx="' + i + '" data-country="' + escapeHTML(cb.country) + '">'
+                + '<span class="cb-tile-country">' + escapeHTML(cb.country) + '</span>'
+                + '<span class="cb-tile-name">' + escapeHTML(cb.name) + '</span>'
+                + '<span class="cb-tile-count">' + cb.indicators + ' indicators</span>'
+                + '</button>';
+        });
+        html += '</div>';
+        $('economics-cb-list').innerHTML = html;
+        catalogCBIdx = -1;
+    }
+
+    function enterCentralBank(country, displayName) {
+        catalogCountry = country;
+        catalogLevel = 'indicators';
+        $('economics-cb-list').classList.add('hidden');
+        $('economics-cb-detail').classList.remove('hidden');
+        $('economics-cb-title').textContent = displayName + ' — ' + country;
+        catalogFilter = '';
+        $('economics-catalog-filter').value = '';
+        catalogIdx = -1;
+        loadCatalog(country);
+    }
+
+    function backToCentralBanks() {
+        catalogLevel = 'cb';
+        catalogCountry = '';
+        $('economics-cb-list').classList.remove('hidden');
+        $('economics-cb-detail').classList.add('hidden');
+        applyVimSelection();
+    }
+
+    // ── Catalog tab — level 2: indicator list for one CB ──
+
+    function loadCatalog(country) {
+        fetch('/api/economics/catalog?country=' + encodeURIComponent(country))
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                catalogRows = Array.isArray(data) ? data : [];
+                renderCatalog();
+            })
+            .catch(function () {
+                $('economics-catalog-host').innerHTML = '<p class="empty-state">Catalog unavailable.</p>';
+            });
+    }
+
+    function renderCatalog() {
+        var f = catalogFilter.toLowerCase();
+        catalogFiltered = catalogRows.filter(function (r) {
+            if (!f) return true;
+            return (
+                r.code.toLowerCase().includes(f) ||
+                r.name.toLowerCase().includes(f) ||
+                r.category.toLowerCase().includes(f)
+            );
+        });
+
+        var groups = {};
+        var order = [];
+        catalogFiltered.forEach(function (row, i) {
+            row._idx = i;
+            if (!groups[row.category]) { groups[row.category] = []; order.push(row.category); }
+            groups[row.category].push(row);
+        });
+
+        var html = '';
+        if (catalogFiltered.length === 0) {
+            html = '<p class="empty-state">No matching indicators.</p>';
+        } else {
+            html += '<table class="economics-table economics-catalog-table"><thead><tr>'
+                + '<th>Identifier</th><th>Indicator</th><th>Frequency</th><th class="num">Latest</th><th>As of</th>'
+                + '</tr></thead><tbody>';
+            for (var i = 0; i < order.length; i++) {
+                var cat = order[i];
+                html += '<tr class="economics-cat-row"><td colspan="5">' + escapeHTML(cat) + '</td></tr>';
+                groups[cat].forEach(function (r) {
+                    html += '<tr class="economics-row economics-catalog-row" data-idx="' + r._idx + '"'
+                        + ' data-identifier="' + escapeHTML(r.identifier) + '"'
+                        + ' data-code="' + escapeHTML(r.code) + '">'
+                        + '<td class="economics-code">' + escapeHTML(r.identifier) + '</td>'
+                        + '<td>' + escapeHTML(r.name) + '</td>'
+                        + '<td>' + escapeHTML(r.frequency) + '</td>'
+                        + '<td class="num">' + (r.hasCache ? fmt(r.latestValue, r.units) : '—') + '</td>'
+                        + '<td>' + escapeHTML(r.latestDate || '') + '</td>'
+                        + '</tr>';
+                });
+            }
+            html += '</tbody></table>';
+        }
+        $('economics-catalog-host').innerHTML = html;
+        catalogIdx = -1;
+        applyVimSelection();
+    }
+
+    // ── Slide-in chart preview (article-reader pane) ──
+
+    var ecoChart = null;
+    function disposeEcoChart() {
+        if (ecoChart) { try { ecoChart.remove(); } catch (e) {} ecoChart = null; }
+    }
+
+    // Memoise fetched series for the session — re-pressing 'p' on the same
+    // indicator shouldn't re-hit the server (or worse, a live FRED roundtrip
+    // when the prefetcher hasn't reached this code yet).
+    var seriesCache = {};
+
+    function openPreviewForIdentifier(identifier, window5y) {
+        if (!identifier) return;
+        if (seriesCache[identifier]) {
+            renderPreview(seriesCache[identifier], identifier, window5y);
+            return;
+        }
+        fetch('/api/economics/series/' + encodeURIComponent(identifier))
+            .then(function (r) { if (!r.ok) throw new Error('preview load failed'); return r.json(); })
+            .then(function (es) {
+                seriesCache[identifier] = es;
+                renderPreview(es, identifier, window5y);
+            })
+            .catch(function () { renderPreviewError(identifier); });
+    }
+
+    function renderPreviewError(identifier) {
+        var reader = $('article-reader');
+        if (!reader) return;
+        $('reader-title').textContent = identifier + ' — data unavailable';
+        $('reader-body').innerHTML = '<p class="empty-state">No data — verify FRED_API_KEY is set and the prefetcher has warmed.</p>';
+        reader.dataset.mode = 'eco-chart';
+        reader.classList.remove('hidden');
+    }
+
+    function renderPreview(es, identifier, window5y) {
+        var reader = $('article-reader');
+        if (!reader || !es) return;
+        var rangeLabel = window5y ? '5y' : 'full';
+        $('reader-title').textContent = identifier + ' — ' + (es.title || identifier) + ' (' + rangeLabel + ')';
+
+        var obs = es.observations || [];
+        if (window5y) {
+            var cutoff = new Date();
+            cutoff.setFullYear(cutoff.getFullYear() - 5);
+            var cutoffISO = cutoff.toISOString().slice(0, 10);
+            obs = obs.filter(function (o) { return o.date >= cutoffISO; });
+        }
+
+        if (obs.length === 0) {
+            $('reader-body').innerHTML = '<p class="empty-state">No observations.</p>';
+            reader.dataset.mode = 'eco-chart';
+            reader.classList.remove('hidden');
+            return;
+        }
+
+        $('reader-body').innerHTML =
+            '<div id="eco-chart-host" style="width:100%;height:320px"></div>'
+            + '<div class="eco-chart-meta">'
+            +   '<span>units: ' + escapeHTML(es.units || '') + '</span>'
+            +   '<span>freq: ' + escapeHTML(es.frequency || '') + '</span>'
+            +   '<span>updated: ' + escapeHTML(es.sourceUpdatedAt || '') + '</span>'
+            + '</div>';
+
+        // Show the slide-in BEFORE creating the chart — lightweight-charts
+        // measures its host element to lay out, and a still-display:none
+        // ancestor reports 0×0. Result was an empty pane on the first 'p'.
+        var wasHidden = reader.classList.contains('hidden');
+        reader.dataset.mode = 'eco-chart';
+        reader.classList.remove('hidden');
+
+        disposeEcoChart();
+        if (!window.LightweightCharts) {
+            $('reader-body').textContent = 'lightweight-charts not loaded';
+            return;
+        }
+
+        // Paint synchronously when the reader was already visible (re-pressing
+        // 'p' on another indicator) so the chart shows up in the same frame;
+        // only defer when the reader was just unhidden, since the layout box
+        // hasn't been computed yet.
+        var paint = function () {
+            var host = $('eco-chart-host');
+            if (!host) return;
+            ecoChart = window.LightweightCharts.createChart(host, {
+                layout: { background: { color: '#0a0a0a' }, textColor: '#888888', fontFamily: "'SF Mono','Consolas',monospace", fontSize: 10, attributionLogo: false },
+                grid: { vertLines: { color: '#1a1a1a' }, horzLines: { color: '#1a1a1a' } },
+                rightPriceScale: { borderColor: '#2a2a2a' },
+                timeScale: { borderColor: '#2a2a2a' },
+                crosshair: { mode: 1 },
+            });
+            var series = ecoChart.addSeries(LightweightCharts.LineSeries, { color: '#4499ff', lineWidth: 2 });
+            series.setData(obs.map(function (o) { return { time: o.date, value: o.value }; }));
+            ecoChart.timeScale().fitContent();
+        };
+        if (wasHidden) requestAnimationFrame(paint);
+        else paint();
+    }
+
+    function closeEcoPreview() {
+        var reader = $('article-reader');
+        if (!reader) return false;
+        if (reader.dataset.mode !== 'eco-chart') return false;
+        disposeEcoChart();
+        reader.classList.add('hidden');
+        delete reader.dataset.mode;
+        return true;
+    }
+
+    // ── Vim selection / cursor ──
+
+    function currentRowSet() {
+        if (activeTab === 'calendar') {
+            return { items: calendarFiltered, container: $('economics-calendar-body'), idx: calendarIdx };
+        }
+        if (catalogLevel === 'cb') {
+            return { items: catalogCBs, container: $('economics-cb-list'), idx: catalogCBIdx };
+        }
+        return { items: catalogFiltered, container: $('economics-catalog-host'), idx: catalogIdx };
+    }
+
+    function applyVimSelection() {
+        document.querySelectorAll('.economics-row.vim-selected').forEach(function (el) {
+            el.classList.remove('vim-selected');
+        });
+        var st = currentRowSet();
+        if (st.idx < 0 || !st.container) return;
+        var row = st.container.querySelector('.economics-row[data-idx="' + st.idx + '"]');
+        if (row) {
+            row.classList.add('vim-selected');
+            row.scrollIntoView({ block: 'nearest' });
+        }
+    }
+
+    // ── Public vim hooks ──
+
+    window._economicsMove = function (dir) {
+        if (dir === 'h' || dir === 'l') {
+            if (activeTab === 'catalog' && catalogLevel === 'indicators' && dir === 'h') {
+                backToCentralBanks();
+                return;
+            }
+            var next = activeTab === 'calendar' ? 'catalog' : 'calendar';
+            if ((dir === 'h' && activeTab === 'catalog') || (dir === 'l' && activeTab === 'calendar')) {
+                switchTab(next);
+            }
+            return;
+        }
+        var st = currentRowSet();
+        if (st.items.length === 0) return;
+        var idx = st.idx;
+        if (dir === 'j') idx = Math.min(idx + 1, st.items.length - 1);
+        else if (dir === 'k') idx = Math.max(idx - 1, 0);
+        if (activeTab === 'calendar') calendarIdx = idx;
+        else if (catalogLevel === 'cb') catalogCBIdx = idx;
+        else catalogIdx = idx;
+        applyVimSelection();
+    };
+
+    window._economicsActivate = function () {
+        // Reserved for a future drill-in. Today only the CB-list level uses
+        // Enter — to descend into a CB's indicators.
+        if (activeTab !== 'catalog' || catalogLevel !== 'cb') return;
+        if (catalogCBIdx < 0 || catalogCBIdx >= catalogCBs.length) return;
+        var cb = catalogCBs[catalogCBIdx];
+        enterCentralBank(cb.country, cb.name);
+    };
+
+    window._economicsAddCmd = function () {
+        if (activeTab !== 'catalog' || catalogLevel !== 'indicators') return null;
+        if (catalogIdx < 0 || catalogIdx >= catalogFiltered.length) return null;
+        var r = catalogFiltered[catalogIdx];
+        return ':add ' + r.identifier;
+    };
+
+    // Toggle behavior: if the eco-chart slide-in is already open for the same
+    // identifier+range, pressing 'p' again closes it. Otherwise (closed, or
+    // open on a different indicator/range) it (re)opens.
+    var lastPreviewKey = null;
+    window._economicsOpenPreview = function (rangeKey) {
+        if (activeTab !== 'catalog' || catalogLevel !== 'indicators') return false;
+        if (catalogIdx < 0 || catalogIdx >= catalogFiltered.length) return false;
+        var r = catalogFiltered[catalogIdx];
+        var key = r.identifier + ':' + (rangeKey || '5y');
+        var reader = $('article-reader');
+        var openOnSame = reader && !reader.classList.contains('hidden')
+            && reader.dataset.mode === 'eco-chart'
+            && lastPreviewKey === key;
+        if (openOnSame) {
+            closeEcoPreview();
+            lastPreviewKey = null;
+            return true;
+        }
+        lastPreviewKey = key;
+        openPreviewForIdentifier(r.identifier, rangeKey !== 'full');
+        return true;
+    };
+
+    window._economicsClosePreview = function () {
+        var closed = closeEcoPreview();
+        if (closed) lastPreviewKey = null;
+        return closed;
+    };
+
+    // Selected-row identifier exposed for the `g` keybinding's navigation hop.
+    window._economicsSelectedIdentifier = function () {
+        if (activeTab !== 'catalog' || catalogLevel !== 'indicators') return null;
+        if (catalogIdx < 0 || catalogIdx >= catalogFiltered.length) return null;
+        return catalogFiltered[catalogIdx].identifier;
+    };
+
+    // ── Wiring ──
+
+    window._economicsInit = function () {
+        // Tab buttons
+        document.querySelectorAll('#economics-tabs .economics-tab').forEach(function (btn) {
+            btn.addEventListener('click', function () { switchTab(btn.dataset.tab); });
+        });
+
+        // Impact badges
+        document.querySelectorAll('.economics-badge').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                calendarImpact = btn.dataset.impact;
+                document.querySelectorAll('.economics-badge').forEach(function (b) {
+                    b.classList.toggle('active', b === btn);
+                });
+                renderCalendar();
+            });
+        });
+
+        // Live filters
+        $('economics-calendar-filter').addEventListener('input', function (e) {
+            calendarFilter = e.target.value; renderCalendar();
+        });
+        $('economics-catalog-filter').addEventListener('input', function (e) {
+            catalogFilter = e.target.value; renderCatalog();
+        });
+        // Enter in either filter input commits the query and returns to normal
+        // mode, so the user can j/k through the filtered list without a
+        // second keystroke. Escape stays bound globally — that one bails out
+        // of insert mode anywhere.
+        function exitFilter(e) {
+            if (e.key !== 'Enter') return;
+            e.preventDefault();
+            e.target.blur();
+        }
+        $('economics-calendar-filter').addEventListener('keydown', exitFilter);
+        $('economics-catalog-filter').addEventListener('keydown', exitFilter);
+
+        // Click handlers — CB tile, indicator row, back button
+        $('economics-cb-list').addEventListener('click', function (e) {
+            var tile = e.target.closest('.economics-cb-tile');
+            if (tile) {
+                var cb = catalogCBs[parseInt(tile.dataset.idx, 10)];
+                if (cb) enterCentralBank(cb.country, cb.name);
+            }
+        });
+        $('economics-cb-back').addEventListener('click', backToCentralBanks);
+        $('economics-catalog-host').addEventListener('click', function (e) {
+            var row = e.target.closest('.economics-catalog-row');
+            if (!row) return;
+            var idx = parseInt(row.dataset.idx, 10);
+            if (!isNaN(idx)) {
+                catalogIdx = idx;
+                applyVimSelection();
+            }
+        });
+
+        loadCalendar();
+        loadCentralBanks();
+    };
+
+    // Per-view filter focus (driven by terminal.js's `/` rebind).
+    window._economicsFocusFilter = function () {
+        var input = activeTab === 'calendar'
+            ? $('economics-calendar-filter')
+            : (catalogLevel === 'indicators' ? $('economics-catalog-filter') : null);
+        if (input) {
+            input.focus();
+            input.select();
+        }
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', window._economicsInit);
+    } else {
+        window._economicsInit();
+    }
+})();

--- a/internal/server/static/financial-graph.js
+++ b/internal/server/static/financial-graph.js
@@ -1,0 +1,106 @@
+// Full-size graph for a single financial-statement field at /graph/TICKER.field
+// (e.g. /graph/AAPL.revenue). Renders the same colored-segments YoY style as
+// the financials slide-in, but full-viewport — sibling to economic-graph.js.
+
+(function () {
+    'use strict';
+
+    var host = document.getElementById('fin-graph-host');
+    if (!host) return;
+    var ticker = host.dataset.ticker;
+    var field = host.dataset.field;
+    if (!ticker || !field) return;
+
+    function waitForLib(cb) {
+        if (window.LightweightCharts) cb();
+        else setTimeout(function () { waitForLib(cb); }, 100);
+    }
+
+    function fmtAxisValue(v) {
+        if (v === null || v === undefined || isNaN(v)) return '—';
+        var n = Number(v);
+        var abs = Math.abs(n);
+        if (abs >= 1e12) return (n / 1e12).toFixed(1) + 'T';
+        if (abs >= 1e9)  return (n / 1e9).toFixed(1) + 'B';
+        if (abs >= 1e6)  return (n / 1e6).toFixed(1) + 'M';
+        if (abs >= 1e3)  return (n / 1e3).toFixed(1) + 'k';
+        return n.toFixed(2);
+    }
+
+    function fetchSeries() {
+        return fetch('/api/historical/financial/' + encodeURIComponent(ticker + '.' + field))
+            .then(function (r) {
+                if (!r.ok) throw new Error('series ' + r.status);
+                return r.json();
+            });
+    }
+
+    function render(data) {
+        // Server returns rows in descending date order (newest first); the chart
+        // wants ascending. Also coerce values to numbers and drop nulls.
+        var series = (data || [])
+            .filter(function (d) { return d.value !== null && d.value !== undefined; })
+            .map(function (d) { return { time: d.date.slice(0, 10), value: Number(d.value) }; })
+            .filter(function (d) { return !isNaN(d.value); })
+            .sort(function (a, b) { return a.time < b.time ? -1 : 1; });
+
+        if (series.length === 0) {
+            host.innerHTML = '<p class="empty-state">No data points for this metric.</p>';
+            return;
+        }
+
+        // YoY segments, same look as the slide-in: each (n-1 → n) edge colored
+        // green if up, red if down, neutral if flat.
+        var GREEN = '#00cc66', RED = '#ff4444', NEUTRAL = '#888888';
+        var priceFormat = { type: 'custom', formatter: fmtAxisValue, minMove: 0.01 };
+
+        var chart = window.LightweightCharts.createChart(host, {
+            layout: { background: { color: '#0a0a0a' }, textColor: '#888888', fontFamily: "'SF Mono','Consolas',monospace", fontSize: 11, attributionLogo: false },
+            grid: { vertLines: { color: '#1a1a1a' }, horzLines: { color: '#1a1a1a' } },
+            rightPriceScale: { borderColor: '#2a2a2a' },
+            timeScale: { borderColor: '#2a2a2a', timeVisible: false },
+            crosshair: { mode: 1 },
+        });
+
+        if (series.length === 1) {
+            var solo = chart.addSeries(LightweightCharts.LineSeries, {
+                color: NEUTRAL, lineWidth: 2, priceFormat: priceFormat, pointMarkersVisible: true,
+            });
+            solo.setData(series);
+        } else {
+            for (var i = 1; i < series.length; i++) {
+                var prev = series[i - 1].value, curr = series[i].value;
+                var color = curr > prev ? GREEN : (curr < prev ? RED : NEUTRAL);
+                var seg = chart.addSeries(LightweightCharts.LineSeries, {
+                    color: color, lineWidth: 2, priceFormat: priceFormat,
+                });
+                seg.setData([series[i - 1], series[i]]);
+            }
+        }
+        chart.timeScale().fitContent();
+
+        // Year-by-year values strip below the chart — matches the slide-in's
+        // fin-chart-points list so the page reads consistently.
+        var pointsEl = document.getElementById('fin-graph-points');
+        if (pointsEl) {
+            pointsEl.innerHTML = series.map(function (p, i) {
+                var year = p.time.substring(0, 4);
+                var val = fmtAxisValue(p.value);
+                var dirClass = '';
+                if (i > 0) {
+                    var prevVal = series[i - 1].value;
+                    if (p.value > prevVal) dirClass = ' price-up';
+                    else if (p.value < prevVal) dirClass = ' price-down';
+                }
+                return '<div class="fin-chart-point"><span class="fin-chart-year">' + year + '</span>'
+                    + '<span class="fin-chart-val' + dirClass + '">' + val + '</span></div>';
+            }).join('');
+        }
+    }
+
+    waitForLib(function () {
+        fetchSeries().then(render).catch(function () {
+            host.innerHTML = '<p class="empty-state">Series unavailable.</p>';
+        });
+    });
+})();

--- a/internal/server/static/ideas.js
+++ b/internal/server/static/ideas.js
@@ -239,7 +239,7 @@
         if (chart) return chart;
         if (!window.LightweightCharts || !hostEl) return null;
         chart = LightweightCharts.createChart(hostEl, {
-            layout: { background: { color: '#0a0a0a' }, textColor: '#888888', fontFamily: "'SF Mono','Consolas',monospace", fontSize: 11 },
+            layout: { background: { color: '#0a0a0a' }, textColor: '#888888', fontFamily: "'SF Mono','Consolas',monospace", fontSize: 11, attributionLogo: false },
             grid: { vertLines: { color: '#1a1a1a' }, horzLines: { color: '#1a1a1a' } },
             crosshair: { mode: LightweightCharts.CrosshairMode.Magnet, vertLine: { color: '#555', style: 2 }, horzLine: { color: '#555', style: 2 } },
             rightPriceScale: { borderColor: '#2a2a2a' },
@@ -384,6 +384,15 @@
         if (!raw) {
             if (!fallbackSymbol) return null;
             return { kind: 'price', identifier: fallbackSymbol, label: fallbackSymbol };
+        }
+        // Economic-catalog lookup runs FIRST — codes like "US.UNRATE" contain
+        // a dot and would otherwise be misread as SYMBOL.field. Bare "UNRATE"
+        // also resolves (v1 has one country). Server emits canonical "US.UNRATE".
+        var econCat = window._econCatalog || {};
+        var econHit = econCat[raw.toUpperCase()];
+        if (econHit) {
+            var ecoId = (econHit.identifier || (econHit.country + '.' + econHit.code)).toUpperCase();
+            return { kind: 'economic', identifier: ecoId, label: econHit.name || ecoId };
         }
         // Tickers can contain periods (BRK.A, BRK.B, GOOG.L), so split on the
         // *rightmost* dot — everything after is the FMP field name (camelCase,

--- a/internal/server/static/indices.js
+++ b/internal/server/static/indices.js
@@ -148,7 +148,7 @@
                         var color = last >= first ? '#00cc66' : '#ff4444';
                         var chart = LightweightCharts.createChart(el, {
                             width: 80, height: 24,
-                            layout: { background: { color: 'transparent' }, textColor: 'transparent' },
+                            layout: { background: { color: 'transparent' }, textColor: 'transparent', attributionLogo: false },
                             grid: { vertLines: { visible: false }, horzLines: { visible: false } },
                             rightPriceScale: { visible: false }, timeScale: { visible: false },
                             handleScroll: false, handleScale: false,

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -497,7 +497,7 @@
         if (!window.LightweightCharts || !host) return;
 
         finChart = LightweightCharts.createChart(host, {
-            layout: { background: { color: '#0a0a0a' }, textColor: '#888888', fontFamily: "'SF Mono','Consolas',monospace", fontSize: 10 },
+            layout: { background: { color: '#0a0a0a' }, textColor: '#888888', fontFamily: "'SF Mono','Consolas',monospace", fontSize: 10, attributionLogo: false },
             grid: { vertLines: { color: '#1a1a1a' }, horzLines: { color: '#1a1a1a' } },
             rightPriceScale: { borderColor: '#2a2a2a' },
             timeScale: { borderColor: '#2a2a2a', timeVisible: false, fixLeftEdge: true, fixRightEdge: true },
@@ -900,7 +900,7 @@
                         var color = last >= first ? '#00cc66' : '#ff4444';
                         var chart = LightweightCharts.createChart(el, {
                             width: 80, height: 24,
-                            layout: { background: { color: 'transparent' }, textColor: 'transparent' },
+                            layout: { background: { color: 'transparent' }, textColor: 'transparent', attributionLogo: false },
                             grid: { vertLines: { visible: false }, horzLines: { visible: false } },
                             rightPriceScale: { visible: false }, timeScale: { visible: false },
                             handleScroll: false, handleScale: false,
@@ -934,7 +934,7 @@
 
         sectorPerfChart = LightweightCharts.createChart(chartEl, {
             width: chartEl.clientWidth, height: 200,
-            layout: { background: { color: '#0a0a0a' }, textColor: '#888', fontFamily: "'SF Mono',monospace", fontSize: 10 },
+            layout: { background: { color: '#0a0a0a' }, textColor: '#888', fontFamily: "'SF Mono',monospace", fontSize: 10, attributionLogo: false },
             grid: { vertLines: { color: '#1a1a1a' }, horzLines: { color: '#1a1a1a' } },
             rightPriceScale: { borderColor: '#2a2a2a' },
             timeScale: { borderColor: '#2a2a2a', timeVisible: false },

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -2963,3 +2963,271 @@ a, [tabindex] {
     box-shadow: 0 0 0 1px var(--orange);
     background: var(--bg-tertiary);
 }
+
+/* ── /economics — calendar + catalog ── */
+
+.economics-layout {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+}
+
+.economics-header {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+}
+
+.economics-tabs {
+    display: flex;
+    gap: 4px;
+}
+
+.economics-tab {
+    background: transparent;
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+    padding: 4px 12px;
+    font-family: inherit;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.economics-tab:hover { color: var(--text-primary); }
+
+.economics-tab.active {
+    color: var(--orange);
+    border-color: var(--orange);
+}
+
+.economics-hint {
+    color: var(--text-muted);
+    font-size: 11px;
+    margin-left: auto;
+}
+
+.economics-panel {
+    flex: 1;
+    overflow: auto;
+    padding: 8px 12px;
+}
+
+.economics-panel.hidden { display: none; }
+
+.economics-filter-bar {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    padding: 8px 0;
+    position: sticky;
+    top: 0;
+    background: var(--bg-primary);
+    z-index: 2;
+}
+
+.economics-filter {
+    flex: 1;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    padding: 4px 8px;
+    font-family: inherit;
+    font-size: 12px;
+}
+
+.economics-filter:focus { outline: none; border-color: var(--blue); }
+
+.economics-filter-badges { display: flex; gap: 4px; }
+
+.economics-badge {
+    background: transparent;
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+    padding: 2px 8px;
+    font-family: inherit;
+    font-size: 11px;
+    cursor: pointer;
+}
+
+.economics-badge.active {
+    color: var(--orange);
+    border-color: var(--orange);
+}
+
+.economics-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+}
+
+.economics-table th {
+    text-align: left;
+    color: var(--text-secondary);
+    font-weight: normal;
+    border-bottom: 1px solid var(--border);
+    padding: 6px 8px;
+    position: sticky;
+    top: 36px;            /* sits below the filter bar */
+    background: var(--bg-primary);
+    z-index: 1;
+}
+
+.economics-table td {
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--bg-tertiary);
+}
+
+.economics-table td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.economics-table th.num { text-align: right; }
+
+.economics-row { cursor: pointer; }
+.economics-row:hover { background: var(--bg-tertiary); }
+.economics-row.vim-selected {
+    background: var(--bg-tertiary);
+    box-shadow: inset 2px 0 0 var(--blue);
+}
+
+.economics-cat-row td {
+    color: var(--orange);
+    background: var(--bg-secondary);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 4px 8px;
+}
+
+.economics-code { color: var(--blue); font-weight: 500; }
+.economics-date { color: var(--text-secondary); }
+.economics-country { color: var(--yellow); }
+
+.economics-impact { font-size: 11px; }
+.economics-impact.impact-high   { color: var(--red); }
+.economics-impact.impact-medium { color: var(--orange); }
+.economics-impact.impact-low    { color: var(--text-muted); }
+
+.economics-table td.pos { color: var(--green); }
+.economics-table td.neg { color: var(--red); }
+
+/* Catalog drill-down */
+.economics-cb-list.hidden,
+.economics-cb-detail.hidden { display: none; }
+
+.economics-cb-breadcrumb {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 6px 0 8px;
+    border-bottom: 1px solid var(--bg-tertiary);
+    margin-bottom: 4px;
+}
+
+.economics-back {
+    background: transparent;
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+    padding: 2px 8px;
+    font-family: inherit;
+    font-size: 11px;
+    cursor: pointer;
+}
+
+.economics-back:hover {
+    color: var(--orange);
+    border-color: var(--orange);
+}
+
+.economics-cb-title {
+    color: var(--orange);
+    font-size: 12px;
+}
+
+/* CB tile grid — drill-down level 1 */
+.economics-cb-tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 12px;
+    padding: 12px 0;
+}
+
+.economics-cb-tile {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    padding: 12px 14px;
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+}
+
+.economics-cb-tile:hover,
+.economics-cb-tile.vim-selected {
+    border-color: var(--blue);
+    background: var(--bg-tertiary);
+}
+
+.cb-tile-country {
+    color: var(--yellow);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.cb-tile-name {
+    color: var(--text-primary);
+    font-size: 14px;
+}
+
+.cb-tile-count {
+    color: var(--text-muted);
+    font-size: 11px;
+}
+
+/* Preview slide-in meta strip below the chart inside #article-reader */
+.eco-chart-meta {
+    display: flex;
+    gap: 16px;
+    padding: 6px 0 4px;
+    color: var(--text-muted);
+    font-size: 11px;
+}
+
+/* Full-size economic graph page (/graph/US.UNRATE etc.) */
+.eco-graph-header {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--border);
+}
+
+.eco-graph-subtitle {
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: normal;
+    margin-left: 8px;
+}
+
+.eco-graph-range {
+    display: flex;
+    gap: 4px;
+}
+
+.eco-graph-meta {
+    display: flex;
+    gap: 12px;
+    margin-left: auto;
+    color: var(--text-muted);
+    font-size: 11px;
+}
+
+.eco-graph-host {
+    height: calc(100vh - 140px);
+    width: 100%;
+}

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -23,6 +23,27 @@ window.onerror = function (msg, src, line, col, err) {
     var newsCurrentTopic = '';
     var newsSeenURLs = new Set();
     var newsReadURLs = new Set();
+    // Economic catalog — keyed by full identifier ("US.UNRATE") AND by bare
+    // code ("UNRATE") for v1 ergonomics where typing `:add unrate` should
+    // still resolve. Populated by loadFredCodes on boot.
+    var econCatalog = {};
+    function loadFredCodes() {
+        fetch('/api/economics/catalog').then(function (r) { return r.json(); })
+            .then(function (rows) {
+                if (!Array.isArray(rows)) return;
+                rows.forEach(function (r) {
+                    var id = (r.identifier || (r.country + '.' + r.code)).toUpperCase();
+                    econCatalog[id] = r;
+                    // Bare-code alias — only one country in v1 so unambiguous.
+                    if (r.code) econCatalog[r.code.toUpperCase()] = r;
+                });
+                window._econCatalog = econCatalog;
+            })
+            .catch(function () { /* economics page is optional */ });
+    }
+    function lookupEcon(s) {
+        return econCatalog[String(s).toUpperCase()];
+    }
 
     // ── Commands ──
 
@@ -33,6 +54,7 @@ window.onerror = function (msg, src, line, col, err) {
         news:       { path: '/news',            needsSecurity: false, usage: 'news [SECURITY]',     desc: 'market news — optionally filter by security', optionalSecurity: true },
         ei:         { path: '/indices',          needsSecurity: false, usage: 'ei',                  desc: 'equity indices — global market overview' },
         ideas:      { path: '/ideas',           needsSecurity: false, usage: 'ideas',               desc: 'sketchpad — comparative graphs across metrics' },
+        economics:  { path: '/economics',       needsSecurity: false, usage: 'economics',           desc: 'economic calendar + indicator catalog (FRED + FMP)', aliases: ['eco', 'econ'] },
         screener:   { path: '/screener',        needsSecurity: false, usage: 'screener',            desc: 'filter and scan stocks by criteria' },
         debug:      { path: '/debug',           needsSecurity: false, usage: 'debug',               desc: 'live server log console' },
         analyze:    { path: '/security/{symbol}#ai', needsSecurity: true, usage: 'analyze <SECURITY>',  desc: 'run deep multi-agent trading analysis', aliases: ['az'] },
@@ -79,7 +101,10 @@ window.onerror = function (msg, src, line, col, err) {
         if (cmd.needsSecurity) {
             resolved = resolved.toUpperCase();
             path = path.replace('{symbol}', resolved);
-            setSecurity(resolved);
+            // skipSecurity is set when the "symbol" isn't a real ticker —
+            // e.g. an economic identifier like US.UNRATE that shouldn't end
+            // up in the security selector or WS subscriptions.
+            if (!opts.skipSecurity) setSecurity(resolved);
         }
         // Caller-supplied explicit path wins over the COMMANDS template. Used
         // by executeIdeasAdd to land on /ideas/{lastId} instead of the default.
@@ -166,6 +191,7 @@ window.onerror = function (msg, src, line, col, err) {
         if (view === 'news') initNews();
         if (view === 'graph') initGraph();
         if (view === 'debug') initDebug();
+        if (view === 'economics' && window._economicsInit) window._economicsInit();
     }
 
     function initGraph() {
@@ -1278,6 +1304,14 @@ window.onerror = function (msg, src, line, col, err) {
             if (!fallbackSymbol) return null;
             return { kind: 'price', identifier: fallbackSymbol, label: fallbackSymbol };
         }
+        // Economic-catalog lookup runs FIRST — "US.UNRATE" contains a dot and
+        // would otherwise be misread as SYMBOL.field. Bare "UNRATE" also
+        // resolves (v1 has one country). Canonical form is "US.UNRATE".
+        var econHit = lookupEcon(raw);
+        if (econHit) {
+            var ecoId = (econHit.identifier || (econHit.country + '.' + econHit.code)).toUpperCase();
+            return { kind: 'economic', identifier: ecoId, label: econHit.name || ecoId };
+        }
         var dot = raw.lastIndexOf('.');
         if (dot > 0 && dot < raw.length - 1) {
             var sym = raw.substring(0, dot).toUpperCase();
@@ -1793,6 +1827,11 @@ window.onerror = function (msg, src, line, col, err) {
                 if (window._ideasToggleHelp) window._ideasToggleHelp();
             },
         },
+        economics: {
+            move: function (dir) { if (window._economicsMove) window._economicsMove(dir); },
+            activate: function () { if (window._economicsActivate) window._economicsActivate(); },
+            focusFilter: function () { if (window._economicsFocusFilter) window._economicsFocusFilter(); },
+        },
         watchlist: {
             getItems: function () {
                 // Only visible rows (filtered by active watchlist)
@@ -2276,12 +2315,15 @@ window.onerror = function (msg, src, line, col, err) {
                 }
                 enterNormalMode();
             } else {
-                // Normal mode: close reader first, then focus command bar
+                // Normal mode: close reader first, then focus command bar.
+                // Dispatch the right close function by the reader's mode so
+                // chart instances get disposed properly (memory leak otherwise).
                 var reader = document.getElementById('article-reader');
                 if (reader && !reader.classList.contains('hidden')) {
-                    // Dispose the financials chart instance if we're closing that mode
-                    if (window._finCloseChart) window._finCloseChart();
-                    reader.classList.add('hidden');
+                    var mode = reader.dataset.mode;
+                    if (mode === 'fin-chart' && window._finCloseChart) window._finCloseChart();
+                    else if (mode === 'eco-chart' && window._economicsClosePreview) window._economicsClosePreview();
+                    else reader.classList.add('hidden');
                     return;
                 }
                 document.getElementById('cmd-input').focus();
@@ -2298,8 +2340,13 @@ window.onerror = function (msg, src, line, col, err) {
 
         switch (e.key) {
             case '/':
-                e.preventDefault();
-                document.getElementById('cmd-input').focus();
+                // Per-vim convention `/` is a *filter*, not the command bar
+                // (use `:` for that). Only views that expose a filter input
+                // claim it; other views drop the key.
+                if (handler && handler.focusFilter) {
+                    e.preventDefault();
+                    handler.focusFilter();
+                }
                 return;
             case 's':
                 e.preventDefault();
@@ -2343,6 +2390,32 @@ window.onerror = function (msg, src, line, col, err) {
                 if (handler && handler.activate) handler.activate();
                 return;
             case 'g':
+                // /economics catalog: navigate to the full graph for the
+                // selected indicator.
+                if (currentView === 'economics' && window._economicsSelectedIdentifier) {
+                    var id = window._economicsSelectedIdentifier();
+                    if (id) {
+                        e.preventDefault();
+                        navigate('graph', id, { skipSecurity: true });
+                        return;
+                    }
+                }
+                // Financials tab: navigate to /graph/SYMBOL.field for the
+                // selected row. Skip calc rows (margins) — they aren't a raw
+                // field the historical endpoint can fetch.
+                if (handler && handler.isFinTab && handler.isFinTab()) {
+                    var rows = window._finGetRows ? window._finGetRows() : [];
+                    var idx = window._finGetSelectedRow ? window._finGetSelectedRow() : -1;
+                    if (idx >= 0 && idx < rows.length && selectedSecurity) {
+                        var row = rows[idx];
+                        var key = row.dataset.finKey || '';
+                        if (row.dataset.finFormat !== 'calc' && key && key.indexOf('/') < 0) {
+                            e.preventDefault();
+                            navigate('graph', selectedSecurity + '.' + key, { skipSecurity: true });
+                            return;
+                        }
+                    }
+                }
                 e.preventDefault();
                 if (handler && handler.sectorNav) handler.sectorNav('graph');
                 else if (handler && handler.graph) handler.graph();
@@ -2387,6 +2460,10 @@ window.onerror = function (msg, src, line, col, err) {
                 }
                 return;
             case 'p':
+                // /economics catalog: open 5-year slide-in chart preview.
+                if (currentView === 'economics' && window._economicsOpenPreview) {
+                    if (window._economicsOpenPreview('5y')) { e.preventDefault(); return; }
+                }
                 // Financials chart slide-in: toggle on the selected row.
                 if (handler && handler.isFinTab && handler.isFinTab()) {
                     e.preventDefault();
@@ -2428,7 +2505,6 @@ window.onerror = function (msg, src, line, col, err) {
                     if (idx >= 0 && idx < rows.length) {
                         var row = rows[idx];
                         var key = row.dataset.finKey || '';
-                        // Skip calculated rows (margins) — they're not raw fields the sketch can fetch.
                         if (row.dataset.finFormat === 'calc' || !key || key.indexOf('/') >= 0) return;
                         if (!selectedSecurity) return;
                         e.preventDefault();
@@ -2436,6 +2512,19 @@ window.onerror = function (msg, src, line, col, err) {
                         cmdInput.value = ':add ' + selectedSecurity + '.' + key;
                         cmdInput.focus();
                         cmdInput.setSelectionRange(cmdInput.value.length, cmdInput.value.length);
+                    }
+                }
+                // 'a' on /economics catalog row prefills :add COUNTRY.CODE so
+                // the user can stack multiple :add commands without leaving
+                // the catalog — same UX as financials.
+                if (currentView === 'economics' && window._economicsAddCmd) {
+                    var prefilled = window._economicsAddCmd();
+                    if (prefilled) {
+                        e.preventDefault();
+                        var ci = document.getElementById('cmd-input');
+                        ci.value = prefilled;
+                        ci.focus();
+                        ci.setSelectionRange(ci.value.length, ci.value.length);
                     }
                 }
                 return;
@@ -2932,7 +3021,7 @@ window.onerror = function (msg, src, line, col, err) {
 
                     var chart = LightweightCharts.createChart(spark, {
                         width: 160, height: 40,
-                        layout: { background: { color: 'transparent' }, textColor: 'transparent' },
+                        layout: { background: { color: 'transparent' }, textColor: 'transparent', attributionLogo: false },
                         grid: { vertLines: { visible: false }, horzLines: { visible: false } },
                         rightPriceScale: { visible: false },
                         timeScale: { visible: false },
@@ -2962,6 +3051,7 @@ window.onerror = function (msg, src, line, col, err) {
         initCommandBar();
         initSecuritySelector();
         loadWatchlists(); // load persisted watchlists early
+        loadFredCodes();  // for :add UNRATE autocomplete + parser fast-path
         connectWS();
         onViewEnter(currentView);
         updateClock();

--- a/internal/server/templates/economic-graph.html
+++ b/internal/server/templates/economic-graph.html
@@ -1,0 +1,18 @@
+{{template "layout" .}}
+{{define "content"}}
+<div class="page-header eco-graph-header">
+    <h2 class="view-title">{{.Symbol}} <span class="eco-graph-subtitle">{{.Name}}</span></h2>
+    <div class="eco-graph-range" id="eco-graph-range">
+        <button class="chart-range-btn" data-range="1Y">1Y</button>
+        <button class="chart-range-btn" data-range="5Y" data-default>5Y</button>
+        <button class="chart-range-btn" data-range="10Y">10Y</button>
+        <button class="chart-range-btn" data-range="MAX">MAX</button>
+    </div>
+    <span class="eco-graph-meta">
+        <span>units: {{.Units}}</span>
+        <span>freq: {{.Frequency}}</span>
+    </span>
+</div>
+<div id="eco-graph-host" class="eco-graph-host" data-identifier="{{.Symbol}}"></div>
+<script src="/static/economic-graph.js?v={{.AssetVersion}}"></script>
+{{end}}

--- a/internal/server/templates/economics.html
+++ b/internal/server/templates/economics.html
@@ -1,0 +1,69 @@
+{{template "layout" .}}
+{{define "content"}}
+<div class="economics-layout" data-view="economics">
+    <header class="page-header economics-header">
+        <h2 class="view-title">Economics</h2>
+        <nav class="economics-tabs" id="economics-tabs">
+            <button class="economics-tab active" data-tab="calendar">1 Calendar</button>
+            <button class="economics-tab" data-tab="catalog">2 Catalog</button>
+        </nav>
+        <span class="economics-hint" id="economics-hint">
+            <kbd>h</kbd>/<kbd>l</kbd> tabs · <kbd>j</kbd>/<kbd>k</kbd> rows · <kbd>/</kbd> filter
+        </span>
+    </header>
+
+    <section class="economics-panel" id="economics-calendar-panel">
+        <div class="economics-filter-bar">
+            <input id="economics-calendar-filter" class="economics-filter" type="text"
+                   placeholder=":high :us cpi   ← directives (:high :medium :low :all, :US :UK :EU …) + free text"
+                   spellcheck="false" autocomplete="off">
+            <div class="economics-filter-badges" id="economics-impact-badges">
+                <button class="economics-badge active" data-impact="all">All</button>
+                <button class="economics-badge" data-impact="High">High</button>
+                <button class="economics-badge" data-impact="Medium">Medium</button>
+                <button class="economics-badge" data-impact="Low">Low</button>
+            </div>
+        </div>
+        <table class="economics-table economics-calendar-table">
+            <thead>
+                <tr>
+                    <th>Date</th>
+                    <th>Country</th>
+                    <th>Event</th>
+                    <th>Impact</th>
+                    <th class="num">Prior</th>
+                    <th class="num">Survey</th>
+                    <th class="num">Actual</th>
+                    <th class="num">Surprise</th>
+                </tr>
+            </thead>
+            <tbody id="economics-calendar-body">
+                <tr><td colspan="8" class="empty-state">Loading calendar…</td></tr>
+            </tbody>
+        </table>
+    </section>
+
+    <section class="economics-panel hidden" id="economics-catalog-panel">
+        <!-- Level 1: central bank list. The future-proofing scaffold — v1 has one row. -->
+        <div class="economics-cb-list" id="economics-cb-list">
+            <p class="empty-state">Loading central banks…</p>
+        </div>
+
+        <!-- Level 2: indicator list for the selected central bank. -->
+        <div class="economics-cb-detail hidden" id="economics-cb-detail">
+            <div class="economics-cb-breadcrumb">
+                <button class="economics-back" id="economics-cb-back">← Central Banks</button>
+                <span class="economics-cb-title" id="economics-cb-title"></span>
+            </div>
+            <div class="economics-filter-bar">
+                <input id="economics-catalog-filter" class="economics-filter" type="text"
+                       placeholder="filter: code name category…" spellcheck="false" autocomplete="off">
+            </div>
+            <div class="economics-catalog-host" id="economics-catalog-host">
+                <p class="empty-state">Loading catalog…</p>
+            </div>
+        </div>
+    </section>
+</div>
+<script src="/static/economics.js?v={{.AssetVersion}}"></script>
+{{end}}

--- a/internal/server/templates/financial-graph.html
+++ b/internal/server/templates/financial-graph.html
@@ -1,0 +1,13 @@
+{{template "layout" .}}
+{{define "content"}}
+<div class="page-header eco-graph-header">
+    <h2 class="view-title">{{.Ticker}}<span class="eco-graph-subtitle">{{.Field}}</span></h2>
+    <span class="eco-graph-meta">
+        <span>annual</span>
+        <span>5y</span>
+    </span>
+</div>
+<div id="fin-graph-host" class="eco-graph-host" data-ticker="{{.Ticker}}" data-field="{{.Field}}"></div>
+<div class="fin-chart-points" id="fin-graph-points"></div>
+<script src="/static/financial-graph.js?v={{.AssetVersion}}"></script>
+{{end}}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -187,14 +187,25 @@ func (s *Store) migrate() error {
 		CREATE TABLE IF NOT EXISTS sketch_metrics (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			sketch_id INTEGER NOT NULL,
-			kind TEXT NOT NULL,        -- 'price' | 'financial' | 'commodity' | 'forex' | 'crypto' | 'index'
-			identifier TEXT NOT NULL,  -- 'AAPL' | 'AAPL.revenue' | 'GCUSD' | 'EURUSD' | 'BTCUSD' | 'SPX'
+			kind TEXT NOT NULL,        -- 'price' | 'financial' | 'commodity' | 'forex' | 'crypto' | 'index' | 'economic'
+			identifier TEXT NOT NULL,  -- 'AAPL' | 'AAPL.revenue' | 'GCUSD' | 'EURUSD' | 'BTCUSD' | 'SPX' | 'UNRATE'
 			label TEXT NOT NULL DEFAULT '',
 			color TEXT NOT NULL DEFAULT '',
 			position INTEGER NOT NULL DEFAULT 0,
 			FOREIGN KEY (sketch_id) REFERENCES sketches(id) ON DELETE CASCADE
 		);
 		CREATE INDEX IF NOT EXISTS idx_sketch_metrics_sketch ON sketch_metrics(sketch_id);
+
+		CREATE TABLE IF NOT EXISTS economic_series (
+			code TEXT PRIMARY KEY,        -- FRED series ID (e.g. UNRATE)
+			title TEXT NOT NULL DEFAULT '',
+			category TEXT NOT NULL DEFAULT '',
+			frequency TEXT NOT NULL DEFAULT '', -- D / W / M / Q / A — from FRED
+			units TEXT NOT NULL DEFAULT '',
+			observations TEXT NOT NULL DEFAULT '[]', -- JSON [{date, value}, ...] in ascending date order
+			source_updated_at TEXT NOT NULL DEFAULT '', -- FRED's last_updated (string, parse on display)
+			fetched_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
 	`)
 	if err != nil {
 		return err
@@ -967,4 +978,83 @@ func (s *Store) AddSketchMetric(m SketchMetric) (int64, error) {
 func (s *Store) RemoveSketchMetric(id int64) error {
 	_, err := s.db.Exec(`DELETE FROM sketch_metrics WHERE id = ?`, id)
 	return err
+}
+
+// EconomicObservation is one (date, value) point on an economic series.
+// Mirrors fred.Observation so the store package stays independent of the
+// FRED client.
+type EconomicObservation struct {
+	Date  string  `json:"date"`
+	Value float64 `json:"value"`
+}
+
+// EconomicSeries is the persisted row for one indicator.
+type EconomicSeries struct {
+	Code            string                `json:"code"`
+	Title           string                `json:"title"`
+	Category        string                `json:"category"`
+	Frequency       string                `json:"frequency"`
+	Units           string                `json:"units"`
+	Observations    []EconomicObservation `json:"observations"`
+	SourceUpdatedAt string                `json:"sourceUpdatedAt"`
+	FetchedAt       time.Time             `json:"fetchedAt"`
+}
+
+// PutEconomicSeries upserts a series row. Observations are stored as JSON in
+// ascending date order so the chart layer can stream straight through.
+func (s *Store) PutEconomicSeries(es *EconomicSeries) error {
+	obs, err := json.Marshal(es.Observations)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(`
+		INSERT INTO economic_series
+			(code, title, category, frequency, units, observations, source_updated_at, fetched_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(code) DO UPDATE SET
+			title             = excluded.title,
+			category          = excluded.category,
+			frequency         = excluded.frequency,
+			units             = excluded.units,
+			observations      = excluded.observations,
+			source_updated_at = excluded.source_updated_at,
+			fetched_at        = CURRENT_TIMESTAMP
+	`, es.Code, es.Title, es.Category, es.Frequency, es.Units, string(obs), es.SourceUpdatedAt)
+	return err
+}
+
+// GetEconomicSeries returns a series by code, or nil if not cached.
+func (s *Store) GetEconomicSeries(code string) (*EconomicSeries, error) {
+	row := s.db.QueryRow(`
+		SELECT code, title, category, frequency, units, observations, source_updated_at, fetched_at
+		FROM economic_series WHERE code = ?
+	`, code)
+	var es EconomicSeries
+	var obsJSON, fetchedAt string
+	err := row.Scan(&es.Code, &es.Title, &es.Category, &es.Frequency, &es.Units, &obsJSON, &es.SourceUpdatedAt, &fetchedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal([]byte(obsJSON), &es.Observations); err != nil {
+		return nil, err
+	}
+	es.FetchedAt, _ = time.Parse("2006-01-02 15:04:05Z", fetchedAt+"Z")
+	return &es, nil
+}
+
+// IsEconomicFresh returns true if the cached series is younger than ttl.
+func (s *Store) IsEconomicFresh(code string, ttl time.Duration) bool {
+	var fetchedAt string
+	err := s.db.QueryRow(`SELECT fetched_at FROM economic_series WHERE code = ?`, code).Scan(&fetchedAt)
+	if err != nil {
+		return false
+	}
+	t, err := time.Parse("2006-01-02 15:04:05Z", fetchedAt+"Z")
+	if err != nil {
+		return false
+	}
+	return time.Since(t) < ttl
 }

--- a/tests/e2e/smoke_test.go
+++ b/tests/e2e/smoke_test.go
@@ -84,7 +84,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// Server
-	srv, err := server.New(server.Config{Port: 0}, h, debug, poll, newsClient, nil, nil, st, logger)
+	srv, err := server.New(server.Config{Port: 0}, h, debug, poll, newsClient, nil, nil, nil, st, logger)
 	if err != nil {
 		panic("failed to create server: " + err.Error())
 	}


### PR DESCRIPTION
## Summary
New `/economics` page modelled on Bloomberg's ECO / ECST / ECWB triad, with sketchpad integration for charting macro indicators alongside prices and financial fields. v1 covers US data via FRED direct; v2 (DBnomics for ECB / BoE / Bundesbank / OECD / IMF) is captured as a follow-up in `ideas.md` item 16.

### Page
- **Calendar tab** — FMP economic-calendar releases (Date · Country · Event · Impact · Prior · Survey · Actual · Surprise). Filter input parses `:high :us cpi`-style directives (impact, country) plus free-text event match.
- **Catalog tab** — drill-down: central-bank tile list first (Federal Reserve · United States today), Enter or click into a CB shows its 33 curated indicators grouped by category (Rates · Inflation · Growth · Labor · Housing · Consumer · Trade) with latest value and as-of date.

### Backend
- New `internal/fred/` package — client (`GetSeries` returning meta + observations), catalog of 33 indicators, frequency-aware TTL map (D 6h · W 24h · M 72h · Q 7d · A 30d), background prefetcher that primes at boot and refreshes stale entries every 30 minutes. Disabled gracefully when `FRED_API_KEY` is unset.
- `economic_series` SQLite table keyed by the full identifier (`US.UNRATE`) so v2 can add `EZ.HICP` / `UK.CPI` without collision.
- `news.GetEconomicCalendar` wraps FMP `/stable/economic-calendar`.

### Vim navigation
- `h`/`l` switch tabs; at the indicator level `h` returns to the CB list.
- `j`/`k` row cursor; `Enter` descends into a CB at the CB-list level (reserved at indicator level for future).
- `/` focuses the visible tab's filter input — this is now a **per-view binding** so `/` is no longer the global command-bar shortcut. Use `:` for the command bar everywhere.
- Filter input `Enter` blurs and returns to normal mode.
- `a` on a catalog indicator prefills `:add US.CODE` in the cmd bar and keeps focus on `/economics` (mirrors financials' `a`).
- `p` toggles the slide-in 5-year preview chart in the article-reader pane (same pane financials uses); `Escape` dispatches close by `reader.dataset.mode` so chart instances are properly disposed.
- `g` navigates to `/graph/US.CODE` — new economic-graph template/JS pair with 1Y/5Y/10Y/MAX range buttons and a full-viewport line series.

### Sketchpad integration
- New `economic` metric kind on `sketch_metrics`. `handleHistorical` routes `kind=economic` to the FRED-backed handler.
- Both `:add` parsers (terminal.js + ideas.js) check the economic catalog **before** the dot heuristic so `:add US.UNRATE` resolves to `kind:'economic'` (was misclassifying as `financial`).

### Full-size graph generalisation
- `handleStock` disambiguates by suffix: catalog hit → economic-graph; lowercase-leading camelCase (`revenue`, `netIncome`) → financial-graph; uppercase suffix (`BRK.A`, `GOOG.L`) → stock OHLC.
- New `financial-graph.html`/`.js` renders the same YoY colour-segmented line as the slide-in but full-viewport, with a year-by-year values strip below. `g` on a selected financial-tab row navigates there.
- `navigate()` gained a `skipSecurity` opt so the new graph URLs don't pollute the security selector or WS subscriptions.

### Other
- `attributionLogo: false` on **all eight** `LightweightCharts.createChart` sites (per user pref — saved to memory).
- `econ` alias for `economics`.
- `ideas.md` updated: item 15 rewritten for v1 scope, new items 16 (DBnomics v2), 17 (migrate backlog to GitHub Issues), 18 (vim `d` to delete a sketch from the sidebar).

## Test plan
- [x] `make test` green
- [x] `make smoke` green
- [x] `/economics` Calendar shows upcoming + recent FMP releases; `:high :us cpi` narrows to high-impact US CPI events
- [x] Catalog drill-down: click the Fed tile → indicator list grouped by category; `←` or `h` returns
- [x] `a` on a catalog indicator prefills `:add US.UNRATE` in cmd bar without leaving the page
- [x] `p` opens 5-year preview slide-in; `p` again closes it; `Escape` also closes
- [x] `g` navigates to `/graph/US.UNRATE` — full-viewport line chart with range buttons
- [ ] `g` on a financials row (e.g. AAPL revenue) navigates to `/graph/AAPL.revenue`
- [x] `:add US.UNRATE` from `/ideas` plots the line correctly (was the regression caught at the end of the session)
- [x] No TradingView watermark on any chart anywhere
- [x] Per-view `/` filter: works on `/economics`, no-op on other views; `:` still focuses the cmd bar everywhere