### PR TITLE
fix(watchlist): autocomplete-or-reject + poller nil guard + ghost rows

### DIFF
--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -119,6 +119,13 @@ func (p *Poller) fetchAndPublish(ctx context.Context, symbols []string) {
 	}
 
 	for _, q := range quotes {
+		// Providers may return a nil entry when a requested symbol can't be
+		// resolved (e.g. typo'd "MICROSOFT"). Don't trust the slice — skip
+		// nils and let the symbol stay unpolled rather than panic the
+		// whole goroutine.
+		if q == nil {
+			continue
+		}
 		html, err := p.renderQuoteRow(q)
 		if err != nil {
 			p.logger.Error("render failed", "symbol", q.Symbol, "error", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -660,18 +660,51 @@ func (s *Server) handleAddToWatchlist(w http.ResponseWriter, r *http.Request) {
 		Symbol string `json:"symbol"`
 	}
 	json.NewDecoder(r.Body).Decode(&req)
-	if req.Symbol == "" {
+	symbol := strings.ToUpper(strings.TrimSpace(req.Symbol))
+	if symbol == "" {
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(map[string]string{"error": "symbol required"})
 		return
 	}
-	err := s.store.AddToWatchlist(id, req.Symbol)
-	if err != nil {
+
+	// Validate the symbol against FMP search before persisting — the
+	// downstream quote poller has no way to recover from a non-resolvable
+	// symbol like "MICROSOFT", and the provider returning a nil quote used
+	// to crash the goroutine. Require an exact symbol-match in the search
+	// results; partial / name-only matches (which is what "Microsoft"
+	// returns: MSFT, not MICROSOFT) are rejected so the client must resolve
+	// via the autocomplete picker.
+	if s.news != nil {
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+		results, err := s.news.SearchSymbol(ctx, symbol, 10)
+		if err == nil {
+			matched := false
+			for _, hit := range results {
+				if strings.EqualFold(hit.Symbol, symbol) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				json.NewEncoder(w).Encode(map[string]string{
+					"error":  "unknown symbol — pick from the dropdown",
+					"symbol": symbol,
+				})
+				return
+			}
+		}
+		// Search errors fall through to the optimistic path — better to let
+		// a real symbol through than block the user when FMP is flaky.
+	}
+
+	if err := s.store.AddToWatchlist(id, symbol); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
-	json.NewEncoder(w).Encode(map[string]string{"status": "added", "symbol": req.Symbol})
+	json.NewEncoder(w).Encode(map[string]string{"status": "added", "symbol": symbol})
 }
 
 func (s *Server) handleRemoveFromWatchlist(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -631,6 +631,10 @@ body {
     text-decoration: underline;
 }
 
+.quote-row-ghost .sym-link { color: var(--text-secondary); }
+.quote-row-ghost .sym-link:hover { color: var(--text-primary); }
+.quote-na { color: var(--text-muted); font-style: italic; }
+
 .price-up { color: var(--green); }
 .price-down { color: var(--red); }
 .price-flat { color: var(--text-secondary); }
@@ -677,6 +681,17 @@ body {
 .add-security-form {
     display: flex;
     gap: 8px;
+    /* anchors the autocomplete dropdown — without this, the absolutely-
+       positioned .security-dropdown attaches to <body> and lands off-screen. */
+    position: relative;
+}
+
+/* Header's security selector anchors right (its input sits on the right);
+   the watchlist add-form sits on the left, so its dropdown should align
+   to the input's left edge for a natural visual line. */
+.add-security-form .security-dropdown {
+    left: 0;
+    right: auto;
 }
 
 .add-security-form input {

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -283,20 +283,7 @@ window.onerror = function (msg, src, line, col, err) {
 
     function initWatchlist() {
         const form = document.getElementById('add-security-form');
-        if (form) {
-            form.onsubmit = function (e) {
-                e.preventDefault();
-                const input = document.getElementById('wl-security-input');
-                const sec = input.value.trim().toUpperCase();
-                if (!sec) {
-                    input.value = '';
-                    return;
-                }
-                subscribeSecurity(sec);
-                addToWatchlist(getActiveWatchlistId(), sec);
-                input.value = '';
-            };
-        }
+        if (form) initWatchlistAddForm(form);
 
         // Re-render tabs (DOM is fresh on SPA navigation)
         renderWatchlistTabs();
@@ -305,7 +292,42 @@ window.onerror = function (msg, src, line, col, err) {
         fetchWatchlistQuotes();
     }
 
+    function ensureWatchlistRow(symbol) {
+        var tbody = document.getElementById('quote-body');
+        if (!tbody) return null;
+        var existing = document.getElementById('quote-' + symbol);
+        if (existing) return existing;
+        // Ghost row — emitted for symbols we have on disk but no quote data
+        // for (e.g. an FMP plan that doesn't cover this exchange). Keeps the
+        // row visible so the user can still `d` it from the watchlist.
+        var html = '<tr id="quote-' + escapeHtml(symbol) + '" class="quote-row-ghost">'
+            + '<td><span class="sym-link" data-symbol="' + escapeHtml(symbol) + '">' + escapeHtml(symbol) + '</span></td>'
+            + '<td class="quote-na">—</td>'
+            + '<td class="quote-na">—</td>'
+            + '<td class="quote-na">—</td>'
+            + '<td class="quote-na">no data</td>'
+            + '<td></td>'
+            + '</tr>';
+        tbody.insertAdjacentHTML('beforeend', html);
+        return document.getElementById('quote-' + symbol);
+    }
+
     function fetchWatchlistQuotes() {
+        // Seed ghost rows for every symbol in every watchlist before the
+        // quote response comes back. Real quotes replace these in-place;
+        // unreachable symbols simply stay as ghosts and remain deletable.
+        var tbody = document.getElementById('quote-body');
+        if (tbody) {
+            var seen = {};
+            (watchlistData || []).forEach(function (wl) {
+                (wl.symbols || []).forEach(function (sym) {
+                    if (!seen[sym]) { seen[sym] = true; ensureWatchlistRow(sym); }
+                });
+            });
+            var empty = document.getElementById('empty-state');
+            if (empty && Object.keys(seen).length > 0) empty.style.display = 'none';
+        }
+
         fetch('/api/watchlists/quotes')
             .then(function (r) { return r.json(); })
             .then(function (quotes) {
@@ -376,7 +398,7 @@ window.onerror = function (msg, src, line, col, err) {
     }
 
     function loadWatchlists() {
-        fetch('/api/watchlists')
+        return fetch('/api/watchlists')
             .then(function (r) { return r.json(); })
             .then(function (lists) {
                 watchlistData = lists || [];
@@ -483,13 +505,138 @@ window.onerror = function (msg, src, line, col, err) {
     }
 
     function addToWatchlist(watchlistId, symbol) {
-        fetch('/api/watchlists/' + (watchlistId || getActiveWatchlistId()) + '/symbols', {
+        return fetch('/api/watchlists/' + (watchlistId || getActiveWatchlistId()) + '/symbols', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ symbol: symbol }),
-        }).then(function () {
-            loadWatchlists(); // refresh
-        }).catch(function (err) { console.error('Watch error:', err); });
+        }).then(function (r) {
+            if (!r.ok) {
+                return r.json().then(function (body) {
+                    flashError(body.error || 'Could not add ' + symbol);
+                });
+            }
+            // Refresh tabs/picker first (so watchlistData is up to date),
+            // then re-render the quote table — without this second call the
+            // new symbol's row only appears on next page load.
+            return loadWatchlists().then(fetchWatchlistQuotes);
+        }).catch(function () { flashError('Add failed — server unreachable'); });
+    }
+
+    // initWatchlistAddForm wires the search-as-you-type dropdown on the
+    // /watchlist page's "Add security" input. Mirrors the global security
+    // selector pattern: typing shows matches, Enter / click commits, raw
+    // unresolved text is refused (server-side validation also enforces this).
+    function initWatchlistAddForm(form) {
+        var input = document.getElementById('wl-security-input');
+        var dropdown = document.getElementById('wl-security-dropdown');
+        if (!input || !dropdown) return;
+
+        var results = [];
+        var hoverIdx = -1;
+
+        function render() {
+            if (document.activeElement !== input || results.length === 0) {
+                dropdown.classList.add('hidden');
+                return;
+            }
+            dropdown.innerHTML = results.map(function (r, i) {
+                return '<div class="security-option' + (i === hoverIdx ? ' active' : '') + '"'
+                    + ' data-symbol="' + escapeHtml(r.symbol) + '">'
+                    + '<span class="sec-sym">' + escapeHtml(r.symbol) + '</span>'
+                    + '<span class="sec-name">' + escapeHtml(r.name || '') + '</span>'
+                    + '</div>';
+            }).join('');
+            dropdown.classList.remove('hidden');
+        }
+
+        function commit(symbol) {
+            if (!symbol) return;
+            subscribeSecurity(symbol);
+            addToWatchlist(getActiveWatchlistId(), symbol);
+            input.value = '';
+            results = [];
+            hoverIdx = -1;
+            dropdown.classList.add('hidden');
+        }
+
+        // Exchange preference — push primary US listings to the top so that
+        // Enter on "microsoft" doesn't accidentally pick a foreign listing
+        // the user's FMP plan can't quote (MSF.BR etc.). Order is intentional:
+        // NASDAQ + NYSE first, then BATS / AMEX / NMS, everything else last.
+        var EXCHANGE_RANK = { 'NASDAQ': 0, 'NYSE': 0, 'BATS': 1, 'AMEX': 1, 'NMS': 1, 'NCM': 1, 'NGM': 1 };
+        function rankResults(rows) {
+            return rows.slice().sort(function (a, b) {
+                var ra = EXCHANGE_RANK[a.exchange] != null ? EXCHANGE_RANK[a.exchange] : 9;
+                var rb = EXCHANGE_RANK[b.exchange] != null ? EXCHANGE_RANK[b.exchange] : 9;
+                return ra - rb;
+            });
+        }
+
+        input.addEventListener('input', function () {
+            var q = input.value.trim();
+            if (!q) { results = []; hoverIdx = -1; render(); return; }
+            searchSecurities(q, function (rows) {
+                results = rankResults(Array.isArray(rows) ? rows : []);
+                // No auto-highlight — accidental Enter on the input must NOT
+                // commit a result the user hasn't actively chosen. Arrow keys
+                // or click moves hoverIdx; raw Enter with no selection falls
+                // through to the exact-match check in onsubmit.
+                hoverIdx = -1;
+                render();
+            });
+        });
+
+        input.addEventListener('keydown', function (e) {
+            if (e.key === 'ArrowDown') {
+                if (results.length === 0) return;
+                e.preventDefault();
+                hoverIdx = Math.min(hoverIdx + 1, results.length - 1);
+                render();
+            } else if (e.key === 'ArrowUp') {
+                if (results.length === 0) return;
+                e.preventDefault();
+                hoverIdx = Math.max(hoverIdx - 1, 0);
+                render();
+            } else if (e.key === 'Escape') {
+                results = []; hoverIdx = -1; dropdown.classList.add('hidden');
+            }
+        });
+
+        // On submit (Enter or +), prefer the highlighted dropdown choice; if
+        // none, accept raw text only when it exactly matches one of the
+        // current results (covers typing "AAPL" and hitting Enter before
+        // moving the cursor onto a row). Anything else: refuse — the server
+        // would reject it anyway and the user should pick from the list.
+        form.onsubmit = function (e) {
+            e.preventDefault();
+            var picked = null;
+            if (hoverIdx >= 0 && hoverIdx < results.length) {
+                picked = results[hoverIdx].symbol;
+            } else {
+                var raw = input.value.trim().toUpperCase();
+                var exact = results.find(function (r) { return r.symbol.toUpperCase() === raw; });
+                if (exact) picked = exact.symbol;
+            }
+            if (!picked) {
+                flashError('Pick a match from the dropdown');
+                return;
+            }
+            commit(picked);
+        };
+
+        dropdown.addEventListener('mousedown', function (e) {
+            var opt = e.target.closest('.security-option');
+            if (opt && opt.dataset.symbol) {
+                e.preventDefault(); // keep input focused through the click
+                commit(opt.dataset.symbol);
+            }
+        });
+
+        input.addEventListener('blur', function () {
+            // Hide on blur but with a short delay so a mousedown on the
+            // dropdown still resolves the click before the dropdown vanishes.
+            setTimeout(function () { dropdown.classList.add('hidden'); }, 150);
+        });
     }
 
     function createWatchlist(name) {

--- a/internal/server/templates/watchlist.html
+++ b/internal/server/templates/watchlist.html
@@ -3,8 +3,9 @@
 <div class="page-header">
     <h1>Watchlist</h1>
     <form id="add-security-form" class="add-security-form">
-        <input type="text" id="wl-security-input" placeholder="Add security (e.g. AAPL)" autocomplete="off" spellcheck="false">
+        <input type="text" id="wl-security-input" placeholder="Add security (search ticker or company name)" autocomplete="off" spellcheck="false">
         <button type="submit">+</button>
+        <div id="wl-security-dropdown" class="security-dropdown hidden"></div>
     </form>
 </div>
 <div id="watchlist-tabs" class="watchlist-tabs"></div>


### PR DESCRIPTION
## Summary
Defence-in-depth fix for the crash chain caused by adding "MICROSOFT" (or its lowercase variant resolving to MSF.BR, a Brussels-exchange listing the user's FMP plan can't quote) via the watchlist add form. The bad symbol got persisted, the poller's provider returned a nil quote for it, and a downstream nil-dereference panicked the goroutine and took the server down.

## Layered fixes

- **Poller nil guard** (`internal/poller/poller.go`) — `fetchAndPublish` now skips nil quote entries instead of dereferencing them. A misbehaving provider can no longer crash the goroutine.
- **Server-side validation** (`handleAddToWatchlist`) — every add is validated against FMP search and requires an **exact** symbol-match before persisting. A search for "microsoft" returns MSFT (name match), so the raw text "MICROSOFT" is now rejected with `422 Unprocessable Entity`.
- **Watchlist add autocomplete** (`initWatchlistAddForm`) — proper search-as-you-type dropdown:
  - ↑/↓ to navigate, Enter or click to commit
  - **No auto-highlight** — an idle Enter on raw text refuses to submit unless the text exactly matches one of the live results (this was the root cause of MSF.BR getting picked: my first pass auto-highlighted index 0, and FMP ranked the Brussels listing first)
  - **US-first ranking** — NASDAQ / NYSE / BATS / AMEX / NMS sort above foreign exchanges so MSFT shows above MSF.BR for a "microsoft" query
- **Ghost rows on /watchlist** (`fetchWatchlistQuotes`) — symbols stored in the DB with no quote data still render as a greyed-out row with `—` placeholders, so the user can `d` them off the list rather than being stuck with an invisible orphan.
- **Refresh-after-add** — `loadWatchlists()` now returns its promise; `addToWatchlist` chains `.then(fetchWatchlistQuotes)` so the new symbol's row appears immediately on successful add instead of waiting for the next poll cycle.
- **CSS fix** — `.add-security-form` was missing `position: relative`, so the absolutely-positioned dropdown was anchoring to `<body>` and landing off-screen. Plus a left-aligned override since this form sits on the left of the page header (the header's existing security selector anchors right).

## Test plan
- [x] `make test` green
- [x] `make smoke` green
- [x] Typing "microsoft" in the watchlist add form shows a dropdown with MSFT at the top
- [x] Pressing Enter without selecting from the dropdown flashes "Pick a match from the dropdown" — does not commit
- [x] Clicking MSFT in the dropdown adds it and the row appears immediately (no reload)
- [x] Server-side POST with raw `{"symbol":"MICROSOFT"}` returns 422 with `unknown symbol — pick from the dropdown`
- [x] If a quote 402s (FMP plan gap), the ghost row stays visible and is deletable with `d`
- [x] Poller no longer panics when a provider returns a nil quote entry