### PR TITLE
feat(ideas): delete a sketch with d from the sidebar

### DIFF
--- a/internal/server/static/ideas.js
+++ b/internal/server/static/ideas.js
@@ -566,6 +566,7 @@
     };
 
     window._ideasDeleteSelected = function () {
+        if (paneFocus === 'list') return deleteSelectedSketch();
         if (paneFocus !== 'chart') return false;
         var rows = getMetricRows();
         if (metricSelectedIdx < 0 || metricSelectedIdx >= rows.length) return false;
@@ -584,6 +585,54 @@
         }, 100);
         return true;
     };
+
+    // Delete the highlighted sketch from the sidebar. Skips the synthetic
+    // "Default" row (data-sketch-id="") — that's the scratchpad and can't be
+    // removed. Cursor stays on the same visual index after re-render so j/k
+    // continue without surprise.
+    function deleteSelectedSketch() {
+        var items = Array.from(document.querySelectorAll('#ideas-list .ideas-list-item'));
+        if (listSelectedIdx < 0 || listSelectedIdx >= items.length) return false;
+        var row = items[listSelectedIdx];
+        var sid = row.dataset.sketchId;
+        if (!sid) {
+            if (window._flash) window._flash('Default scratchpad can\'t be deleted');
+            return true;
+        }
+        var name = row.querySelector('.ideas-list-name');
+        var label = name ? name.textContent : sid;
+        var wasLoaded = currentSketch && currentSketch.id && String(currentSketch.id) === String(sid);
+        var keepIdx = listSelectedIdx;
+
+        fetch('/api/sketches/' + sid, { method: 'DELETE' })
+            .then(function (r) {
+                if (!r.ok) throw new Error('delete ' + r.status);
+                if (window._flash) window._flash('Deleted ' + label);
+                if (wasLoaded) {
+                    // The deleted sketch was the one on the chart — clear the
+                    // canvas and drop the persisted "last sketch" pointer so
+                    // we don't dead-end the next page load on a missing id.
+                    localStorage.removeItem('stocktopus-last-sketch');
+                    currentSketch = { id: 0, name: '', metrics: [] };
+                }
+                return loadSketches();
+            })
+            .then(function () {
+                // Re-select the row that took the deleted slot, or move up
+                // if the deleted row was the last.
+                var newItems = Array.from(document.querySelectorAll('#ideas-list .ideas-list-item'));
+                if (!newItems.length) return;
+                listSelectedIdx = Math.min(keepIdx, newItems.length - 1);
+                newItems.forEach(function (el, i) { el.classList.toggle('vim-selected', i === listSelectedIdx); });
+                // If the deleted sketch was loaded, navigate to whatever now
+                // sits at the cursor (could be Default if all customs are gone).
+                if (wasLoaded && newItems[listSelectedIdx]) {
+                    navigateToSketch(newItems[listSelectedIdx].dataset.sketchId);
+                }
+            })
+            .catch(function () { if (window._flash) window._flash('Delete failed for ' + label); });
+        return true;
+    }
 
     window._ideasGetPaneFocus = function () { return paneFocus; };
 

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -182,6 +182,9 @@ window.onerror = function (msg, src, line, col, err) {
             cmdInput.style.color = '';
         }, 2000);
     }
+    // Exposed for per-view scripts (ideas.js etc.) that need to surface a
+    // status string through the same cmd-bar flash without duplicating it.
+    window._flash = flashError;
 
     // ── View Lifecycle ──
 

--- a/internal/server/templates/ideas.html
+++ b/internal/server/templates/ideas.html
@@ -22,7 +22,7 @@
         <div id="ideas-help" class="ideas-help hidden">
             <span class="ideas-help-row"><kbd>:add AAPL</kbd> · <kbd>:add AAPL.revenue</kbd> · <kbd>:add GCUSD</kbd> · <kbd>:add EURUSD</kbd> · <kbd>:add BTCUSD</kbd></span>
             <span class="ideas-help-row">Financials tab → <kbd>a</kbd> on a highlighted row prefills <kbd>:add SYMBOL.field</kbd></span>
-            <span class="ideas-help-row"><kbd>h</kbd>/<kbd>l</kbd> switch panes (list ↔ chart ↔ notes) · <kbd>j</kbd>/<kbd>k</kbd> within pane · <kbd>d</kbd> on a metric removes it · <kbd>\</kbd> drops a price line · <kbd>:cl</kbd> clears lines · <kbd>:save NAME</kbd></span>
+            <span class="ideas-help-row"><kbd>h</kbd>/<kbd>l</kbd> switch panes (list ↔ chart ↔ notes) · <kbd>j</kbd>/<kbd>k</kbd> within pane · <kbd>d</kbd> deletes the selected sketch (list) or metric (chart) · <kbd>\</kbd> drops a price line · <kbd>:cl</kbd> clears lines · <kbd>:save NAME</kbd></span>
         </div>
         <div id="ideas-chart-host" class="ideas-chart-host"></div>
         <div id="ideas-legend" class="ideas-legend"></div>


### PR DESCRIPTION
## Summary
Closes idea #18. Pressing `d` on a highlighted row in the `/ideas` sidebar deletes that sketch. Mirrors the chart pane's `d`-deletes-the-metric pattern so the binding reads consistently across panes.

- `_ideasDeleteSelected` branches on `paneFocus`: `'list'` → new sketch-delete path; `'chart'` → existing metric-remove.
- Cursor stays at the same visual index after re-render, snapping up one row if the deleted row was last.
- If the deleted sketch was the one on the chart, the canvas clears, `stocktopus-last-sketch` is dropped from localStorage so the next page load doesn't dead-end on a missing id, and the row that took the deleted slot gets navigated to (Default scratchpad if no customs remain).
- The synthetic "Default" row (`data-sketch-id=""`) is protected — `d` on it flashes `Default scratchpad can't be deleted` rather than silently no-op'ing.
- `terminal.js` exposes `flashError` as `window._flash` so per-view scripts can surface status through the same cmd-bar slot without duplicating it.
- `?` help row on `/ideas` advertises the new binding.

## Test plan
- [x] `make test` green
- [x] `make smoke` green
- [ ] `h` to focus sidebar, `j`/`k` to a custom sketch, `d` → row disappears, cursor lands on next sketch
- [ ] `d` on the last row → cursor moves up one
- [ ] `d` on the currently-loaded sketch → chart clears, navigates to the row that took the slot
- [ ] `d` on the "Default" row → refuses with a flash, doesn't delete
- [ ] Chart-pane `d` (delete metric) still works as before