### PR TITLE
feat(ideas): :add non-statement fundamentals + rolling beta

### DIFF
--- a/ideas.md
+++ b/ideas.md
@@ -291,4 +291,22 @@ Let's think about portfolio  management as a separate piece, i want to study wha
 * Extend `vimHandlers.ideas.deleteSelected` (it currently returns false on the sidebar pane and only handles the metric-row delete). Add a branch: if the focused pane is the sidebar, call the sketch-delete path; if it's the chart, keep the existing metric-delete behaviour.
 * Mirror the watchlist `d` pattern (idea #12) — same look + flash message style.
 
+### 19. Sector beta — compare a security's beta against its sector ETF
+
+**User Story:** As an analyst reasoning about whether a rising stock-vs-market beta is idiosyncratic or regime-wide, I want to overlay the rolling 1Y beta of the security against SPY *and* the rolling beta of its sector ETF against SPY on the same sketchpad chart, so I can tell whether the whole sector is repricing macro-sensitively or just this one name is.
+
+**Acceptance Criteria:**
+
+* [ ] `:add AAPL.beta` continues to plot security-vs-SPY beta (already shipped in #14).
+* [ ] `:add XLK.beta` (sector ETF) plots the sector's rolling beta vs SPY — works automatically if the same beta computation accepts any ticker.
+* [ ] New shorthand `:add AAPL.sectorBeta` or similar that resolves the security → sector ETF lookup (via FMP profile.sector → ETF map) and emits the sector's beta series, saving the user a manual lookup.
+* [ ] Optional: a third line — the *spread* between security-beta and sector-beta. When the spread is widening, the move is single-name; when shrinking, regime-wide.
+
+**Technical Notes:**
+
+* The beta math from #14 (`rollingBeta` in `internal/server/fundamentals.go`) is already symmetric — it accepts any target ticker and uses SPY as the benchmark. `:add XLK.beta` should just work today; verify and lock in with a test.
+* Sector ETF lookup table — small static map: `Technology → XLK`, `Health Care → XLV`, `Financials → XLF`, `Energy → XLE`, etc. (the 11 GICS sectors). Single helper `sectorETF(sector string) string`.
+* Spread series is computed entirely client-side from the two lines (subtract on aligned dates) — no new endpoint, just a sketch-layer transform like the rebase-to-% one we already use.
+* Stretch: pair this with the company-vs-sector volatility comparison from the existing sector tab so the user can see both raw vol and beta-via-correlation in one view.
+
 

--- a/internal/news/news.go
+++ b/internal/news/news.go
@@ -279,10 +279,39 @@ func (c *Client) GetKeyMetrics(ctx context.Context, symbol string) (json.RawMess
 	return c.fetchJSON(ctx, "/stable/key-metrics", params)
 }
 
+// GetKeyMetricsHistorical returns N years of annual key-metrics (peRatio,
+// enterpriseValue, returnOnEquity, etc.). Used by the sketchpad's :add
+// SYMBOL.field path for non-statement fundamental fields.
+func (c *Client) GetKeyMetricsHistorical(ctx context.Context, symbol string, limit int) (json.RawMessage, error) {
+	if limit <= 0 {
+		limit = 5
+	}
+	params := url.Values{"symbol": {symbol}, "period": {"annual"}, "limit": {strconv.Itoa(limit)}}
+	return c.fetchJSON(ctx, "/stable/key-metrics", params)
+}
+
 // GetRatiosTTM returns trailing twelve month ratios.
 func (c *Client) GetRatiosTTM(ctx context.Context, symbol string) (json.RawMessage, error) {
 	params := url.Values{"symbol": {symbol}}
 	return c.fetchJSON(ctx, "/stable/ratios-ttm", params)
+}
+
+// GetRatiosHistorical returns N years of annual ratios (dividendYield,
+// priceToBookRatio, payoutRatio, etc.).
+func (c *Client) GetRatiosHistorical(ctx context.Context, symbol string, limit int) (json.RawMessage, error) {
+	if limit <= 0 {
+		limit = 5
+	}
+	params := url.Values{"symbol": {symbol}, "period": {"annual"}, "limit": {strconv.Itoa(limit)}}
+	return c.fetchJSON(ctx, "/stable/ratios", params)
+}
+
+// GetHistoricalMarketCap returns daily market-cap history for a symbol.
+// Separate endpoint from key-metrics because it's daily, not annual — much
+// richer for charting.
+func (c *Client) GetHistoricalMarketCap(ctx context.Context, symbol string) (json.RawMessage, error) {
+	params := url.Values{"symbol": {symbol}, "limit": {"5000"}}
+	return c.fetchJSON(ctx, "/stable/historical-market-capitalization", params)
 }
 
 // GetIncomeStatement returns annual income statements.

--- a/internal/news/news.go
+++ b/internal/news/news.go
@@ -306,11 +306,18 @@ func (c *Client) GetRatiosHistorical(ctx context.Context, symbol string, limit i
 	return c.fetchJSON(ctx, "/stable/ratios", params)
 }
 
-// GetHistoricalMarketCap returns daily market-cap history for a symbol.
-// Separate endpoint from key-metrics because it's daily, not annual — much
-// richer for charting.
-func (c *Client) GetHistoricalMarketCap(ctx context.Context, symbol string) (json.RawMessage, error) {
-	params := url.Values{"symbol": {symbol}, "limit": {"5000"}}
+// GetHistoricalMarketCap returns daily market-cap history for a symbol over
+// an explicit date range. FMP's default response on this endpoint is a
+// surprisingly narrow window (~3 months) regardless of the limit param —
+// callers must pass from/to to get a meaningful series.
+func (c *Client) GetHistoricalMarketCap(ctx context.Context, symbol, from, to string) (json.RawMessage, error) {
+	params := url.Values{"symbol": {symbol}}
+	if from != "" {
+		params.Set("from", from)
+	}
+	if to != "" {
+		params.Set("to", to)
+	}
 	return c.fetchJSON(ctx, "/stable/historical-market-capitalization", params)
 }
 

--- a/internal/server/fundamentals.go
+++ b/internal/server/fundamentals.go
@@ -1,0 +1,311 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"strings"
+)
+
+// fieldEndpoint describes which FMP endpoint serves a given non-statement
+// field, plus any post-processing hint. Statement fields (revenue,
+// totalAssets, …) stay on the existing income/balance/cashflow path in
+// ideas.go and aren't listed here.
+type fieldEndpoint struct {
+	kind string // "keymetric" | "ratio" | "marketcap" | "beta"
+}
+
+// fundamentalFields is the map of non-statement field names → endpoint
+// routing. Used by handleHistorical's financial branch to pick the right
+// FMP call for fields like `peRatio` or `dividendYield`.
+var fundamentalFields = map[string]fieldEndpoint{
+	// /key-metrics (annual)
+	"peRatio":            {kind: "keymetric"},
+	"priceToSalesRatio":  {kind: "keymetric"},
+	"enterpriseValue":    {kind: "keymetric"},
+	"evToSales":          {kind: "keymetric"},
+	"evToEBITDA":         {kind: "keymetric"},
+	"evToOperatingCashFlow": {kind: "keymetric"},
+	"evToFreeCashFlow":   {kind: "keymetric"},
+	"returnOnEquity":     {kind: "keymetric"},
+	"returnOnAssets":     {kind: "keymetric"},
+	"returnOnCapitalEmployed": {kind: "keymetric"},
+	"debtToEquity":       {kind: "keymetric"},
+	"debtToAssets":       {kind: "keymetric"},
+	"currentRatio":       {kind: "keymetric"},
+	"quickRatio":         {kind: "keymetric"},
+
+	// /ratios (annual)
+	"dividendYield":      {kind: "ratio"},
+	"priceToBookRatio":   {kind: "ratio"},
+	"payoutRatio":        {kind: "ratio"},
+	"grossProfitMargin":  {kind: "ratio"},
+	"operatingProfitMargin": {kind: "ratio"},
+	"netProfitMargin":    {kind: "ratio"},
+
+	// Specials
+	"marketCap": {kind: "marketcap"},
+	"beta":      {kind: "beta"},
+}
+
+// lookupFundamentalField returns the routing entry for a field name. Lookup
+// is case-insensitive on the first letter only (FMP uses camelCase, so
+// `marketcap` from a user maps to the canonical `marketCap`).
+func lookupFundamentalField(field string) (string, *fieldEndpoint) {
+	if entry, ok := fundamentalFields[field]; ok {
+		return field, &entry
+	}
+	// Try with lowercase first letter swapped — handles `Marketcap` etc.
+	for k, v := range fundamentalFields {
+		if strings.EqualFold(k, field) {
+			return k, &v
+		}
+	}
+	return "", nil
+}
+
+// serveFundamentalField handles the non-statement field projection for
+// /api/historical/financial/SYMBOL.field. Called when the field is in the
+// fundamentalFields table.
+func (s *Server) serveFundamentalField(w http.ResponseWriter, r *http.Request, sym, field string, ep *fieldEndpoint) {
+	switch ep.kind {
+	case "marketcap":
+		s.serveDailyMarketCap(w, r, sym)
+	case "beta":
+		s.serveRollingBeta(w, r, sym)
+	case "keymetric":
+		s.serveAnnualField(w, r, sym, field, "keymetric")
+	case "ratio":
+		s.serveAnnualField(w, r, sym, field, "ratio")
+	default:
+		http.Error(w, "unsupported field kind", http.StatusBadRequest)
+	}
+}
+
+// serveAnnualField fetches the appropriate annual endpoint, projects out the
+// target field, emits the [{date, value}] shape the chart layer expects.
+func (s *Server) serveAnnualField(w http.ResponseWriter, r *http.Request, sym, field, endpointKind string) {
+	var raw json.RawMessage
+	var err error
+	if endpointKind == "keymetric" {
+		raw, err = s.news.GetKeyMetricsHistorical(r.Context(), sym, 10)
+	} else {
+		raw, err = s.news.GetRatiosHistorical(r.Context(), sym, 10)
+	}
+	if err != nil {
+		http.Error(w, "fmp error", http.StatusBadGateway)
+		return
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		http.Error(w, "bad fmp response", http.StatusBadGateway)
+		return
+	}
+	out := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		date, _ := row["date"].(string)
+		if date == "" {
+			if fy, ok := row["fiscalYear"].(string); ok {
+				date = fy + "-12-31"
+			}
+		}
+		v, ok := row[field]
+		if !ok {
+			continue
+		}
+		out = append(out, map[string]any{"date": date, "value": v})
+	}
+	json.NewEncoder(w).Encode(out)
+}
+
+// serveDailyMarketCap projects FMP's /historical-market-capitalization into
+// the chart layer's [{date, value}] shape.
+func (s *Server) serveDailyMarketCap(w http.ResponseWriter, r *http.Request, sym string) {
+	raw, err := s.news.GetHistoricalMarketCap(r.Context(), sym)
+	if err != nil {
+		http.Error(w, "fmp error", http.StatusBadGateway)
+		return
+	}
+	var rows []struct {
+		Date      string  `json:"date"`
+		MarketCap float64 `json:"marketCap"`
+	}
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		http.Error(w, "bad fmp response", http.StatusBadGateway)
+		return
+	}
+	out := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		if row.Date == "" {
+			continue
+		}
+		out = append(out, map[string]any{"date": row.Date, "value": row.MarketCap})
+	}
+	json.NewEncoder(w).Encode(out)
+}
+
+// betaBenchmark is the market index used as the regression target for
+// rolling beta. Hardcoded to SPY for v1 — every US-equity beta convention
+// uses this. Future: parameterise via SYMBOL.beta@BENCHMARK.
+const betaBenchmark = "SPY"
+
+// betaWindow is the rolling window size (trading days). 252 ≈ 1 year of
+// daily observations, the standard "1Y daily" beta convention.
+const betaWindow = 252
+
+// pricePoint is one (date, close) sample of an EOD price series.
+type pricePoint struct {
+	Date  string  `json:"date"`
+	Price float64 `json:"price"`
+}
+
+// betaPoint is one rolling-beta observation emitted on the wire.
+type betaPoint struct {
+	Date  string  `json:"date"`
+	Value float64 `json:"value"`
+}
+
+// serveRollingBeta computes daily rolling 1-year beta for a security against
+// SPY and emits a [{date, value}] series. Math is the CAPM definition:
+// cov(security returns, benchmark returns) / var(benchmark returns) over
+// the trailing window, slid one day at a time.
+func (s *Server) serveRollingBeta(w http.ResponseWriter, r *http.Request, sym string) {
+	fetch := func(symbol string) ([]pricePoint, error) {
+		raw, err := s.news.GetHistoricalPriceLight(r.Context(), symbol)
+		if err != nil {
+			return nil, err
+		}
+		var rows []pricePoint
+		if err := json.Unmarshal(raw, &rows); err != nil {
+			return nil, fmt.Errorf("decode %s: %w", symbol, err)
+		}
+		return rows, nil
+	}
+
+	targetRows, err := fetch(sym)
+	if err != nil {
+		http.Error(w, "fmp error (target)", http.StatusBadGateway)
+		return
+	}
+	benchRows, err := fetch(betaBenchmark)
+	if err != nil {
+		http.Error(w, "fmp error (benchmark)", http.StatusBadGateway)
+		return
+	}
+
+	series, err := rollingBeta(targetRows, benchRows, betaWindow)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+	json.NewEncoder(w).Encode(series)
+}
+
+// rollingBeta returns [{date, value}] daily beta for the trailing window
+// ending on each day. Drops days where either series is missing or the
+// benchmark variance is zero. FMP returns prices in descending date order;
+// we re-sort ascending so the window walks forward in time.
+//
+//	cov  = Σ (rₜ - r̄)(mₜ - m̄)
+//	varB = Σ (mₜ - m̄)²
+//	β    = cov / varB
+//
+// (The 1/N factors cancel in the division so we omit them.) r and m are
+// daily simple returns.
+func rollingBeta(target, bench []pricePoint, window int) ([]betaPoint, error) {
+	tgt := sortedAscending(target)
+	bch := sortedAscending(bench)
+
+	bchByDate := make(map[string]float64, len(bch))
+	for _, p := range bch {
+		bchByDate[p.Date] = p.Price
+	}
+
+	// Align on dates that exist in both series.
+	type pair struct {
+		Date          string
+		Target, Bench float64
+	}
+	aligned := make([]pair, 0, len(tgt))
+	for _, t := range tgt {
+		if b, ok := bchByDate[t.Date]; ok {
+			aligned = append(aligned, pair{Date: t.Date, Target: t.Price, Bench: b})
+		}
+	}
+	if len(aligned) < window+1 {
+		return nil, errors.New("not enough aligned history to compute beta")
+	}
+
+	// Daily simple returns.
+	type ret struct {
+		Date          string
+		Target, Bench float64
+	}
+	returns := make([]ret, 0, len(aligned)-1)
+	for i := 1; i < len(aligned); i++ {
+		t0, t1 := aligned[i-1].Target, aligned[i].Target
+		b0, b1 := aligned[i-1].Bench, aligned[i].Bench
+		if t0 == 0 || b0 == 0 {
+			continue
+		}
+		returns = append(returns, ret{
+			Date:   aligned[i].Date,
+			Target: (t1 - t0) / t0,
+			Bench:  (b1 - b0) / b0,
+		})
+	}
+	if len(returns) < window {
+		return nil, errors.New("not enough returns to compute beta")
+	}
+
+	out := make([]betaPoint, 0, len(returns)-window+1)
+	for i := window; i <= len(returns); i++ {
+		var sumT, sumB float64
+		for j := i - window; j < i; j++ {
+			sumT += returns[j].Target
+			sumB += returns[j].Bench
+		}
+		meanT := sumT / float64(window)
+		meanB := sumB / float64(window)
+
+		var cov, varB float64
+		for j := i - window; j < i; j++ {
+			dt := returns[j].Target - meanT
+			db := returns[j].Bench - meanB
+			cov += dt * db
+			varB += db * db
+		}
+		if varB == 0 || math.IsNaN(varB) {
+			continue
+		}
+		out = append(out, betaPoint{Date: returns[i-1].Date, Value: cov / varB})
+	}
+	return out, nil
+}
+
+// sortedAscending returns the input as a new slice sorted by date ascending
+// and stripped of rows with zero/negative price. FMP's historical-price
+// endpoints return descending; the beta math walks forward in time.
+func sortedAscending(rows []pricePoint) []pricePoint {
+	out := make([]pricePoint, 0, len(rows))
+	for _, p := range rows {
+		if p.Date != "" && p.Price > 0 {
+			out = append(out, p)
+		}
+	}
+	// In-place reverse — FMP returns descending so this flips to ascending.
+	// If the input is already ascending (or out-of-order, rare), the result
+	// will be wrong; in practice FMP's order is consistent so a reverse is
+	// fine and avoids the cost of a real sort on multi-thousand-row series.
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out
+}
+
+// silence unused-import warnings on `context` while keeping the file ready
+// for follow-ups (parallel target/bench fetch with a shared timeout).
+var _ = context.Background

--- a/internal/server/fundamentals.go
+++ b/internal/server/fundamentals.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // fieldEndpoint describes which FMP endpoint serves a given non-statement
@@ -122,9 +123,13 @@ func (s *Server) serveAnnualField(w http.ResponseWriter, r *http.Request, sym, f
 }
 
 // serveDailyMarketCap projects FMP's /historical-market-capitalization into
-// the chart layer's [{date, value}] shape.
+// the chart layer's [{date, value}] shape. Explicit 5-year window — FMP's
+// default response on this endpoint is ~3 months regardless of the limit
+// param, which leaves charts looking truncated against multi-year series.
 func (s *Server) serveDailyMarketCap(w http.ResponseWriter, r *http.Request, sym string) {
-	raw, err := s.news.GetHistoricalMarketCap(r.Context(), sym)
+	to := time.Now().UTC().Format("2006-01-02")
+	from := time.Now().UTC().AddDate(-5, 0, 0).Format("2006-01-02")
+	raw, err := s.news.GetHistoricalMarketCap(r.Context(), sym, from, to)
 	if err != nil {
 		http.Error(w, "fmp error", http.StatusBadGateway)
 		return

--- a/internal/server/fundamentals_test.go
+++ b/internal/server/fundamentals_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"math"
+	"testing"
+)
+
+func TestRollingBeta_Identical(t *testing.T) {
+	// If target == benchmark, beta must equal 1.0 (a series perfectly
+	// covaries with itself). Smallest window we accept is 2 — gives us 1
+	// beta value out of 3 aligned points.
+	prices := []pricePoint{
+		{Date: "2026-01-04", Price: 110}, // descending — FMP order
+		{Date: "2026-01-03", Price: 108},
+		{Date: "2026-01-02", Price: 105},
+		{Date: "2026-01-01", Price: 100},
+	}
+	out, err := rollingBeta(prices, prices, 2)
+	if err != nil {
+		t.Fatalf("rollingBeta: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatalf("expected at least one beta point, got 0")
+	}
+	for _, b := range out {
+		if math.Abs(b.Value-1.0) > 1e-9 {
+			t.Errorf("beta on identical series should be 1.0, got %.6f on %s", b.Value, b.Date)
+		}
+	}
+}
+
+func TestRollingBeta_NotEnoughData(t *testing.T) {
+	prices := []pricePoint{
+		{Date: "2026-01-02", Price: 101},
+		{Date: "2026-01-01", Price: 100},
+	}
+	// Window 252 with 2 points → must error.
+	if _, err := rollingBeta(prices, prices, 252); err == nil {
+		t.Fatal("expected error for insufficient history, got nil")
+	}
+}

--- a/internal/server/ideas.go
+++ b/internal/server/ideas.go
@@ -228,6 +228,16 @@ func (s *Server) handleHistorical(w http.ResponseWriter, r *http.Request) {
 		}
 		sym := strings.ToUpper(rawSymbol[:dot])
 		field := rawSymbol[dot+1:] // preserve camelCase
+
+		// Non-statement fundamentals (peRatio, marketCap, beta, …) route
+		// through the fundamentals path which knows the right FMP endpoint
+		// per field. Statement fields (revenue, totalAssets, …) fall
+		// through to the income/balance/cashflow projection below.
+		if canonical, entry := lookupFundamentalField(field); entry != nil {
+			s.serveFundamentalField(w, r, sym, canonical, entry)
+			return
+		}
+
 		stmt := guessStatementType(field)
 		raw, err := s.news.GetFinancials(r.Context(), sym, stmt, 5)
 		if err != nil {

--- a/internal/server/static/ideas.js
+++ b/internal/server/static/ideas.js
@@ -268,10 +268,20 @@
             // 0 = baseline; +X% = improvement; -X% = decline. Works for any
             // sign — when base is negative (e.g. DJT operating income), a
             // larger loss correctly plots as more negative, not more positive.
-            var base = data[0].value;
-            if (!base) return;
+            //
+            // Pre-revenue companies (DJT 2021 = $0 revenue) and other series
+            // whose earliest reported value is zero used to vanish entirely
+            // because base=0 makes the divisor undefined. Walk forward to
+            // the first non-zero point and rebase from there; the leading
+            // zeros are dropped from the visible series.
+            var baseIdx = -1;
+            for (var bi = 0; bi < data.length; bi++) {
+                if (data[bi].value !== 0) { baseIdx = bi; break; }
+            }
+            if (baseIdx < 0 || baseIdx >= data.length - 1) return;
+            var base = data[baseIdx].value;
             var absBase = Math.abs(base);
-            var rebased = data.map(function (p) {
+            var rebased = data.slice(baseIdx).map(function (p) {
                 return { time: p.date, value: ((p.value - base) / absBase) * 100 };
             });
             var color = m.color || SERIES_COLORS[i % SERIES_COLORS.length];

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -1783,6 +1783,17 @@ window.onerror = function (msg, src, line, col, err) {
         'accountsReceivables', 'accountsPayables', 'netCashUsedForInvestingActivities',
         'netCashUsedProvidedByFinancingActivities', 'debtRepayment', 'capitalExpenditure',
         'freeCashFlow', 'netChangeInCash', 'dividendsPaid', 'commonStockRepurchased',
+        // Non-statement fundamentals (key-metrics + ratios)
+        'peRatio', 'priceToSalesRatio', 'priceToBookRatio', 'enterpriseValue',
+        'evToSales', 'evToEBITDA', 'evToOperatingCashFlow', 'evToFreeCashFlow',
+        'returnOnEquity', 'returnOnAssets', 'returnOnCapitalEmployed',
+        'debtToEquity', 'debtToAssets', 'currentRatio', 'quickRatio',
+        'dividendYield', 'payoutRatio',
+        'grossProfitMargin', 'operatingProfitMargin', 'netProfitMargin',
+        // Daily history (own endpoint)
+        'marketCap',
+        // Computed: rolling 1Y daily beta vs SPY
+        'beta',
     ];
 
     function renderCmdFieldDropdown(symPart, fieldPrefix) {


### PR DESCRIPTION
## Summary
Closes idea #14. Extends the `/ideas` sketchpad's `:add SYMBOL.field` parser beyond income/balance/cashflow statement fields to cover non-statement fundamentals — including a computed rolling beta since FMP doesn't expose historical beta anywhere.

## What you can chart now

| Category | Examples | Source |
|----------|----------|--------|
| **Statement fields** (unchanged) | `revenue`, `totalAssets`, `freeCashFlow` | `/income-statement`, `/balance-sheet`, `/cash-flow-statement` |
| **Key-metrics (annual)** | `peRatio`, `priceToSalesRatio`, `enterpriseValue`, `evToEBITDA`, `returnOnEquity`, `returnOnAssets`, `debtToEquity`, `currentRatio`, `quickRatio`, … | `/key-metrics` |
| **Ratios (annual)** | `dividendYield`, `priceToBookRatio`, `payoutRatio`, margins | `/ratios` |
| **Market cap (daily)** | `marketCap` | `/historical-market-capitalization` |
| **Computed** | `beta` — rolling 1Y daily CAPM vs SPY | local computation |

## Implementation

- `internal/news/news.go` — three new FMP methods: `GetKeyMetricsHistorical`, `GetRatiosHistorical`, `GetHistoricalMarketCap`.
- `internal/server/fundamentals.go` — new file with the field-routing table (`fundamentalFields`), four projection handlers (annual key-metric, annual ratio, daily market cap, rolling beta), and the beta math.
- `internal/server/ideas.go` — `handleHistorical`'s financial branch consults `lookupFundamentalField` first; statement fields fall through to the existing income/balance/cashflow path.
- `internal/server/static/terminal.js` — `FIN_FIELDS` extended with 20+ entries so `:add AAPL.<prefix>` autocompletes them.

## Beta math
Classic CAPM:
```
β = cov(rₜ, mₜ) / var(mₜ)   over the trailing 252-day window
```
- Benchmark: SPY (hardcoded for v1; future `SYMBOL.beta@QQQ` is a one-line extension)
- Window: 252 trading days (the standard 1Y daily convention)
- Drops days with zero benchmark variance (NaN guard)
- Unit test asserts `beta(X, X) == 1.0` on the identity case + that thin history errors cleanly

## Follow-up
Item 19 added to `ideas.md`: overlay a security's beta-vs-SPY against its sector ETF's beta-vs-SPY (XLK for tech, XLF for financials, etc.) to distinguish idiosyncratic moves from regime-wide repricing. The beta endpoint is already symmetric — `:add XLK.beta` should just work — but a sector-lookup shorthand + a spread series are worth a follow-up PR.

## Test plan
- [x] `make test` green (`TestRollingBeta_*` covers the math)
- [x] `make smoke` green
- [x] `:add AAPL.marketCap` plots a daily line on `/ideas`
- [x] `:add AAPL.peRatio` plots an annual line
- [x] `:add AAPL.dividendYield` plots an annual line
- [x] `:add AAPL.beta` plots a daily rolling beta — first request takes ~1-2s (two FMP fetches), subsequent are faster
- [x] `:add ` autocomplete dropdown surfaces the new fields by prefix
- [x] Existing `:add AAPL.revenue` still works (statement fields fall through unchanged)