### PR TITLE
feat(econ): UK economics via BoE direct + DBnomics/ONS hybrid

### DIFF
--- a/cmd/stocktopus/main.go
+++ b/cmd/stocktopus/main.go
@@ -13,6 +13,7 @@ import (
 
 	"stocktopus/internal/agent"
 	"stocktopus/internal/agent/trading"
+	"stocktopus/internal/boe"
 	"stocktopus/internal/dbnomics"
 	"stocktopus/internal/econ"
 	"stocktopus/internal/fred"
@@ -201,7 +202,8 @@ func main() {
 	// uses the same fetcher to keep all curated series warm.
 	fredClient := fred.New(os.Getenv("FRED_API_KEY"))
 	dbnomicsClient := dbnomics.New()
-	econFetcher := econ.NewFetcher(fredClient, dbnomicsClient)
+	boeClient := boe.New()
+	econFetcher := econ.NewFetcher(fredClient, dbnomicsClient, boeClient)
 	if st != nil {
 		go econ.NewPrefetcher(econFetcher, st, logger, 30*time.Minute).Run(appCtx)
 	}

--- a/internal/boe/client.go
+++ b/internal/boe/client.go
@@ -1,0 +1,155 @@
+// Package boe is a thin client for the Bank of England Interactive Database
+// (IADB) CSV endpoint.
+//
+// BoE does not publish a JSON API; the IADB serves daily-refreshed CSV from
+// https://www.bankofengland.co.uk/boeapps/iadb/ . We use it for the UK
+// monetary side (Bank Rate, SONIA, gilt yields, M4 growth) where DBnomics's
+// BoE coverage is limited to MFI flow datasets. Inflation/labour/GDP for
+// the UK still flow through DBnomics → ONS.
+//
+// Series are identified by an alphanumeric IADB code, e.g. IUDBEDR
+// (Official Bank Rate). The endpoint follows a 302 to the actual CSV.
+package boe
+
+import (
+	"bufio"
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	baseURL = "https://www.bankofengland.co.uk/boeapps/iadb/fromshowcolumns.asp"
+	// IADB returns dates like "02 Jan 2026".
+	csvDateFormat = "02 Jan 2006"
+)
+
+// Observation is one (date, value) point. Dates are YYYY-MM-DD strings to
+// match the cross-provider shape used in internal/dbnomics and internal/fred.
+type Observation struct {
+	Date  string  `json:"date"`
+	Value float64 `json:"value"`
+}
+
+// Series bundles metadata + observations for one BoE IADB series.
+type Series struct {
+	Code         string        `json:"code"`         // IADB code, e.g. IUDBEDR
+	Name         string        `json:"name"`         // human label from CSV header
+	Observations []Observation `json:"observations"`
+}
+
+type Client struct {
+	http *http.Client
+}
+
+func New() *Client {
+	return &Client{http: &http.Client{Timeout: 30 * time.Second}}
+}
+
+// GetSeries fetches the full observation history for an IADB series code.
+// Start date is hard-coded to 1975 (the IADB's earliest broad coverage) so
+// callers don't have to know — we cache the full history downstream anyway.
+func (c *Client) GetSeries(ctx context.Context, code string) (*Series, error) {
+	q := fmt.Sprintf(
+		"%s?csv.x=yes&Datefrom=01/Jan/1975&Dateto=now&SeriesCodes=%s&CSVF=TT&UsingCodes=Y&VPD=Y&VFD=N",
+		baseURL, code,
+	)
+	req, err := http.NewRequestWithContext(ctx, "GET", q, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("boe %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return parseCSV(resp.Body, code)
+}
+
+// parseCSV decodes the IADB's two-block CSV: a description block then a
+// DATE,CODE block. We tolerate either Unix or Windows line endings.
+//
+//	SERIES,DESCRIPTION
+//	IUDBEDR,Official Bank Rate
+//
+//	DATE,IUDBEDR
+//	02 Jan 2020,0.75
+//	…
+func parseCSV(r io.Reader, code string) (*Series, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+	var name string
+	var dataLines []string
+	state := 0 // 0=desc-header, 1=desc-row, 2=blank-or-data-header, 3=data
+
+	for scanner.Scan() {
+		line := strings.TrimRight(scanner.Text(), "\r")
+		switch state {
+		case 0:
+			// Header "SERIES,DESCRIPTION" — discard.
+			state = 1
+		case 1:
+			// "IUDBEDR,Official Bank Rate" — pull the description.
+			parts := strings.SplitN(line, ",", 2)
+			if len(parts) == 2 {
+				name = strings.TrimSpace(parts[1])
+			}
+			state = 2
+		case 2:
+			// Blank then "DATE,CODE" — skip until we see the data header.
+			if strings.HasPrefix(line, "DATE,") {
+				state = 3
+			}
+		case 3:
+			if line == "" {
+				continue
+			}
+			dataLines = append(dataLines, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("boe csv scan: %w", err)
+	}
+
+	obs := make([]Observation, 0, len(dataLines))
+	cr := csv.NewReader(strings.NewReader(strings.Join(dataLines, "\n")))
+	cr.FieldsPerRecord = -1
+	for {
+		rec, err := cr.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("boe csv parse: %w", err)
+		}
+		if len(rec) < 2 {
+			continue
+		}
+		raw := strings.TrimSpace(rec[1])
+		if raw == "" || raw == "NA" {
+			// Blank rows are common for monthly series sampled at daily dates.
+			continue
+		}
+		t, err := time.Parse(csvDateFormat, strings.TrimSpace(rec[0]))
+		if err != nil {
+			continue
+		}
+		v, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			continue
+		}
+		obs = append(obs, Observation{Date: t.UTC().Format("2006-01-02"), Value: v})
+	}
+
+	return &Series{Code: code, Name: name, Observations: obs}, nil
+}

--- a/internal/econ/catalog.go
+++ b/internal/econ/catalog.go
@@ -44,6 +44,37 @@ func ezEntry(code, name, category, freq, units, dbPath string) CatalogEntry {
 	}
 }
 
+// ukBoEEntry routes a UK indicator through the BoE IADB CSV (monetary side:
+// Bank Rate, SONIA, gilt yields, M4). The central bank is attributed to BoE.
+func ukBoEEntry(code, name, category, freq, units, iadbCode string) CatalogEntry {
+	return CatalogEntry{
+		Country:     "UK",
+		Code:        code,
+		Name:        name,
+		Category:    category,
+		Frequency:   freq,
+		Units:       units,
+		CentralBank: "Bank of England",
+		Route:       "boe:" + iadbCode,
+	}
+}
+
+// ukONSEntry routes a UK indicator through DBnomics → ONS (inflation, labour,
+// GDP). Central bank is still BoE — the catalog groups by country, not by
+// data source.
+func ukONSEntry(code, name, category, freq, units, dbPath string) CatalogEntry {
+	return CatalogEntry{
+		Country:     "UK",
+		Code:        code,
+		Name:        name,
+		Category:    category,
+		Frequency:   freq,
+		Units:       units,
+		CentralBank: "Bank of England",
+		Route:       "dbnomics:" + dbPath,
+	}
+}
+
 var Catalog = []CatalogEntry{
 	// ── United States · Federal Reserve / FRED ──
 	// Rates & Monetary
@@ -102,6 +133,26 @@ var Catalog = []CatalogEntry{
 		"ECB/ICP/M.U2.N.000000.4.ANR"),
 	ezEntry("HICPCORE", "Euro Area Core HICP (Annual Rate)", "Inflation", "M", "%",
 		"ECB/ICP/M.U2.N.XEF000.4.ANR"),
+
+	// ── United Kingdom · Bank of England + ONS ──
+	// Rates & Monetary (BoE IADB)
+	ukBoEEntry("RATE", "Official Bank Rate", "Rates", "D", "%", "IUDBEDR"),
+	ukBoEEntry("SONIA", "Sterling Overnight Index Average", "Rates", "D", "%", "IUDSOIA"),
+	ukBoEEntry("10Y", "10-Year Gilt Nominal Par Yield", "Rates", "D", "%", "IUDMNPY"),
+	ukBoEEntry("M4", "M4 Money Supply (12-mo Growth, SA)", "Rates", "M", "%", "LPMVQJW"),
+	// Inflation (ONS MM23)
+	ukONSEntry("CPI", "UK CPI (Annual Rate, All Items)", "Inflation", "M", "%",
+		"ONS/MM23/D7G7.M"),
+	ukONSEntry("CPIH", "UK CPIH (Annual Rate, All Items)", "Inflation", "M", "%",
+		"ONS/MM23/L55O.M"),
+	ukONSEntry("COREPI", "UK Core CPI (excl. food/energy/alcohol/tobacco)", "Inflation", "M", "%",
+		"ONS/MM23/DKO8.M"),
+	// Labor (ONS LMS)
+	ukONSEntry("UNRATE", "UK Unemployment Rate (16+, SA)", "Labor", "M", "%",
+		"ONS/LMS/MGSX.M"),
+	// Growth (ONS PN2)
+	ukONSEntry("GDP", "UK GDP Growth (YoY, CVM SA)", "Growth", "Q", "%",
+		"ONS/PN2/IHYR.Q"),
 }
 
 // LookupCatalog returns the curated entry for an identifier. Accepts either

--- a/internal/econ/fetcher.go
+++ b/internal/econ/fetcher.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 
+	"stocktopus/internal/boe"
 	"stocktopus/internal/dbnomics"
 	"stocktopus/internal/fred"
 )
@@ -15,10 +16,11 @@ import (
 type Fetcher struct {
 	fred     *fred.Client
 	dbnomics *dbnomics.Client
+	boe      *boe.Client
 }
 
-func NewFetcher(fc *fred.Client, dc *dbnomics.Client) *Fetcher {
-	return &Fetcher{fred: fc, dbnomics: dc}
+func NewFetcher(fc *fred.Client, dc *dbnomics.Client, bc *boe.Client) *Fetcher {
+	return &Fetcher{fred: fc, dbnomics: dc, boe: bc}
 }
 
 // FetchEntry resolves the entry's Route and pulls the series. Returned
@@ -54,6 +56,16 @@ func (f *Fetcher) FetchEntry(ctx context.Context, e *CatalogEntry) (*Series, err
 			return nil, err
 		}
 		return dbnomicsToSeries(e, s), nil
+
+	case "boe":
+		if f.boe == nil {
+			return nil, errors.New("boe client not configured")
+		}
+		s, err := f.boe.GetSeries(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		return boeToSeries(e, s), nil
 
 	default:
 		return nil, errors.New("unknown route source: " + source)
@@ -94,6 +106,25 @@ func fredToSeries(e *CatalogEntry, s *fred.Series) *Series {
 		Frequency:    freq,
 		Units:        units,
 		UpdatedAt:    s.Meta.LastUpdated,
+		Observations: obs,
+	}
+}
+
+func boeToSeries(e *CatalogEntry, s *boe.Series) *Series {
+	obs := make([]Observation, len(s.Observations))
+	for i, o := range s.Observations {
+		obs[i] = Observation{Date: o.Date, Value: o.Value}
+	}
+	title := s.Name
+	if title == "" {
+		title = e.Name
+	}
+	return &Series{
+		Identifier:   e.Identifier(),
+		Title:        title,
+		Category:     e.Category,
+		Frequency:    e.Frequency,
+		Units:        e.Units,
 		Observations: obs,
 	}
 }

--- a/tests/e2e/economics_test.go
+++ b/tests/e2e/economics_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 )
 
-// Catalog includes both FRED (US) and DBnomics (EZ) routed entries. Tests
-// the shape of the response + that both sources appear, but does NOT fetch
-// any series (the test scaffold has no econ.Fetcher wired).
+// Catalog includes FRED (US), DBnomics→ECB (EZ), BoE direct + DBnomics→ONS
+// (UK) routed entries. Tests the shape of the response + that all three
+// regions appear, but does NOT fetch any series (the test scaffold has no
+// econ.Fetcher wired).
 
 func TestSmoke_EconomicsCatalog(t *testing.T) {
 	resp := get(t, "/api/economics/catalog")
@@ -33,14 +34,19 @@ func TestSmoke_EconomicsCatalog(t *testing.T) {
 		t.Errorf("expected 30+ catalog entries, got %d", len(rows))
 	}
 
-	// Spot-check coverage of both sources.
-	foundUS, foundEZ := false, false
+	// Spot-check coverage of all three regions. UK.RATE (BoE direct) and
+	// UK.CPI (DBnomics→ONS) cover both UK source paths.
+	foundUS, foundEZ, foundUKBoE, foundUKONS := false, false, false, false
 	for _, r := range rows {
 		switch r.Identifier {
 		case "US.UNRATE":
 			foundUS = true
 		case "EZ.RATE":
 			foundEZ = true
+		case "UK.RATE":
+			foundUKBoE = true
+		case "UK.CPI":
+			foundUKONS = true
 		}
 		// All entries must carry the domain fields; provider details must
 		// not leak (Route is tagged json:"-").
@@ -53,6 +59,12 @@ func TestSmoke_EconomicsCatalog(t *testing.T) {
 	}
 	if !foundEZ {
 		t.Error("expected EZ.RATE in catalog")
+	}
+	if !foundUKBoE {
+		t.Error("expected UK.RATE (BoE direct) in catalog")
+	}
+	if !foundUKONS {
+		t.Error("expected UK.CPI (DBnomics→ONS) in catalog")
 	}
 }
 
@@ -75,6 +87,33 @@ func TestSmoke_EconomicsCatalogCountryFilter(t *testing.T) {
 	}
 }
 
+func TestSmoke_EconomicsCatalogUKFilter(t *testing.T) {
+	resp := get(t, "/api/economics/catalog?country=UK")
+	defer resp.Body.Close()
+	assertStatus(t, resp, 200)
+
+	var rows []struct {
+		Country string `json:"country"`
+		Code    string `json:"code"`
+	}
+	json.NewDecoder(resp.Body).Decode(&rows)
+	if len(rows) < 5 {
+		t.Fatalf("expected several UK catalog entries (BoE + ONS), got %d", len(rows))
+	}
+	codes := map[string]bool{}
+	for _, r := range rows {
+		if r.Country != "UK" {
+			t.Errorf("expected only UK entries, got %q", r.Country)
+		}
+		codes[r.Code] = true
+	}
+	for _, want := range []string{"RATE", "CPI", "UNRATE"} {
+		if !codes[want] {
+			t.Errorf("expected UK.%s in catalog", want)
+		}
+	}
+}
+
 func TestSmoke_EconomicsCentralBanks(t *testing.T) {
 	resp := get(t, "/api/economics/central-banks")
 	defer resp.Body.Close()
@@ -86,10 +125,10 @@ func TestSmoke_EconomicsCentralBanks(t *testing.T) {
 		Indicators int    `json:"indicators"`
 	}
 	json.NewDecoder(resp.Body).Decode(&cbs)
-	if len(cbs) < 2 {
-		t.Fatalf("expected at least 2 central banks (Fed + ECB), got %d", len(cbs))
+	if len(cbs) < 3 {
+		t.Fatalf("expected at least 3 central banks (Fed + ECB + BoE), got %d", len(cbs))
 	}
-	foundFed, foundECB := false, false
+	foundFed, foundECB, foundBoE := false, false, false
 	for _, cb := range cbs {
 		if cb.Country == "US" && cb.Indicators > 0 {
 			foundFed = true
@@ -97,12 +136,18 @@ func TestSmoke_EconomicsCentralBanks(t *testing.T) {
 		if cb.Country == "EZ" && cb.Indicators > 0 {
 			foundECB = true
 		}
+		if cb.Country == "UK" && cb.Indicators > 0 {
+			foundBoE = true
+		}
 	}
 	if !foundFed {
 		t.Error("expected Federal Reserve in central banks list")
 	}
 	if !foundECB {
 		t.Error("expected ECB in central banks list")
+	}
+	if !foundBoE {
+		t.Error("expected Bank of England in central banks list")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds 9 UK indicators to the economics catalog via a hybrid approach: BoE IADB CSV for monetary side (Bank Rate, SONIA, 10Y gilt, M4) + DBnomics→ONS for inflation, unemployment, GDP
- New `internal/boe/` package wraps the BoE Interactive Database CSV endpoint (no JSON API), handles the 302 redirect and `02 Jan 2006` date format
- `internal/econ/fetcher.go` gains a `boe:` route branch alongside the existing fred / dbnomics dispatch

## Series added
| ID | Source | Description |
|---|---|---|
| UK.RATE | BoE/IUDBEDR | Official Bank Rate (daily) |
| UK.SONIA | BoE/IUDSOIA | Sterling Overnight Index Average (daily) |
| UK.10Y | BoE/IUDMNPY | 10-year gilt nominal par yield (daily) |
| UK.M4 | BoE/LPMVQJW | M4 12-mo growth SA (monthly) |
| UK.CPI | ONS/MM23/D7G7.M | CPI annual rate (monthly) |
| UK.CPIH | ONS/MM23/L55O.M | CPIH annual rate (monthly) |
| UK.COREPI | ONS/MM23/DKO8.M | Core CPI (monthly) |
| UK.UNRATE | ONS/LMS/MGSX.M | Unemployment rate 16+ SA (monthly) |
| UK.GDP | ONS/PN2/IHYR.Q | GDP YoY growth CVM SA (quarterly) |

## Why hybrid
BoE's DBnomics coverage is limited to MFI flow datasets — no policy rate, no SONIA, no gilt yields. BoE direct CSV is the source of record for monetary. ONS data on DBnomics is comprehensive for inflation/labour/GDP.

## Test plan
- [x] `make test` passes
- [x] `make smoke` passes — UK series appear in catalog, UK filter works, BoE in central-banks list
- [x] BoE client live-verified against IADB for all 4 codes (full history loads, 1975→present for Bank Rate)

Closes #87