### PR TITLE
feat(fundamentals): :add SYMBOL.sectorBeta

### DIFF
--- a/internal/server/fundamentals.go
+++ b/internal/server/fundamentals.go
@@ -16,7 +16,7 @@ import (
 // totalAssets, …) stay on the existing income/balance/cashflow path in
 // ideas.go and aren't listed here.
 type fieldEndpoint struct {
-	kind string // "keymetric" | "ratio" | "marketcap" | "beta"
+	kind string // "keymetric" | "ratio" | "marketcap" | "beta" | "sectorBeta"
 	// fmpField overrides the FMP JSON field name when it differs from the
 	// user-facing handle. Empty = use the map key. FMP's naming is wildly
 	// inconsistent — e.g. our friendly "peRatio" comes off /ratios as
@@ -57,8 +57,44 @@ var fundamentalFields = map[string]fieldEndpoint{
 	"netProfitMargin":       {kind: "ratio"},
 
 	// Specials
-	"marketCap": {kind: "marketcap"},
-	"beta":      {kind: "beta"},
+	"marketCap":  {kind: "marketcap"},
+	"beta":       {kind: "beta"},
+	"sectorBeta": {kind: "sectorBeta"},
+}
+
+// sectorETFs maps GICS sector names (and the variants FMP returns on
+// /stable/profile) to the State Street SPDR sector ETF symbol. Used by the
+// `sectorBeta` field to resolve a security to the ETF whose rolling beta
+// represents the sector's macro sensitivity.
+//
+// Keys are normalised to lower-case at lookup time so casing differences
+// between FMP's "Financial Services" and the canonical "Financials" don't
+// matter.
+var sectorETFs = map[string]string{
+	"technology":             "XLK",
+	"information technology": "XLK",
+	"health care":            "XLV",
+	"healthcare":             "XLV",
+	"financials":             "XLF",
+	"financial services":     "XLF",
+	"energy":                 "XLE",
+	"consumer discretionary": "XLY",
+	"consumer cyclical":      "XLY",
+	"consumer staples":       "XLP",
+	"consumer defensive":     "XLP",
+	"industrials":            "XLI",
+	"utilities":              "XLU",
+	"materials":              "XLB",
+	"basic materials":        "XLB",
+	"real estate":            "XLRE",
+	"communication services": "XLC",
+	"communications":         "XLC",
+}
+
+// sectorETF returns the SPDR sector ETF symbol for a sector name, or "" if
+// the sector is unknown. Case- and whitespace-insensitive.
+func sectorETF(sector string) string {
+	return sectorETFs[strings.ToLower(strings.TrimSpace(sector))]
 }
 
 // lookupFundamentalField returns the routing entry for a field name. Lookup
@@ -86,6 +122,8 @@ func (s *Server) serveFundamentalField(w http.ResponseWriter, r *http.Request, s
 		s.serveDailyMarketCap(w, r, sym)
 	case "beta":
 		s.serveRollingBeta(w, r, sym)
+	case "sectorBeta":
+		s.serveSectorBeta(w, r, sym)
 	case "keymetric":
 		s.serveAnnualField(w, r, sym, fmpFieldFor(field, ep), "keymetric")
 	case "ratio":
@@ -225,6 +263,34 @@ func (s *Server) serveRollingBeta(w http.ResponseWriter, r *http.Request, sym st
 		return
 	}
 	json.NewEncoder(w).Encode(series)
+}
+
+// serveSectorBeta resolves the security's sector via FMP /profile, maps it
+// to the SPDR sector ETF, and emits that ETF's rolling beta vs SPY. The
+// user-side use is the spread test: when sectorBeta and beta diverge, the
+// move is single-name; when they track, the whole sector is repricing.
+func (s *Server) serveSectorBeta(w http.ResponseWriter, r *http.Request, sym string) {
+	raw, err := s.news.GetProfile(r.Context(), sym)
+	if err != nil {
+		http.Error(w, "fmp profile error", http.StatusBadGateway)
+		return
+	}
+	// FMP returns an array even for a single-symbol profile lookup.
+	var rows []struct {
+		Sector string `json:"sector"`
+	}
+	if err := json.Unmarshal(raw, &rows); err != nil || len(rows) == 0 {
+		http.Error(w, "no profile data", http.StatusUnprocessableEntity)
+		return
+	}
+	etf := sectorETF(rows[0].Sector)
+	if etf == "" {
+		http.Error(w, "unknown sector: "+rows[0].Sector, http.StatusUnprocessableEntity)
+		return
+	}
+	// Reuse the same rolling-beta machinery the bare `.beta` field uses —
+	// the math is symmetric in the target, so we just hand it the ETF.
+	s.serveRollingBeta(w, r, etf)
 }
 
 // rollingBeta returns [{date, value}] daily beta for the trailing window

--- a/internal/server/fundamentals_test.go
+++ b/internal/server/fundamentals_test.go
@@ -39,3 +39,33 @@ func TestRollingBeta_NotEnoughData(t *testing.T) {
 		t.Fatal("expected error for insufficient history, got nil")
 	}
 }
+
+func TestSectorETF(t *testing.T) {
+	cases := map[string]string{
+		"Technology":             "XLK",
+		"information technology": "XLK",
+		"Health Care":            "XLV",
+		"Healthcare":             "XLV",
+		"Financials":             "XLF",
+		"Financial Services":     "XLF",
+		"Consumer Cyclical":      "XLY",
+		"Consumer Discretionary": "XLY",
+		"Consumer Defensive":     "XLP",
+		"Consumer Staples":       "XLP",
+		"Energy":                 "XLE",
+		"Industrials":            "XLI",
+		"Utilities":              "XLU",
+		"Materials":              "XLB",
+		"Basic Materials":        "XLB",
+		"Real Estate":            "XLRE",
+		"Communication Services": "XLC",
+		"  Technology  ":         "XLK", // whitespace tolerance
+		"unknown sector":         "",    // graceful miss
+		"":                       "",
+	}
+	for sector, want := range cases {
+		if got := sectorETF(sector); got != want {
+			t.Errorf("sectorETF(%q) = %q, want %q", sector, got, want)
+		}
+	}
+}

--- a/tests/e2e/historical_test.go
+++ b/tests/e2e/historical_test.go
@@ -89,6 +89,49 @@ func TestSmoke_HistoricalBeta(t *testing.T) {
 	}
 }
 
+// :add XLK.beta — the rolling-beta math is symmetric in the target, so an
+// ETF should produce a valid series too. Locks in the behaviour relied on
+// by the sectorBeta resolver below.
+func TestSmoke_HistoricalBetaETF(t *testing.T) {
+	resp := get(t, "/api/historical/financial/XLK.beta")
+	defer resp.Body.Close()
+	assertStatus(t, resp, 200)
+	var rows []map[string]any
+	json.NewDecoder(resp.Body).Decode(&rows)
+	if len(rows) == 0 {
+		t.Fatal("expected XLK beta data points")
+	}
+	// Sector ETF betas hug 1.0 (by construction — they are subsets of SPY).
+	// XLK is the spiciest of the SPDRs but still well inside [0, 2].
+	first, ok := rows[0]["value"].(float64)
+	if !ok {
+		t.Fatalf("expected numeric beta value, got %T", rows[0]["value"])
+	}
+	if first < 0 || first > 2 {
+		t.Errorf("XLK beta outside expected range [0, 2]: %f", first)
+	}
+}
+
+// :add AAPL.sectorBeta — resolves AAPL → Technology → XLK and emits XLK's
+// rolling beta. Validates both the sector map and the resolver plumbing.
+func TestSmoke_HistoricalSectorBeta(t *testing.T) {
+	resp := get(t, "/api/historical/financial/AAPL.sectorBeta")
+	defer resp.Body.Close()
+	assertStatus(t, resp, 200)
+	var rows []map[string]any
+	json.NewDecoder(resp.Body).Decode(&rows)
+	if len(rows) == 0 {
+		t.Fatal("expected sectorBeta data points")
+	}
+	first, ok := rows[0]["value"].(float64)
+	if !ok {
+		t.Fatalf("expected numeric sectorBeta value, got %T", rows[0]["value"])
+	}
+	if first < 0 || first > 2 {
+		t.Errorf("sectorBeta outside expected range [0, 2]: %f", first)
+	}
+}
+
 func trim(b []byte) string {
 	s := string(b)
 	if len(s) > 200 {


### PR DESCRIPTION
## Summary
- New `sectorBeta` field: `:add AAPL.sectorBeta` resolves AAPL → Technology → XLK, then plots XLK's rolling 1Y beta vs SPY
- `:add XLK.beta` already works today (rolling-beta math is symmetric in the target); locked in with a smoke test
- Sector→ETF map covers all 11 GICS sectors plus FMP's naming variants ("Financial Services", "Healthcare", "Consumer Cyclical")

## How it reads
Overlay both lines on a sketch:
- **lines track** → sector is repricing macro-sensitively; the move is regime-wide
- **lines diverge** → the move is idiosyncratic to this name

A spread series (security beta − sector beta) is a natural client-side derivation but kept out of this PR — the two lines are the building blocks.

## Test plan
- [x] `make test` — new unit test `TestSectorETF` covers all 11 sectors + FMP variants + whitespace tolerance + graceful miss
- [x] `make smoke` — three beta tests (AAPL.beta, XLK.beta, AAPL.sectorBeta) all green
- [x] Beta values land in expected ranges (sector ETFs hug 1.0 by construction)

Closes #78