### PR TITLE
feat(crypto): crypto info page + SEC-skip for non-stocks

### DIFF
--- a/internal/agent/trading/analysts.go
+++ b/internal/agent/trading/analysts.go
@@ -17,6 +17,7 @@ import (
 
 	"stocktopus/internal/model"
 	"stocktopus/internal/news"
+	"stocktopus/internal/store"
 )
 
 // AnalystRunner executes the 4 analyst agents in parallel using Ollama.
@@ -27,6 +28,33 @@ type AnalystRunner struct {
 	agentsDir   string
 	client      *http.Client
 	logger      *slog.Logger
+
+	// store is optional — when set, the runner consults the cached
+	// security_types row to skip SEC-filing fetches for non-stock
+	// symbols (crypto / forex / index / etf), saving an FMP roundtrip
+	// per analyst on every run.
+	store *store.Store
+}
+
+// SetStore wires an optional store on an already-constructed runner.
+// Used by the pipeline so SEC-skip lookups don't require a constructor
+// change. nil is allowed; a nil store means the runner falls back to
+// full-stock behaviour for every symbol.
+func (ar *AnalystRunner) SetStore(s *store.Store) { ar.store = s }
+
+// skipSECForSymbol returns true when the analyst should bypass FMP's
+// SEC filing fetch — crypto / forex / index / etf don't file with
+// the SEC. Falls back to false when the store hasn't seen the symbol
+// yet (worst case: one wasted FMP call, response is empty).
+func (ar *AnalystRunner) skipSECForSymbol(symbol string) bool {
+	if ar.store == nil {
+		return false
+	}
+	switch ar.store.GetSecurityType(symbol) {
+	case "crypto", "forex", "index", "etf":
+		return true
+	}
+	return false
 }
 
 func NewAnalystRunner(fmp *news.Client, ollamaHost, ollamaModel, agentsDir string, logger *slog.Logger) *AnalystRunner {
@@ -225,11 +253,16 @@ func (ar *AnalystRunner) runFundamentals(ctx context.Context, symbol string) (An
 		{"ratios", func() (json.RawMessage, error) { return ar.fmp.GetRatiosTTM(ctx, symbol) }},
 		{"estimates", func() (json.RawMessage, error) { return ar.fmp.GetAnalystEstimates(ctx, symbol, 3) }},
 		{"peers", func() (json.RawMessage, error) { return ar.fmp.GetPeers(ctx, symbol) }},
-		{"sec_filings", func() (json.RawMessage, error) {
+	}
+	if !ar.skipSECForSymbol(symbol) {
+		fetches = append(fetches, struct {
+			name string
+			fn   func() (json.RawMessage, error)
+		}{"sec_filings", func() (json.RawMessage, error) {
 			secFrom := time.Now().UTC().AddDate(-1, 0, 0).Format("2006-01-02")
 			secTo := time.Now().UTC().Format("2006-01-02")
 			return ar.fmp.GetSECFilings(ctx, symbol, secFrom, secTo)
-		}},
+		}})
 	}
 
 	results := make([]fetchResult, len(fetches))
@@ -304,14 +337,21 @@ func (ar *AnalystRunner) runNews(ctx context.Context, symbol string) (AnalystRep
 	to := time.Now().UTC().Format("2006-01-02")
 	from := time.Now().UTC().AddDate(0, 0, -14).Format("2006-01-02")
 
-	// Fetch company news, press releases, macro news, AND SEC filings in parallel
+	// Fetch company news, press releases, macro news, AND (for stocks
+	// only) SEC filings in parallel. Crypto / forex / index / etf skip
+	// the SEC fetch since they don't file.
 	var stockItems, pressItems, macroItems []model.NewsItem
 	var secData json.RawMessage
 	var stockErr error
 	var wg sync.WaitGroup
 	var profile string
 
-	wg.Add(5)
+	skipSEC := ar.skipSECForSymbol(symbol)
+	if skipSEC {
+		wg.Add(4)
+	} else {
+		wg.Add(5)
+	}
 	go func() {
 		defer wg.Done()
 		stockItems, stockErr = ar.fmp.GetNewsWithDates(ctx, news.Stock, symbol, 0, 20, from, to)
@@ -328,12 +368,14 @@ func (ar *AnalystRunner) runNews(ctx context.Context, symbol string) (AnalystRep
 		defer wg.Done()
 		profile = ar.fetchProfile(ctx, symbol)
 	}()
-	go func() {
-		defer wg.Done()
-		secFrom := time.Now().UTC().AddDate(0, -3, 0).Format("2006-01-02")
-		secTo := time.Now().UTC().Format("2006-01-02")
-		secData, _ = ar.fmp.GetSECFilings(ctx, symbol, secFrom, secTo)
-	}()
+	if !skipSEC {
+		go func() {
+			defer wg.Done()
+			secFrom := time.Now().UTC().AddDate(0, -3, 0).Format("2006-01-02")
+			secTo := time.Now().UTC().Format("2006-01-02")
+			secData, _ = ar.fmp.GetSECFilings(ctx, symbol, secFrom, secTo)
+		}()
+	}
 	wg.Wait()
 
 	if stockErr != nil {

--- a/internal/agent/trading/pipeline.go
+++ b/internal/agent/trading/pipeline.go
@@ -40,6 +40,7 @@ type TradingPipelineConfig struct {
 
 func NewTradingPipeline(cfg TradingPipelineConfig, fmp *news.Client, st *store.Store, logger *slog.Logger) *TradingPipeline {
 	analysts := NewAnalystRunner(fmp, cfg.OllamaHost, cfg.OllamaModel, cfg.AgentsDir, logger)
+	analysts.SetStore(st) // enables SEC-skip for crypto / forex / index / etf
 	debater := NewDebater(cfg.OllamaHost, cfg.OllamaModel, cfg.DebateRounds, logger)
 	people := NewPeopleExtractor(cfg.OllamaHost, cfg.OllamaModel, fmp, st, logger)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -148,6 +148,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/article/entities", s.handleArticleEntities)
 	mux.HandleFunc("GET /api/chart/intraday/{interval}/{symbol}", s.handleChartIntraday)
 	mux.HandleFunc("GET /api/security/{symbol}/profile", s.handleSecurityProfile)
+	mux.HandleFunc("GET /api/security/{symbol}/quote", s.handleSecurityQuote)
 	mux.HandleFunc("GET /api/security/{symbol}/metrics", s.handleSecurityMetrics)
 	mux.HandleFunc("GET /api/security/{symbol}/financials", s.handleSecurityFinancials)
 	mux.HandleFunc("GET /api/security/{symbol}/estimates", s.handleSecurityEstimates)
@@ -466,6 +467,16 @@ func (s *Server) handleNewsAPI(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleSecurityProfile(w http.ResponseWriter, r *http.Request) {
 	s.proxyFMP(w, r, func(sym string) (json.RawMessage, error) {
 		return s.news.GetProfile(r.Context(), sym)
+	})
+}
+
+// handleSecurityQuote exposes /stable/quote — the universal realtime
+// snapshot that works across stocks, ETFs, crypto, forex, indices. The
+// crypto / forex pages rely on it because /stable/profile returns empty
+// for those types.
+func (s *Server) handleSecurityQuote(w http.ResponseWriter, r *http.Request) {
+	s.proxyFMP(w, r, func(sym string) (json.RawMessage, error) {
+		return s.news.GetQuote(r.Context(), sym)
 	})
 }
 

--- a/internal/server/static/crypto.js
+++ b/internal/server/static/crypto.js
@@ -1,0 +1,448 @@
+// crypto.js — info-page-equivalent JS for /crypto/{symbol}. Mirrors the
+// shape of info.js (tab switching, content rendering, vim tabs via the
+// shared terminal.js handler) but with crypto-shaped data:
+//   - Overview: price, 24h/7d/30d %, volume, exchange, description
+//   - News: only Crypto, Articles, General categories
+//   - AI Analysis: shared trading pipeline (server-side gates SEC fetches)
+//   - Peer Coins: curated top-10 with 1M sparklines
+//
+// Stock fundamentals tabs (Financials / Estimates / SEC / Sector) are
+// dropped — they're meaningless for a coin.
+
+(function () {
+    var container = document.getElementById('info-content');
+    if (!container) return;
+    var symbol = container.dataset.symbol;
+    var currentTab = 'overview';
+
+    function esc(s) {
+        if (s == null) return '';
+        return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    function pct(n) {
+        if (n == null || isNaN(n)) return '—';
+        return (+n).toFixed(2) + '%';
+    }
+
+    function pctClass(n) {
+        if (n == null || isNaN(n)) return '';
+        return n >= 0 ? 'price-up' : 'price-down';
+    }
+
+    function fmtVol(n) {
+        if (!n) return '—';
+        if (n >= 1e12) return (n / 1e12).toFixed(2) + 'T';
+        if (n >= 1e9) return (n / 1e9).toFixed(2) + 'B';
+        if (n >= 1e6) return (n / 1e6).toFixed(2) + 'M';
+        if (n >= 1e3) return (n / 1e3).toFixed(2) + 'K';
+        return n.toFixed(0);
+    }
+
+    function fmtPrice(n) {
+        if (n == null || isNaN(n)) return '—';
+        if (n >= 1000) return n.toFixed(2);
+        if (n >= 1) return n.toFixed(4);
+        return n.toFixed(6);
+    }
+
+    // ── Tab Switching ──
+
+    var tabsEl = document.getElementById('info-tabs');
+    if (tabsEl) {
+        tabsEl.querySelectorAll('.info-tab').forEach(function (tab) {
+            tab.onclick = function () {
+                tabsEl.querySelectorAll('.info-tab').forEach(function (t) { t.classList.remove('active'); });
+                tab.classList.add('active');
+                loadTab(tab.dataset.tab);
+            };
+        });
+    }
+
+    window._infoJumpToTab = function (n) {
+        var allTabs = tabsEl.querySelectorAll('.info-tab');
+        if (n < allTabs.length) allTabs[n].click();
+    };
+
+    function loadTab(tab) {
+        currentTab = tab;
+        container.innerHTML = '<p class="empty-state">Loading...</p>';
+        try {
+            switch (tab) {
+                case 'overview': loadOverview(); break;
+                case 'news': loadNews(); break;
+                case 'ai': loadAI(); break;
+                case 'peers': loadPeers(); break;
+            }
+        } catch (e) {
+            console.error('Crypto tab load error:', tab, e);
+            container.innerHTML = '<p class="empty-state">Failed to load ' + tab + '</p>';
+        }
+    }
+
+    // ── Overview ──
+
+    function loadOverview() {
+        // Profile is usually empty for crypto, but try in case the coin is
+        // a wrapped/tokenised security with metadata. Quote is the load-
+        // bearing call — always returns a row for tradable symbols.
+        Promise.all([
+            fetch('/api/security/' + symbol + '/quote').then(function (r) { return r.json(); }).catch(function () { return []; }),
+            fetch('/api/security/' + symbol + '/profile').then(function (r) { return r.json(); }).catch(function () { return []; }),
+            fetch('/api/historical/price/' + symbol).then(function (r) { return r.json(); }).catch(function () { return []; }),
+        ]).then(function (results) {
+            var q = (results[0] && results[0][0]) || {};
+            var p = (results[1] && results[1][0]) || {};
+            // history is descending by date; index 0 = latest, 1 = -1d, …
+            var hist = results[2] || [];
+
+            var price = q.price;
+            var ch24 = q.changePercentage;
+            var ch7d = pctChangeFromHistory(hist, 7);
+            var ch30d = pctChangeFromHistory(hist, 30);
+
+            var html = '';
+            html += '<div class="crypto-header">';
+            html += '<span class="crypto-name">' + esc(q.name || p.companyName || symbol) + '</span>';
+            html += '<span class="crypto-exchange">' + esc(q.exchange || p.exchange || 'CRYPTO') + '</span>';
+            html += '</div>';
+
+            html += '<div class="crypto-price-row">';
+            html += '<span class="crypto-price">$' + fmtPrice(price) + '</span>';
+            html += '<span class="crypto-change ' + pctClass(ch24) + '">24h ' + pct(ch24) + '</span>';
+            html += '<span class="crypto-change ' + pctClass(ch7d) + '">7d ' + pct(ch7d) + '</span>';
+            html += '<span class="crypto-change ' + pctClass(ch30d) + '">30d ' + pct(ch30d) + '</span>';
+            html += '</div>';
+
+            html += '<div class="crypto-stats">';
+            html += statCell('Volume (24h)', fmtVol(q.volume));
+            html += statCell('Day Range', q.dayLow && q.dayHigh ? '$' + fmtPrice(q.dayLow) + ' – $' + fmtPrice(q.dayHigh) : '—');
+            html += statCell('52W Range', q.yearLow && q.yearHigh ? '$' + fmtPrice(q.yearLow) + ' – $' + fmtPrice(q.yearHigh) : '—');
+            html += statCell('Market Cap', q.marketCap ? '$' + fmtVol(q.marketCap) : '—');
+            html += statCell('50-day Avg', q.priceAvg50 ? '$' + fmtPrice(q.priceAvg50) : '—');
+            html += statCell('200-day Avg', q.priceAvg200 ? '$' + fmtPrice(q.priceAvg200) : '—');
+            html += '</div>';
+
+            // Inline 1Y price chart so the page lands with a glance-level
+            // context. Sketchpad / full chart is elsewhere via :graph.
+            html += '<div id="crypto-chart-1y" class="crypto-chart"></div>';
+
+            // Description from profile if FMP has one (rare for coins).
+            if (p.description) {
+                html += '<div class="crypto-desc">' + esc(p.description) + '</div>';
+            }
+
+            container.innerHTML = html;
+            renderOverviewChart(hist);
+        }).catch(function (err) {
+            console.error('Crypto overview error:', err);
+            container.innerHTML = '<p class="empty-state">Failed to load overview</p>';
+        });
+    }
+
+    function statCell(label, value) {
+        return '<div class="crypto-stat"><span class="crypto-stat-label">' + esc(label) + '</span><span class="crypto-stat-value">' + esc(value) + '</span></div>';
+    }
+
+    function pctChangeFromHistory(hist, daysAgo) {
+        if (!hist || hist.length <= daysAgo) return null;
+        var latest = hist[0].price;
+        var past = hist[daysAgo].price;
+        if (!past) return null;
+        return ((latest - past) / past) * 100;
+    }
+
+    function renderOverviewChart(hist) {
+        var el = document.getElementById('crypto-chart-1y');
+        if (!el || !window.LightweightCharts || !hist || hist.length === 0) return;
+        var slice = hist.slice(0, Math.min(365, hist.length));
+        var data = slice.map(function (d) { return { time: d.date, value: d.price }; }).reverse();
+        var chart = LightweightCharts.createChart(el, {
+            width: el.clientWidth, height: 240,
+            layout: { background: { color: 'transparent' }, textColor: '#9ca3af', attributionLogo: false },
+            grid: { vertLines: { color: 'rgba(60,60,60,0.3)' }, horzLines: { color: 'rgba(60,60,60,0.3)' } },
+            rightPriceScale: { borderColor: 'rgba(80,80,80,0.5)' },
+            timeScale: { borderColor: 'rgba(80,80,80,0.5)' },
+        });
+        var first = data[0].value, last = data[data.length - 1].value;
+        var color = last >= first ? '#00cc66' : '#ff4444';
+        var series = chart.addSeries(LightweightCharts.AreaSeries, {
+            lineColor: color,
+            topColor: color === '#00cc66' ? 'rgba(0, 204, 102, 0.2)' : 'rgba(255, 68, 68, 0.2)',
+            bottomColor: 'transparent', lineWidth: 1, priceLineVisible: false,
+        });
+        series.setData(data);
+        chart.timeScale().fitContent();
+    }
+
+    // ── News ──
+
+    var NEWS_CATS = [
+        { key: 'crypto', label: 'Crypto' },
+        { key: 'articles', label: 'Articles' },
+        { key: 'general', label: 'General' },
+    ];
+    var activeNewsCat = 'crypto';
+
+    function loadNews() {
+        var html = '<div class="news-sub-tabs" id="news-sub-tabs">';
+        NEWS_CATS.forEach(function (c) {
+            html += '<button class="info-sub-tab' + (c.key === activeNewsCat ? ' active' : '') + '" data-cat="' + esc(c.key) + '">' + esc(c.label) + '</button>';
+        });
+        html += '</div><div id="news-cards" class="news-cards"><p class="empty-state">Loading...</p></div>';
+        container.innerHTML = html;
+
+        container.querySelectorAll('.info-sub-tab').forEach(function (tab) {
+            tab.onclick = function () {
+                container.querySelectorAll('.info-sub-tab').forEach(function (t) { t.classList.remove('active'); });
+                tab.classList.add('active');
+                activeNewsCat = tab.dataset.cat;
+                loadNewsCategory(activeNewsCat);
+            };
+        });
+        loadNewsCategory(activeNewsCat);
+    }
+
+    function loadNewsCategory(cat) {
+        var listEl = document.getElementById('news-cards');
+        listEl.innerHTML = '<p class="empty-state">Loading...</p>';
+        // crypto news is global by default; symbol filter narrows it.
+        var url = '/api/news/' + cat + '?symbol=' + encodeURIComponent(symbol) + '&limit=20';
+        fetch(url).then(function (r) { return r.json(); }).then(function (items) {
+            if (!items || items.length === 0) {
+                // Retry without symbol filter — crypto news rarely tags
+                // individual coins; fall back to the broad feed.
+                fetch('/api/news/' + cat + '?limit=20')
+                    .then(function (r) { return r.json(); })
+                    .then(renderNewsList);
+                return;
+            }
+            renderNewsList(items);
+        }).catch(function () {
+            listEl.innerHTML = '<p class="empty-state">Failed to load news</p>';
+        });
+    }
+
+    function renderNewsList(items) {
+        var listEl = document.getElementById('news-cards');
+        if (!items || items.length === 0) {
+            listEl.innerHTML = '<p class="empty-state">No news</p>';
+            return;
+        }
+        var html = '';
+        items.forEach(function (n) {
+            var url = n.url || '#';
+            var d = n.publishedDate ? new Date(n.publishedDate).toLocaleString() : '';
+            html += '<div class="news-card">';
+            html += '<div class="news-card-title"><a href="' + esc(url) + '" target="_blank" rel="noopener">' + esc(n.title || '—') + '</a></div>';
+            html += '<div class="news-card-meta"><span>' + esc(n.site || n.publisher || '') + '</span><span>' + esc(d) + '</span></div>';
+            if (n.text || n.snippet) {
+                html += '<div class="news-card-snippet">' + esc((n.text || n.snippet).slice(0, 240)) + '…</div>';
+            }
+            html += '</div>';
+        });
+        listEl.innerHTML = html;
+    }
+
+    // ── AI Analysis ──
+
+    function loadAI() {
+        Promise.all([
+            fetch('/api/trading/cost').then(function (r) { return r.json(); }).catch(function () { return { available: false }; }),
+            fetch('/api/security/' + symbol + '/trading/result').then(function (r) { return r.json(); }).then(function (d) { return d && d.status !== 'none' ? d : null; }).catch(function () { return null; }),
+        ]).then(function (results) {
+            var costInfo = results[0];
+            var tradingResult = results[1];
+
+            var html = '<div class="trading-header trading-vim-item" data-trading-vim="btn" tabindex="0">';
+            html += '<span class="ai-section-title" style="margin:0">Deep Analysis — Multi-Agent Pipeline</span>';
+            html += renderTradingButton(costInfo, tradingResult);
+            html += '</div>';
+
+            if (tradingResult && tradingResult.analystReports && tradingResult.analystReports.length > 0) {
+                html += renderTradingResultLite(tradingResult);
+            } else {
+                html += '<p class="empty-state">No analysis yet. SEC + competitor analysts are skipped for crypto.</p>';
+            }
+            container.innerHTML = html;
+            wireTradingButton();
+            if (tradingResult && !isFinished(tradingResult)) pollTradingStatus();
+        });
+    }
+
+    function isFinished(result) {
+        return result && result.finishedAt && !result.finishedAt.startsWith('0001');
+    }
+
+    function renderTradingButton(costInfo, tradingResult) {
+        var isRunning = tradingResult && !isFinished(tradingResult) && tradingResult.startedAt;
+        var costStr = costInfo && costInfo.available ? 'Est. $' + costInfo.estimatedCost.toFixed(3) : '';
+        var html = '';
+        if (isRunning) {
+            html += '<button class="trading-btn trading-btn-running" disabled>'
+                + '<span class="spinner" style="width:12px;height:12px;display:inline-block"></span> Running…</button>';
+        } else {
+            html += '<button class="trading-btn" id="trading-analyze-btn">&#129302; Run Deep Analysis</button>';
+        }
+        if (costStr) html += '<span class="trading-cost">' + esc(costStr) + '</span>';
+        if (isFinished(tradingResult) && tradingResult.totalCostUsd !== undefined) {
+            html += '<span class="trading-actual-cost">Actual: $' + tradingResult.totalCostUsd.toFixed(4) + '</span>';
+        }
+        return html;
+    }
+
+    function wireTradingButton() {
+        var btn = document.getElementById('trading-analyze-btn');
+        if (!btn) return;
+        btn.onclick = function () {
+            btn.disabled = true;
+            btn.innerHTML = '<span class="spinner" style="width:12px;height:12px;display:inline-block"></span> Starting…';
+            fetch('/api/security/' + symbol + '/trading/analyze', { method: 'POST' })
+                .then(function (r) { return r.json(); })
+                .then(function (resp) {
+                    if (resp.status === 'started' || resp.status === 'already_running') pollTradingStatus();
+                })
+                .catch(function () { btn.disabled = false; btn.textContent = 'Run Deep Analysis'; });
+        };
+    }
+
+    var tradingPollInterval = null;
+    function pollTradingStatus() {
+        if (tradingPollInterval) clearInterval(tradingPollInterval);
+        tradingPollInterval = setInterval(function () {
+            if (currentTab !== 'ai') { clearInterval(tradingPollInterval); return; }
+            fetch('/api/security/' + symbol + '/trading/result')
+                .then(function (r) { return r.ok ? r.json() : null; })
+                .then(function (result) {
+                    if (!result) return;
+                    if (isFinished(result)) {
+                        clearInterval(tradingPollInterval);
+                        loadAI();
+                    }
+                });
+        }, 3000);
+    }
+
+    function renderTradingResultLite(result) {
+        var html = '<div class="trading-analysts">';
+        result.analystReports.forEach(function (r) {
+            var outlookClass = r.outlook === 'bullish' ? 'price-up' : r.outlook === 'bearish' ? 'price-down' : '';
+            html += '<div class="trading-analyst-card trading-vim-item">';
+            html += '<div class="trading-analyst-header">';
+            html += '<span class="trading-analyst-name">' + esc(r.analyst) + '</span>';
+            html += '<span class="trading-analyst-outlook ' + outlookClass + '">' + esc(r.outlook || 'neutral') + '</span>';
+            html += '</div>';
+            html += '<div class="trading-analyst-body">';
+            if (r.summary) html += '<p class="ai-text">' + esc(r.summary) + '</p>';
+            if (r.keyPoints && r.keyPoints.length) {
+                html += '<ul class="ai-list">';
+                r.keyPoints.forEach(function (p) { html += '<li>' + esc(p) + '</li>'; });
+                html += '</ul>';
+            }
+            html += '</div></div>';
+        });
+        html += '</div>';
+        return html;
+    }
+
+    // ── Peer Coins ──
+
+    // Curated top-10 by market cap. Static list — same pattern as the
+    // sectorETFs map in fundamentals.go. Update as rankings shift.
+    var PEER_COINS = [
+        'BTCUSD', 'ETHUSD', 'SOLUSD', 'BNBUSD', 'XRPUSD',
+        'ADAUSD', 'AVAXUSD', 'DOTUSD', 'MATICUSD', 'LINKUSD',
+    ];
+
+    function loadPeers() {
+        var html = '<div class="sector-section-title">Top Coins by Market Cap</div>';
+        html += '<table class="fin-table peer-table" id="peer-table"><thead><tr>';
+        html += '<th>Coin</th><th>Name</th><th>Price</th><th>24h</th><th>Market Cap</th><th>1M</th>';
+        html += '</tr></thead><tbody>';
+        PEER_COINS.forEach(function (sym) {
+            var isCurrent = sym === symbol;
+            html += '<tr class="peer-row' + (isCurrent ? ' peer-current' : '') + '" data-symbol="' + esc(sym) + '">';
+            html += '<td><span class="sym-link">' + esc(sym) + '</span></td>';
+            html += '<td data-cell="name">—</td>';
+            html += '<td data-cell="price">—</td>';
+            html += '<td data-cell="ch24">—</td>';
+            html += '<td data-cell="mcap">—</td>';
+            html += '<td><div class="peer-spark" data-spark-sym="' + esc(sym) + '"></div></td>';
+            html += '</tr>';
+        });
+        html += '</tbody></table>';
+        container.innerHTML = html;
+
+        // Click → navigate to that coin's crypto page.
+        container.querySelectorAll('.peer-row').forEach(function (row) {
+            row.onclick = function () {
+                var sym = row.dataset.symbol;
+                if (sym) window.location.href = '/crypto/' + sym;
+            };
+        });
+
+        // Fill quotes in parallel — one fetch per coin keeps the code
+        // simple and the request count tiny.
+        PEER_COINS.forEach(function (sym) {
+            fetch('/api/security/' + sym + '/quote')
+                .then(function (r) { return r.json(); })
+                .then(function (rows) {
+                    if (!rows || !rows[0]) return;
+                    var q = rows[0];
+                    var row = container.querySelector('.peer-row[data-symbol="' + sym + '"]');
+                    if (!row) return;
+                    row.querySelector('[data-cell="name"]').textContent = q.name || '';
+                    row.querySelector('[data-cell="price"]').textContent = '$' + fmtPrice(q.price);
+                    var ch24 = q.changePercentage;
+                    var chEl = row.querySelector('[data-cell="ch24"]');
+                    chEl.textContent = pct(ch24);
+                    chEl.classList.add(pctClass(ch24));
+                    row.querySelector('[data-cell="mcap"]').textContent = q.marketCap ? '$' + fmtVol(q.marketCap) : '—';
+                });
+        });
+
+        loadPeerSparklines();
+    }
+
+    function loadPeerSparklines() {
+        function tryRender() {
+            if (!window.LightweightCharts) { setTimeout(tryRender, 200); return; }
+            var from = new Date(); from.setMonth(from.getMonth() - 1);
+            var fromStr = from.toISOString().slice(0, 10);
+            var toStr = new Date().toISOString().slice(0, 10);
+
+            container.querySelectorAll('.peer-spark').forEach(function (el) {
+                var sym = el.dataset.sparkSym;
+                if (!sym) return;
+                fetch('/api/chart/eod/' + sym + '?from=' + fromStr + '&to=' + toStr)
+                    .then(function (r) { return r.json(); })
+                    .then(function (data) {
+                        if (!data || data.length < 2) return;
+                        var first = data[0].close, last = data[data.length - 1].close;
+                        var color = last >= first ? '#00cc66' : '#ff4444';
+                        var chart = LightweightCharts.createChart(el, {
+                            width: 80, height: 24,
+                            layout: { background: { color: 'transparent' }, textColor: 'transparent', attributionLogo: false },
+                            grid: { vertLines: { visible: false }, horzLines: { visible: false } },
+                            rightPriceScale: { visible: false }, timeScale: { visible: false },
+                            handleScroll: false, handleScale: false,
+                            crosshair: { vertLine: { visible: false }, horzLine: { visible: false } },
+                        });
+                        var series = chart.addSeries(LightweightCharts.AreaSeries, {
+                            lineColor: color,
+                            topColor: color === '#00cc66' ? 'rgba(0, 204, 102, 0.15)' : 'rgba(255, 68, 68, 0.15)',
+                            bottomColor: 'transparent', lineWidth: 1,
+                            priceLineVisible: false, lastValueVisible: false,
+                        });
+                        series.setData(data.map(function (d) { return { time: d.date, value: d.close }; }));
+                        chart.timeScale().fitContent();
+                    }).catch(function () {});
+            });
+        }
+        tryRender();
+    }
+
+    // ── Init ──
+
+    loadTab('overview');
+})();

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -1048,6 +1048,80 @@ body {
     letter-spacing: 0.5px;
 }
 
+/* ── /crypto/{symbol} page ── */
+.crypto-header {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+.crypto-name {
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+.crypto-exchange {
+    font-size: 10px;
+    color: var(--text-muted);
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+}
+.crypto-price-row {
+    display: flex;
+    align-items: baseline;
+    gap: 16px;
+    margin: 8px 0 16px 0;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--border);
+}
+.crypto-price {
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+}
+.crypto-change {
+    font-size: 12px;
+    font-family: var(--font-mono);
+}
+.crypto-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 6px;
+    margin-bottom: 16px;
+}
+.crypto-stat {
+    display: flex;
+    flex-direction: column;
+    padding: 6px 8px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 2px;
+}
+.crypto-stat-label {
+    font-size: 10px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.crypto-stat-value {
+    font-size: 13px;
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+    margin-top: 2px;
+}
+.crypto-chart {
+    margin: 12px 0;
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
+}
+.crypto-desc {
+    margin-top: 12px;
+    font-size: 12px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
 .peer-table .sym-link {
     color: var(--blue);
     font-weight: 700;

--- a/internal/server/templates/crypto.html
+++ b/internal/server/templates/crypto.html
@@ -9,6 +9,7 @@
     <button class="info-tab" data-tab="peers"><span class="tab-key">4</span> Peer Coins</button>
 </div>
 <div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
-    <p class="empty-state">Crypto page coming soon. Tracked in #99.</p>
+    <p class="empty-state">Loading...</p>
 </div>
+<script src="/static/crypto.js?v={{.AssetVersion}}"></script>
 {{end}}

--- a/tests/e2e/security_routing_test.go
+++ b/tests/e2e/security_routing_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -85,6 +86,38 @@ func TestSmoke_SecurityRouting_PerTypeRoutes(t *testing.T) {
 			assertContains(t, resp, "<html")
 		})
 	}
+}
+
+// /api/security/{sym}/quote serves the universal quote endpoint used by
+// the crypto page (and the routing type-resolver). Confirms the new
+// route + the FMP wrapper return a sane shape for a crypto symbol.
+func TestSmoke_SecurityQuote_Crypto(t *testing.T) {
+	resp := get(t, "/api/security/BTCUSD/quote")
+	defer resp.Body.Close()
+	assertStatus(t, resp, 200)
+	body, _ := io.ReadAll(resp.Body)
+	s := string(body)
+	if !strings.HasPrefix(strings.TrimSpace(s), "[") {
+		t.Fatalf("expected JSON array, got: %.200s", s)
+	}
+	if !strings.Contains(s, `"BTCUSD"`) {
+		t.Errorf("expected symbol BTCUSD in quote body, got: %.200s", s)
+	}
+	// FMP may emit `"exchange":"CRYPTO"` or `"exchange": "CRYPTO"`
+	// depending on the version — match either.
+	if !strings.Contains(s, `"CRYPTO"`) {
+		t.Errorf("expected exchange CRYPTO in quote body, got: %.200s", s)
+	}
+}
+
+// The crypto page template is wired to load /static/crypto.js — verify
+// the file is served by the static handler so the page actually has
+// behaviour, not just the HTML shell.
+func TestSmoke_SecurityRouting_CryptoStaticAsset(t *testing.T) {
+	resp := get(t, "/static/crypto.js")
+	defer resp.Body.Close()
+	assertStatus(t, resp, 200)
+	assertContains(t, resp, "crypto.js")
 }
 
 // Index symbols use '^' prefix — the resolver short-circuits without a


### PR DESCRIPTION
## Summary
Vertical slice for `/crypto/{sym}` on top of the foundation that merged in #103. Fills out the 4 tabs the page advertises plus a server-side gate so the analyst pipeline stops fetching SEC filings for crypto / forex / index / ETF symbols (they don't file).

### Tabs
- **Overview** — price, 24h / 7d / 30d %, volume, day / 52w range, market cap, 50d / 200d moving averages, inline 1Y price chart. 24h derives from `quote.changePercentage`; 7d / 30d derived client-side from `historical-price-eod`.
- **News** — only `Crypto`, `Articles`, `General` categories (drops `Stock` / `Forex` / `Press Releases` — irrelevant). Falls back to the broad feed when symbol-tagged crypto news is empty (FMP rarely tags individual coins).
- **AI Analysis** — existing trading-pipeline button + lite analyst panel render. Polling mirrors info.js's stock AI tab.
- **Peer Coins** — curated top-10 (BTC, ETH, SOL, BNB, XRP, ADA, AVAX, DOT, MATIC, LINK), each with a 1M sparkline reusing the `.peer-spark` pattern from the stock sector tab.

### Server-side: SEC-skip for non-stocks
`internal/agent/trading/analysts.go` — the analyst runner now consults the cached `security_types` row (foundation #98) and skips the FMP SEC-filings fetch in `runFundamentals` and `runNews` when the symbol is crypto / forex / index / etf. Saves one round-trip per analyst per run for non-stocks, where the response is empty anyway.

### New endpoint
`GET /api/security/{sym}/quote` — exposes the universal quote shape (the existing `/profile` is empty for crypto / forex). Used by the crypto overview and peer tabs.

## Test plan
- [x] `make test` — Go unit suite green
- [x] `make smoke` — full e2e suite green, including 3 new tests:
  - `/api/security/BTCUSD/quote` returns a 200 JSON array with `BTCUSD` + `CRYPTO`
  - `/static/crypto.js` served by static handler
  - existing routing tests still pass (foundation didn't regress)
- [x] Manual browser verification — visit `/crypto/BTCUSD` and confirm Overview / News / AI / Peer Coins all render

Closes #99
Parent: #97