### PR TITLE
feat(index): index info page (components + movers + AI)

### DIFF
--- a/internal/news/news.go
+++ b/internal/news/news.go
@@ -300,6 +300,33 @@ func (c *Client) GetETFInfo(ctx context.Context, symbol string) (json.RawMessage
 	return c.fetchJSON(ctx, "/stable/etf/info", params)
 }
 
+// GetIndexConstituents returns the component list for an equity index.
+// FMP serves these on per-index paths rather than a unified endpoint, so
+// we map the index symbol (^DJI / ^GSPC / ^IXIC) to the right path here.
+// Returns ([]any, nil) when the symbol isn't a known index.
+func (c *Client) GetIndexConstituents(ctx context.Context, symbol string) (json.RawMessage, error) {
+	endpoint := ""
+	switch strings.ToUpper(symbol) {
+	case "^DJI":
+		endpoint = "/stable/dowjones-constituent"
+	case "^GSPC":
+		endpoint = "/stable/sp500-constituent"
+	case "^IXIC":
+		endpoint = "/stable/nasdaq-constituent"
+	default:
+		return json.RawMessage("[]"), nil
+	}
+	return c.fetchJSON(ctx, endpoint, url.Values{})
+}
+
+// GetBatchQuote fetches realtime quotes for multiple symbols in one
+// call. FMP appears to cap the response at ~50 rows, so callers that
+// need more (e.g. S&P 500 movers) should chunk on the client.
+func (c *Client) GetBatchQuote(ctx context.Context, symbols []string) (json.RawMessage, error) {
+	params := url.Values{"symbols": {strings.Join(symbols, ",")}}
+	return c.fetchJSON(ctx, "/stable/batch-quote", params)
+}
+
 // GetKeyMetrics returns key financial metrics.
 func (c *Client) GetKeyMetrics(ctx context.Context, symbol string) (json.RawMessage, error) {
 	params := url.Values{"symbol": {symbol}, "limit": {"1"}}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -151,6 +151,8 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/security/{symbol}/quote", s.handleSecurityQuote)
 	mux.HandleFunc("GET /api/security/{symbol}/etf-holdings", s.handleETFHoldings)
 	mux.HandleFunc("GET /api/security/{symbol}/etf-info", s.handleETFInfo)
+	mux.HandleFunc("GET /api/security/{symbol}/index-constituents", s.handleIndexConstituents)
+	mux.HandleFunc("GET /api/batch-quote", s.handleBatchQuote)
 	mux.HandleFunc("GET /api/security/{symbol}/metrics", s.handleSecurityMetrics)
 	mux.HandleFunc("GET /api/security/{symbol}/financials", s.handleSecurityFinancials)
 	mux.HandleFunc("GET /api/security/{symbol}/estimates", s.handleSecurityEstimates)
@@ -497,6 +499,33 @@ func (s *Server) handleETFInfo(w http.ResponseWriter, r *http.Request) {
 	s.proxyFMP(w, r, func(sym string) (json.RawMessage, error) {
 		return s.news.GetETFInfo(r.Context(), sym)
 	})
+}
+
+// handleIndexConstituents returns the component list for ^DJI / ^GSPC /
+// ^IXIC. The index page's Components tab uses it; unknown index symbols
+// return an empty array (handled by GetIndexConstituents).
+func (s *Server) handleIndexConstituents(w http.ResponseWriter, r *http.Request) {
+	s.proxyFMP(w, r, func(sym string) (json.RawMessage, error) {
+		return s.news.GetIndexConstituents(r.Context(), sym)
+	})
+}
+
+// handleBatchQuote fronts /stable/batch-quote for client-side gainers/
+// losers derivation on the index page. Accepts ?symbols=A,B,C — clients
+// must chunk into ≤50 per call (FMP truncates beyond that).
+func (s *Server) handleBatchQuote(w http.ResponseWriter, r *http.Request) {
+	syms := r.URL.Query().Get("symbols")
+	if syms == "" {
+		http.Error(w, "missing symbols", http.StatusBadRequest)
+		return
+	}
+	raw, err := s.news.GetBatchQuote(r.Context(), strings.Split(syms, ","))
+	if err != nil {
+		http.Error(w, "fmp error", http.StatusBadGateway)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(raw)
 }
 
 func (s *Server) handleSecurityMetrics(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/static/index_page.js
+++ b/internal/server/static/index_page.js
@@ -1,0 +1,463 @@
+// index_page.js — /index/{symbol} page (^DJI, ^GSPC, ^IXIC). Mirrors
+// the shape of etf.js / crypto.js. Tabs: Overview, Components, Movers,
+// News, AI Analysis. Filename is index_page.js (not index.js) to keep
+// it visually distinct from any /static/index.html bundling that
+// might exist downstream.
+
+(function () {
+    var container = document.getElementById('info-content');
+    if (!container) return;
+    var symbol = container.dataset.symbol;
+    var currentTab = 'overview';
+
+    function esc(s) {
+        if (s == null) return '';
+        return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    function pct(n) {
+        if (n == null || isNaN(n)) return '—';
+        return (+n).toFixed(2) + '%';
+    }
+
+    function pctClass(n) {
+        if (n == null || isNaN(n)) return '';
+        return n >= 0 ? 'price-up' : 'price-down';
+    }
+
+    function fmtVol(n) {
+        if (!n) return '—';
+        if (n >= 1e12) return (n / 1e12).toFixed(2) + 'T';
+        if (n >= 1e9) return (n / 1e9).toFixed(2) + 'B';
+        if (n >= 1e6) return (n / 1e6).toFixed(2) + 'M';
+        if (n >= 1e3) return (n / 1e3).toFixed(2) + 'K';
+        return n.toFixed(0);
+    }
+
+    function fmtPrice(n) {
+        if (n == null || isNaN(n)) return '—';
+        if (n >= 10000) return n.toFixed(0);
+        if (n >= 100) return n.toFixed(2);
+        return n.toFixed(2);
+    }
+
+    // ── Tab Switching ──
+
+    var tabsEl = document.getElementById('info-tabs');
+    if (tabsEl) {
+        tabsEl.querySelectorAll('.info-tab').forEach(function (tab) {
+            tab.onclick = function () {
+                tabsEl.querySelectorAll('.info-tab').forEach(function (t) { t.classList.remove('active'); });
+                tab.classList.add('active');
+                loadTab(tab.dataset.tab);
+            };
+        });
+    }
+
+    window._infoJumpToTab = function (n) {
+        var allTabs = tabsEl.querySelectorAll('.info-tab');
+        if (n < allTabs.length) allTabs[n].click();
+    };
+
+    function loadTab(tab) {
+        currentTab = tab;
+        container.innerHTML = '<p class="empty-state">Loading...</p>';
+        try {
+            switch (tab) {
+                case 'overview': loadOverview(); break;
+                case 'components': loadComponents(); break;
+                case 'movers': loadMovers(); break;
+                case 'news': loadNews(); break;
+                case 'ai': loadAI(); break;
+            }
+        } catch (e) {
+            console.error('Index tab load error:', tab, e);
+            container.innerHTML = '<p class="empty-state">Failed to load ' + tab + '</p>';
+        }
+    }
+
+    // ── Cached constituents (shared between Components + Movers) ──
+
+    var _constituentsCache = null;
+    function fetchConstituents() {
+        if (_constituentsCache) return Promise.resolve(_constituentsCache);
+        return fetch('/api/security/' + encodeURIComponent(symbol) + '/index-constituents')
+            .then(function (r) { return r.json(); })
+            .then(function (rows) {
+                _constituentsCache = rows || [];
+                return _constituentsCache;
+            })
+            .catch(function () { return []; });
+    }
+
+    // ── Overview ──
+
+    function loadOverview() {
+        Promise.all([
+            fetch('/api/security/' + encodeURIComponent(symbol) + '/quote').then(function (r) { return r.json(); }).catch(function () { return []; }),
+            fetch('/api/historical/price/' + encodeURIComponent(symbol)).then(function (r) { return r.json(); }).catch(function () { return []; }),
+            fetchConstituents(),
+        ]).then(function (results) {
+            var q = (results[0] && results[0][0]) || {};
+            var hist = results[1] || [];
+            var components = results[2] || [];
+
+            var price = q.price;
+            var ch1d = q.changePercentage;
+            var chYTD = pctChangeFromHistoryYTD(hist);
+            var ch1Y = pctChangeFromHistory(hist, 252);
+
+            var html = '';
+            html += '<div class="crypto-header">';
+            html += '<span class="crypto-name">' + esc(q.name || symbol) + '</span>';
+            html += '<span class="crypto-exchange">INDEX</span>';
+            html += '</div>';
+
+            html += '<div class="crypto-price-row">';
+            html += '<span class="crypto-price">' + fmtPrice(price) + '</span>';
+            html += '<span class="crypto-change ' + pctClass(ch1d) + '">1d ' + pct(ch1d) + '</span>';
+            html += '<span class="crypto-change ' + pctClass(chYTD) + '">YTD ' + pct(chYTD) + '</span>';
+            html += '<span class="crypto-change ' + pctClass(ch1Y) + '">1y ' + pct(ch1Y) + '</span>';
+            html += '</div>';
+
+            html += '<div class="crypto-stats">';
+            html += statCell('Components', components.length || '—');
+            html += statCell('Day Range', q.dayLow && q.dayHigh ? fmtPrice(q.dayLow) + ' – ' + fmtPrice(q.dayHigh) : '—');
+            html += statCell('52W Range', q.yearLow && q.yearHigh ? fmtPrice(q.yearLow) + ' – ' + fmtPrice(q.yearHigh) : '—');
+            html += statCell('Volume', fmtVol(q.volume));
+            html += statCell('50-day Avg', q.priceAvg50 ? fmtPrice(q.priceAvg50) : '—');
+            html += statCell('200-day Avg', q.priceAvg200 ? fmtPrice(q.priceAvg200) : '—');
+            html += '</div>';
+
+            html += '<div id="index-chart-1y" class="crypto-chart"></div>';
+
+            container.innerHTML = html;
+            renderOverviewChart(hist);
+        }).catch(function (err) {
+            console.error('Index overview error:', err);
+            container.innerHTML = '<p class="empty-state">Failed to load overview</p>';
+        });
+    }
+
+    function statCell(label, value) {
+        return '<div class="crypto-stat"><span class="crypto-stat-label">' + esc(label) + '</span><span class="crypto-stat-value">' + esc(String(value)) + '</span></div>';
+    }
+
+    function pctChangeFromHistory(hist, daysAgo) {
+        if (!hist || hist.length <= daysAgo) return null;
+        var latest = hist[0].price;
+        var past = hist[daysAgo].price;
+        if (!past) return null;
+        return ((latest - past) / past) * 100;
+    }
+
+    function pctChangeFromHistoryYTD(hist) {
+        if (!hist || hist.length === 0) return null;
+        var latest = hist[0];
+        var year = (latest.date || '').slice(0, 4);
+        if (!year) return null;
+        var yearStart = null;
+        for (var i = hist.length - 1; i >= 0; i--) {
+            if ((hist[i].date || '').slice(0, 4) === year) {
+                yearStart = hist[i];
+                break;
+            }
+        }
+        if (!yearStart || !yearStart.price) return null;
+        return ((latest.price - yearStart.price) / yearStart.price) * 100;
+    }
+
+    function renderOverviewChart(hist) {
+        var el = document.getElementById('index-chart-1y');
+        if (!el || !window.LightweightCharts || !hist || hist.length === 0) return;
+        var slice = hist.slice(0, Math.min(252, hist.length));
+        var data = slice.map(function (d) { return { time: d.date, value: d.price }; }).reverse();
+        var chart = LightweightCharts.createChart(el, {
+            width: el.clientWidth, height: 240,
+            layout: { background: { color: 'transparent' }, textColor: '#9ca3af', attributionLogo: false },
+            grid: { vertLines: { color: 'rgba(60,60,60,0.3)' }, horzLines: { color: 'rgba(60,60,60,0.3)' } },
+            rightPriceScale: { borderColor: 'rgba(80,80,80,0.5)' },
+            timeScale: { borderColor: 'rgba(80,80,80,0.5)' },
+        });
+        var first = data[0].value, last = data[data.length - 1].value;
+        var color = last >= first ? '#00cc66' : '#ff4444';
+        var series = chart.addSeries(LightweightCharts.AreaSeries, {
+            lineColor: color,
+            topColor: color === '#00cc66' ? 'rgba(0, 204, 102, 0.2)' : 'rgba(255, 68, 68, 0.2)',
+            bottomColor: 'transparent', lineWidth: 1, priceLineVisible: false,
+        });
+        series.setData(data);
+        chart.timeScale().fitContent();
+    }
+
+    // ── Components ──
+
+    function loadComponents() {
+        fetchConstituents().then(function (rows) {
+            if (!rows || rows.length === 0) {
+                container.innerHTML = '<p class="empty-state">No constituents data — try ^DJI, ^GSPC, or ^IXIC</p>';
+                return;
+            }
+            var html = '<div class="sector-section-title">Components (' + rows.length + ')</div>';
+            html += '<table class="fin-table peer-table"><thead><tr>';
+            html += '<th>Ticker</th><th>Name</th><th>Sector</th><th>Sub-Sector</th><th>Added</th>';
+            html += '</tr></thead><tbody>';
+            rows.forEach(function (r) {
+                html += '<tr class="peer-row" data-symbol="' + esc(r.symbol) + '">';
+                html += '<td><span class="sym-link">' + esc(r.symbol) + '</span></td>';
+                html += '<td>' + esc(r.name || '') + '</td>';
+                html += '<td>' + esc(r.sector || '') + '</td>';
+                html += '<td>' + esc(r.subSector || '') + '</td>';
+                html += '<td>' + esc(r.dateFirstAdded || '') + '</td>';
+                html += '</tr>';
+            });
+            html += '</tbody></table>';
+            container.innerHTML = html;
+
+            container.querySelectorAll('.peer-row').forEach(function (row) {
+                row.onclick = function () {
+                    var sym = row.dataset.symbol;
+                    if (sym) window.location.href = '/security/' + sym;
+                };
+            });
+        });
+    }
+
+    // ── Movers ──
+
+    // FMP's batch-quote tops out around ~50 rows per call, so chunk
+    // the constituent list and merge. Sequential keeps the request
+    // rate low; the index pages aren't on the hot path.
+    function loadMovers() {
+        container.innerHTML = '<p class="empty-state">Fetching today’s constituent quotes…</p>';
+        fetchConstituents().then(function (rows) {
+            if (!rows || rows.length === 0) {
+                container.innerHTML = '<p class="empty-state">No constituents — movers unavailable</p>';
+                return;
+            }
+            var syms = rows.map(function (r) { return r.symbol; });
+            // Map ticker → display name for the rendered table.
+            var nameBySym = {};
+            rows.forEach(function (r) { nameBySym[r.symbol] = r.name || ''; });
+
+            chunkedBatchQuote(syms, 50).then(function (quotes) {
+                quotes.sort(function (a, b) { return (b.changePercentage || 0) - (a.changePercentage || 0); });
+                var gainers = quotes.slice(0, 5);
+                var losers = quotes.slice(-5).reverse();
+
+                var html = '';
+                html += '<div class="sector-section-title">Top Gainers</div>';
+                html += renderMoversTable(gainers, nameBySym);
+                html += '<div class="sector-section-title">Top Losers</div>';
+                html += renderMoversTable(losers, nameBySym);
+                container.innerHTML = html;
+
+                container.querySelectorAll('.peer-row').forEach(function (row) {
+                    row.onclick = function () {
+                        var sym = row.dataset.symbol;
+                        if (sym) window.location.href = '/security/' + sym;
+                    };
+                });
+            });
+        });
+    }
+
+    function chunkedBatchQuote(symbols, chunkSize) {
+        var chunks = [];
+        for (var i = 0; i < symbols.length; i += chunkSize) {
+            chunks.push(symbols.slice(i, i + chunkSize));
+        }
+        // Sequential, not parallel — FMP has rate caps and this isn't
+        // perf-critical (the page is rarely the hot path).
+        var out = [];
+        return chunks.reduce(function (p, chunk) {
+            return p.then(function () {
+                return fetch('/api/batch-quote?symbols=' + chunk.join(','))
+                    .then(function (r) { return r.json(); })
+                    .then(function (rows) { if (rows && rows.length) out = out.concat(rows); });
+            });
+        }, Promise.resolve()).then(function () { return out; });
+    }
+
+    function renderMoversTable(rows, nameBySym) {
+        if (!rows || rows.length === 0) return '<p class="empty-state">—</p>';
+        var html = '<table class="fin-table peer-table"><thead><tr>';
+        html += '<th>Ticker</th><th>Name</th><th>Price</th><th>Change</th>';
+        html += '</tr></thead><tbody>';
+        rows.forEach(function (q) {
+            html += '<tr class="peer-row" data-symbol="' + esc(q.symbol) + '">';
+            html += '<td><span class="sym-link">' + esc(q.symbol) + '</span></td>';
+            html += '<td>' + esc(nameBySym[q.symbol] || q.name || '') + '</td>';
+            html += '<td>$' + fmtPrice(q.price) + '</td>';
+            html += '<td class="' + pctClass(q.changePercentage) + '">' + pct(q.changePercentage) + '</td>';
+            html += '</tr>';
+        });
+        html += '</tbody></table>';
+        return html;
+    }
+
+    // ── News ──
+
+    var NEWS_CATS = [
+        { key: 'general', label: 'General' },
+        { key: 'articles', label: 'Articles' },
+        { key: 'stock', label: 'Stock' },
+    ];
+    var activeNewsCat = 'general';
+
+    function loadNews() {
+        var html = '<div class="news-sub-tabs" id="news-sub-tabs">';
+        NEWS_CATS.forEach(function (c) {
+            html += '<button class="info-sub-tab' + (c.key === activeNewsCat ? ' active' : '') + '" data-cat="' + esc(c.key) + '">' + esc(c.label) + '</button>';
+        });
+        html += '</div><div id="news-cards" class="news-cards"><p class="empty-state">Loading...</p></div>';
+        container.innerHTML = html;
+
+        container.querySelectorAll('.info-sub-tab').forEach(function (tab) {
+            tab.onclick = function () {
+                container.querySelectorAll('.info-sub-tab').forEach(function (t) { t.classList.remove('active'); });
+                tab.classList.add('active');
+                activeNewsCat = tab.dataset.cat;
+                loadNewsCategory(activeNewsCat);
+            };
+        });
+        loadNewsCategory(activeNewsCat);
+    }
+
+    function loadNewsCategory(cat) {
+        var listEl = document.getElementById('news-cards');
+        listEl.innerHTML = '<p class="empty-state">Loading...</p>';
+        // Index symbols rarely tag in symbol-filtered feeds, so go
+        // straight to the broad feed.
+        var url = '/api/news/' + cat + '?limit=20';
+        fetch(url).then(function (r) { return r.json(); }).then(renderNewsList).catch(function () {
+            listEl.innerHTML = '<p class="empty-state">Failed to load news</p>';
+        });
+    }
+
+    function renderNewsList(items) {
+        var listEl = document.getElementById('news-cards');
+        if (!items || items.length === 0) {
+            listEl.innerHTML = '<p class="empty-state">No news</p>';
+            return;
+        }
+        var html = '';
+        items.forEach(function (n) {
+            var url = n.url || '#';
+            var d = n.publishedDate ? new Date(n.publishedDate).toLocaleString() : '';
+            html += '<div class="news-card">';
+            html += '<div class="news-card-title"><a href="' + esc(url) + '" target="_blank" rel="noopener">' + esc(n.title || '—') + '</a></div>';
+            html += '<div class="news-card-meta"><span>' + esc(n.site || n.publisher || '') + '</span><span>' + esc(d) + '</span></div>';
+            if (n.text || n.snippet) {
+                html += '<div class="news-card-snippet">' + esc((n.text || n.snippet).slice(0, 240)) + '…</div>';
+            }
+            html += '</div>';
+        });
+        listEl.innerHTML = html;
+    }
+
+    // ── AI Analysis ──
+
+    function loadAI() {
+        Promise.all([
+            fetch('/api/trading/cost').then(function (r) { return r.json(); }).catch(function () { return { available: false }; }),
+            fetch('/api/security/' + encodeURIComponent(symbol) + '/trading/result').then(function (r) { return r.json(); }).then(function (d) { return d && d.status !== 'none' ? d : null; }).catch(function () { return null; }),
+        ]).then(function (results) {
+            var costInfo = results[0];
+            var tradingResult = results[1];
+
+            var html = '<div class="trading-header trading-vim-item" data-trading-vim="btn" tabindex="0">';
+            html += '<span class="ai-section-title" style="margin:0">Deep Analysis — Multi-Agent Pipeline</span>';
+            html += renderTradingButton(costInfo, tradingResult);
+            html += '</div>';
+
+            if (tradingResult && tradingResult.analystReports && tradingResult.analystReports.length > 0) {
+                html += renderTradingResultLite(tradingResult);
+            } else {
+                html += '<p class="empty-state">No analysis yet. SEC + competitor analysts are skipped for indices.</p>';
+            }
+            container.innerHTML = html;
+            wireTradingButton();
+            if (tradingResult && !isFinished(tradingResult)) pollTradingStatus();
+        });
+    }
+
+    function isFinished(result) {
+        return result && result.finishedAt && !result.finishedAt.startsWith('0001');
+    }
+
+    function renderTradingButton(costInfo, tradingResult) {
+        var isRunning = tradingResult && !isFinished(tradingResult) && tradingResult.startedAt;
+        var costStr = costInfo && costInfo.available ? 'Est. $' + costInfo.estimatedCost.toFixed(3) : '';
+        var html = '';
+        if (isRunning) {
+            html += '<button class="trading-btn trading-btn-running" disabled>'
+                + '<span class="spinner" style="width:12px;height:12px;display:inline-block"></span> Running…</button>';
+        } else {
+            html += '<button class="trading-btn" id="trading-analyze-btn">&#129302; Run Deep Analysis</button>';
+        }
+        if (costStr) html += '<span class="trading-cost">' + esc(costStr) + '</span>';
+        if (isFinished(tradingResult) && tradingResult.totalCostUsd !== undefined) {
+            html += '<span class="trading-actual-cost">Actual: $' + tradingResult.totalCostUsd.toFixed(4) + '</span>';
+        }
+        return html;
+    }
+
+    function wireTradingButton() {
+        var btn = document.getElementById('trading-analyze-btn');
+        if (!btn) return;
+        btn.onclick = function () {
+            btn.disabled = true;
+            btn.innerHTML = '<span class="spinner" style="width:12px;height:12px;display:inline-block"></span> Starting…';
+            fetch('/api/security/' + encodeURIComponent(symbol) + '/trading/analyze', { method: 'POST' })
+                .then(function (r) { return r.json(); })
+                .then(function (resp) {
+                    if (resp.status === 'started' || resp.status === 'already_running') pollTradingStatus();
+                })
+                .catch(function () { btn.disabled = false; btn.textContent = 'Run Deep Analysis'; });
+        };
+    }
+
+    var tradingPollInterval = null;
+    function pollTradingStatus() {
+        if (tradingPollInterval) clearInterval(tradingPollInterval);
+        tradingPollInterval = setInterval(function () {
+            if (currentTab !== 'ai') { clearInterval(tradingPollInterval); return; }
+            fetch('/api/security/' + encodeURIComponent(symbol) + '/trading/result')
+                .then(function (r) { return r.ok ? r.json() : null; })
+                .then(function (result) {
+                    if (!result) return;
+                    if (isFinished(result)) {
+                        clearInterval(tradingPollInterval);
+                        loadAI();
+                    }
+                });
+        }, 3000);
+    }
+
+    function renderTradingResultLite(result) {
+        var html = '<div class="trading-analysts">';
+        result.analystReports.forEach(function (r) {
+            var outlookClass = r.outlook === 'bullish' ? 'price-up' : r.outlook === 'bearish' ? 'price-down' : '';
+            html += '<div class="trading-analyst-card trading-vim-item">';
+            html += '<div class="trading-analyst-header">';
+            html += '<span class="trading-analyst-name">' + esc(r.analyst) + '</span>';
+            html += '<span class="trading-analyst-outlook ' + outlookClass + '">' + esc(r.outlook || 'neutral') + '</span>';
+            html += '</div>';
+            html += '<div class="trading-analyst-body">';
+            if (r.summary) html += '<p class="ai-text">' + esc(r.summary) + '</p>';
+            if (r.keyPoints && r.keyPoints.length) {
+                html += '<ul class="ai-list">';
+                r.keyPoints.forEach(function (p) { html += '<li>' + esc(p) + '</li>'; });
+                html += '</ul>';
+            }
+            html += '</div></div>';
+        });
+        html += '</div>';
+        return html;
+    }
+
+    // ── Init ──
+
+    loadTab('overview');
+})();

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -5,10 +5,12 @@
 <div class="info-tabs" id="info-tabs">
     <button class="info-tab active" data-tab="overview"><span class="tab-key">1</span> Overview</button>
     <button class="info-tab" data-tab="components"><span class="tab-key">2</span> Components</button>
-    <button class="info-tab" data-tab="news"><span class="tab-key">3</span> News</button>
-    <button class="info-tab" data-tab="ai"><span class="tab-key">4</span> AI Analysis</button>
+    <button class="info-tab" data-tab="movers"><span class="tab-key">3</span> Movers</button>
+    <button class="info-tab" data-tab="news"><span class="tab-key">4</span> News</button>
+    <button class="info-tab" data-tab="ai"><span class="tab-key">5</span> AI Analysis</button>
 </div>
 <div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
-    <p class="empty-state">Index page coming soon. Tracked in #101.</p>
+    <p class="empty-state">Loading...</p>
 </div>
+<script src="/static/index_page.js?v={{.AssetVersion}}"></script>
 {{end}}

--- a/tests/e2e/security_routing_test.go
+++ b/tests/e2e/security_routing_test.go
@@ -160,6 +160,45 @@ func TestSmoke_ETFInfo(t *testing.T) {
 	}
 }
 
+// Same for the index page — index_page.js must be reachable.
+func TestSmoke_SecurityRouting_IndexStaticAsset(t *testing.T) {
+	resp := get(t, "/static/index_page.js")
+	defer resp.Body.Close()
+	assertStatus(t, resp, 200)
+	assertContains(t, resp, "index_page.js")
+}
+
+// /api/security/^DJI/index-constituents returns the 30 Dow components.
+// Each row carries `symbol`, `name`, `sector`, `subSector`.
+func TestSmoke_IndexConstituents(t *testing.T) {
+	resp := get(t, "/api/security/%5EDJI/index-constituents")
+	defer resp.Body.Close()
+	assertStatus(t, resp, 200)
+	body, _ := io.ReadAll(resp.Body)
+	s := string(body)
+	if !strings.HasPrefix(strings.TrimSpace(s), "[") {
+		t.Fatalf("expected JSON array, got: %.200s", s)
+	}
+	for _, want := range []string{`"symbol"`, `"sector"`} {
+		if !strings.Contains(s, want) {
+			t.Errorf("expected %s in constituents body, got: %.200s", want, s)
+		}
+	}
+}
+
+// /api/batch-quote fronts FMP's batch quote endpoint. Verify it returns
+// an array for a small set.
+func TestSmoke_BatchQuote(t *testing.T) {
+	resp := get(t, "/api/batch-quote?symbols=AAPL,MSFT")
+	defer resp.Body.Close()
+	assertStatus(t, resp, 200)
+	body, _ := io.ReadAll(resp.Body)
+	s := string(body)
+	if !strings.HasPrefix(strings.TrimSpace(s), "[") {
+		t.Fatalf("expected JSON array, got: %.200s", s)
+	}
+}
+
 // SPY is an ETF — /security/SPY should 301 to /etf/SPY once the type
 // resolver has seen isEtf=true on the profile.
 func TestSmoke_SecurityRouting_ETFRedirect(t *testing.T) {


### PR DESCRIPTION
## Summary
Vertical slice for `/index/{sym}`. ^DJI / ^GSPC / ^IXIC now render index-shaped tabs instead of the stock template.

### Tabs
- **Overview** — index name, price, 1d / YTD / 1y %, day range, 52W range, volume, 50d / 200d avg, components count + 1Y price chart.
- **Components** — full constituent list with sector + sub-sector + date-first-added. Click → `/security/{ticker}`.
- **Movers** — top 5 gainers + top 5 losers, derived client-side by chunked `batch-quote` (~50 symbols per call to stay under FMP's truncation cap). Works for DJI (30) in one call, S&P 500 (503) in ~11.
- **News** — General + Articles + Stock (broad-feed only — indices don't tag in symbol-filtered feeds).
- **AI Analysis** — shared trading-pipeline UI; SEC analyst already skipped via the gate from PR #106.

### Server
New FMP wrappers in `internal/news/news.go`:
- `GetIndexConstituents` — maps `^DJI` / `^GSPC` / `^IXIC` to the right per-index endpoint (FMP doesn't unify them)
- `GetBatchQuote` — `/stable/batch-quote` for the movers tab

New routes:
- `GET /api/security/{sym}/index-constituents`
- `GET /api/batch-quote?symbols=A,B,C`

## Test plan
- [x] `make test` — Go unit suite green
- [x] `make smoke` — full e2e suite green, including 3 new tests:
  - `GET /api/security/^DJI/index-constituents` → 200 with `symbol` + `sector`
  - `GET /api/batch-quote?symbols=AAPL,MSFT` → 200 array
  - `GET /static/index_page.js` → 200
- [x] Manual browser: `/index/^DJI` Overview + Components + Movers + AI all render; `/security/^DJI` still 301s correctly (foundation `^` short-circuit)

Closes #101
Parent: #97