### PR TITLE
feat(vim): declarative navigable-elements core (#104)

### DIFF
--- a/internal/server/static/crypto.js
+++ b/internal/server/static/crypto.js
@@ -134,6 +134,7 @@
 
             container.innerHTML = html;
             renderOverviewChart(hist);
+            if (window.VimNav) window.VimNav.reset();
         }).catch(function (err) {
             console.error('Crypto overview error:', err);
             container.innerHTML = '<p class="empty-state">Failed to load overview</p>';
@@ -185,9 +186,9 @@
     var activeNewsCat = 'crypto';
 
     function loadNews() {
-        var html = '<div class="news-sub-tabs" id="news-sub-tabs">';
+        var html = '<div class="news-sub-tabs" id="news-sub-tabs" data-vim-row>';
         NEWS_CATS.forEach(function (c) {
-            html += '<button class="info-sub-tab' + (c.key === activeNewsCat ? ' active' : '') + '" data-cat="' + esc(c.key) + '">' + esc(c.label) + '</button>';
+            html += '<button class="info-sub-tab' + (c.key === activeNewsCat ? ' active' : '') + '" data-cat="' + esc(c.key) + '" data-vim-item>' + esc(c.label) + '</button>';
         });
         html += '</div><div id="news-cards" class="news-cards"><p class="empty-state">Loading...</p></div>';
         container.innerHTML = html;
@@ -227,21 +228,25 @@
         var listEl = document.getElementById('news-cards');
         if (!items || items.length === 0) {
             listEl.innerHTML = '<p class="empty-state">No news</p>';
+            if (window.VimNav) window.VimNav.reset();
             return;
         }
         var html = '';
         items.forEach(function (n) {
             var url = n.url || '#';
             var d = n.publishedDate ? new Date(n.publishedDate).toLocaleString() : '';
-            html += '<div class="news-card">';
+            var title = (n.title || '—').replace(/"/g, '&quot;');
+            html += '<div class="news-card" data-vim-row>';
+            html += '<div class="news-card-inner" data-vim-item data-vim-action="open-reader" data-vim-url="' + esc(url) + '" data-vim-title="' + esc(title) + '">';
             html += '<div class="news-card-title"><a href="' + esc(url) + '" target="_blank" rel="noopener">' + esc(n.title || '—') + '</a></div>';
             html += '<div class="news-card-meta"><span>' + esc(n.site || n.publisher || '') + '</span><span>' + esc(d) + '</span></div>';
             if (n.text || n.snippet) {
                 html += '<div class="news-card-snippet">' + esc((n.text || n.snippet).slice(0, 240)) + '…</div>';
             }
-            html += '</div>';
+            html += '</div></div>';
         });
         listEl.innerHTML = html;
+        if (window.VimNav) window.VimNav.reset();
     }
 
     // ── AI Analysis ──
@@ -254,7 +259,7 @@
             var costInfo = results[0];
             var tradingResult = results[1];
 
-            var html = '<div class="trading-header trading-vim-item" data-trading-vim="btn" tabindex="0">';
+            var html = '<div class="trading-header trading-vim-item" data-trading-vim="btn" data-vim-row>';
             html += '<span class="ai-section-title" style="margin:0">Deep Analysis — Multi-Agent Pipeline</span>';
             html += renderTradingButton(costInfo, tradingResult);
             html += '</div>';
@@ -267,6 +272,7 @@
             container.innerHTML = html;
             wireTradingButton();
             if (tradingResult && !isFinished(tradingResult)) pollTradingStatus();
+            if (window.VimNav) window.VimNav.reset();
         });
     }
 
@@ -279,10 +285,10 @@
         var costStr = costInfo && costInfo.available ? 'Est. $' + costInfo.estimatedCost.toFixed(3) : '';
         var html = '';
         if (isRunning) {
-            html += '<button class="trading-btn trading-btn-running" disabled>'
+            html += '<button class="trading-btn trading-btn-running" disabled data-vim-item>'
                 + '<span class="spinner" style="width:12px;height:12px;display:inline-block"></span> Running…</button>';
         } else {
-            html += '<button class="trading-btn" id="trading-analyze-btn">&#129302; Run Deep Analysis</button>';
+            html += '<button class="trading-btn" id="trading-analyze-btn" data-vim-item>&#129302; Run Deep Analysis</button>';
         }
         if (costStr) html += '<span class="trading-cost">' + esc(costStr) + '</span>';
         if (isFinished(tradingResult) && tradingResult.totalCostUsd !== undefined) {
@@ -327,7 +333,8 @@
         var html = '<div class="trading-analysts">';
         result.analystReports.forEach(function (r) {
             var outlookClass = r.outlook === 'bullish' ? 'price-up' : r.outlook === 'bearish' ? 'price-down' : '';
-            html += '<div class="trading-analyst-card trading-vim-item">';
+            html += '<div class="trading-analyst-card trading-vim-item" data-vim-row>';
+            html += '<div class="trading-analyst-card-inner" data-vim-item data-vim-action="toggle" data-vim-toggle-class="trading-panel-open">';
             html += '<div class="trading-analyst-header">';
             html += '<span class="trading-analyst-name">' + esc(r.analyst) + '</span>';
             html += '<span class="trading-analyst-outlook ' + outlookClass + '">' + esc(r.outlook || 'neutral') + '</span>';
@@ -339,7 +346,7 @@
                 r.keyPoints.forEach(function (p) { html += '<li>' + esc(p) + '</li>'; });
                 html += '</ul>';
             }
-            html += '</div></div>';
+            html += '</div></div></div>';
         });
         html += '</div>';
         return html;
@@ -361,13 +368,13 @@
         html += '</tr></thead><tbody>';
         PEER_COINS.forEach(function (sym) {
             var isCurrent = sym === symbol;
-            html += '<tr class="peer-row' + (isCurrent ? ' peer-current' : '') + '" data-symbol="' + esc(sym) + '">';
-            html += '<td><span class="sym-link">' + esc(sym) + '</span></td>';
-            html += '<td data-cell="name">—</td>';
-            html += '<td data-cell="price">—</td>';
-            html += '<td data-cell="ch24">—</td>';
-            html += '<td data-cell="mcap">—</td>';
-            html += '<td><div class="peer-spark" data-spark-sym="' + esc(sym) + '"></div></td>';
+            html += '<tr class="peer-row' + (isCurrent ? ' peer-current' : '') + '" data-symbol="' + esc(sym) + '" data-vim-row data-vim-action="navigate" data-vim-href="/crypto/' + encodeURIComponent(sym) + '">';
+            html += '<td data-vim-item><span class="sym-link">' + esc(sym) + '</span></td>';
+            html += '<td data-cell="name" data-vim-item>—</td>';
+            html += '<td data-cell="price" data-vim-item>—</td>';
+            html += '<td data-cell="ch24" data-vim-item>—</td>';
+            html += '<td data-cell="mcap" data-vim-item>—</td>';
+            html += '<td data-vim-item><div class="peer-spark" data-spark-sym="' + esc(sym) + '"></div></td>';
             html += '</tr>';
         });
         html += '</tbody></table>';
@@ -380,6 +387,7 @@
                 if (sym) window.location.href = '/crypto/' + sym;
             };
         });
+        if (window.VimNav) window.VimNav.reset();
 
         // Fill quotes in parallel — one fetch per coin keeps the code
         // simple and the request count tiny.

--- a/internal/server/static/etf.js
+++ b/internal/server/static/etf.js
@@ -152,6 +152,7 @@
 
             container.innerHTML = html;
             renderOverviewChart(hist);
+            if (window.VimNav) window.VimNav.reset();
         }).catch(function (err) {
             console.error('ETF overview error:', err);
             container.innerHTML = '<p class="empty-state">Failed to load overview</p>';
@@ -234,12 +235,12 @@
                 html += '</tr></thead><tbody>';
                 top.forEach(function (h, i) {
                     var sym = h.asset || h.symbol || '';
-                    html += '<tr class="peer-row" data-symbol="' + esc(sym) + '">';
-                    html += '<td>' + (i + 1) + '</td>';
-                    html += '<td><span class="sym-link">' + esc(sym) + '</span></td>';
-                    html += '<td>' + esc(h.name || '') + '</td>';
-                    html += '<td>' + pct(h.weightPercentage) + '</td>';
-                    html += '<td>' + fmtBig(h.marketValue) + '</td>';
+                    html += '<tr class="peer-row" data-symbol="' + esc(sym) + '" data-vim-row data-vim-action="navigate" data-vim-href="/security/' + encodeURIComponent(sym) + '">';
+                    html += '<td data-vim-item>' + (i + 1) + '</td>';
+                    html += '<td data-vim-item><span class="sym-link">' + esc(sym) + '</span></td>';
+                    html += '<td data-vim-item>' + esc(h.name || '') + '</td>';
+                    html += '<td data-vim-item>' + pct(h.weightPercentage) + '</td>';
+                    html += '<td data-vim-item>' + fmtBig(h.marketValue) + '</td>';
                     html += '</tr>';
                 });
                 html += '</tbody></table>';
@@ -254,6 +255,7 @@
                         if (sym) window.location.href = '/security/' + sym;
                     };
                 });
+                if (window.VimNav) window.VimNav.reset();
             })
             .catch(function () {
                 container.innerHTML = '<p class="empty-state">Failed to load holdings</p>';
@@ -276,12 +278,14 @@
             html += '</tr></thead><tbody>';
             sectors.forEach(function (s) {
                 var w = s.exposure || 0;
-                html += '<tr><td>' + esc(s.industry) + '</td>';
-                html += '<td>' + pct(w) + '</td>';
-                html += '<td><div class="sector-bar"><div class="sector-bar-fill" style="width:' + Math.min(100, w * 2) + '%"></div></div></td></tr>';
+                html += '<tr data-vim-row>';
+                html += '<td data-vim-item>' + esc(s.industry) + '</td>';
+                html += '<td data-vim-item>' + pct(w) + '</td>';
+                html += '<td data-vim-item><div class="sector-bar"><div class="sector-bar-fill" style="width:' + Math.min(100, w * 2) + '%"></div></div></td></tr>';
             });
             html += '</tbody></table>';
             container.innerHTML = html;
+            if (window.VimNav) window.VimNav.reset();
         });
     }
 
@@ -295,9 +299,9 @@
     var activeNewsCat = 'stock';
 
     function loadNews() {
-        var html = '<div class="news-sub-tabs" id="news-sub-tabs">';
+        var html = '<div class="news-sub-tabs" id="news-sub-tabs" data-vim-row>';
         NEWS_CATS.forEach(function (c) {
-            html += '<button class="info-sub-tab' + (c.key === activeNewsCat ? ' active' : '') + '" data-cat="' + esc(c.key) + '">' + esc(c.label) + '</button>';
+            html += '<button class="info-sub-tab' + (c.key === activeNewsCat ? ' active' : '') + '" data-cat="' + esc(c.key) + '" data-vim-item>' + esc(c.label) + '</button>';
         });
         html += '</div><div id="news-cards" class="news-cards"><p class="empty-state">Loading...</p></div>';
         container.innerHTML = html;
@@ -336,21 +340,25 @@
         var listEl = document.getElementById('news-cards');
         if (!items || items.length === 0) {
             listEl.innerHTML = '<p class="empty-state">No news</p>';
+            if (window.VimNav) window.VimNav.reset();
             return;
         }
         var html = '';
         items.forEach(function (n) {
             var url = n.url || '#';
             var d = n.publishedDate ? new Date(n.publishedDate).toLocaleString() : '';
-            html += '<div class="news-card">';
+            var title = (n.title || '—').replace(/"/g, '&quot;');
+            html += '<div class="news-card" data-vim-row>';
+            html += '<div class="news-card-inner" data-vim-item data-vim-action="open-reader" data-vim-url="' + esc(url) + '" data-vim-title="' + esc(title) + '">';
             html += '<div class="news-card-title"><a href="' + esc(url) + '" target="_blank" rel="noopener">' + esc(n.title || '—') + '</a></div>';
             html += '<div class="news-card-meta"><span>' + esc(n.site || n.publisher || '') + '</span><span>' + esc(d) + '</span></div>';
             if (n.text || n.snippet) {
                 html += '<div class="news-card-snippet">' + esc((n.text || n.snippet).slice(0, 240)) + '…</div>';
             }
-            html += '</div>';
+            html += '</div></div>';
         });
         listEl.innerHTML = html;
+        if (window.VimNav) window.VimNav.reset();
     }
 
     // ── AI Analysis ──
@@ -363,7 +371,7 @@
             var costInfo = results[0];
             var tradingResult = results[1];
 
-            var html = '<div class="trading-header trading-vim-item" data-trading-vim="btn" tabindex="0">';
+            var html = '<div class="trading-header trading-vim-item" data-trading-vim="btn" data-vim-row>';
             html += '<span class="ai-section-title" style="margin:0">Deep Analysis — Multi-Agent Pipeline</span>';
             html += renderTradingButton(costInfo, tradingResult);
             html += '</div>';
@@ -376,6 +384,7 @@
             container.innerHTML = html;
             wireTradingButton();
             if (tradingResult && !isFinished(tradingResult)) pollTradingStatus();
+            if (window.VimNav) window.VimNav.reset();
         });
     }
 
@@ -388,10 +397,10 @@
         var costStr = costInfo && costInfo.available ? 'Est. $' + costInfo.estimatedCost.toFixed(3) : '';
         var html = '';
         if (isRunning) {
-            html += '<button class="trading-btn trading-btn-running" disabled>'
+            html += '<button class="trading-btn trading-btn-running" disabled data-vim-item>'
                 + '<span class="spinner" style="width:12px;height:12px;display:inline-block"></span> Running…</button>';
         } else {
-            html += '<button class="trading-btn" id="trading-analyze-btn">&#129302; Run Deep Analysis</button>';
+            html += '<button class="trading-btn" id="trading-analyze-btn" data-vim-item>&#129302; Run Deep Analysis</button>';
         }
         if (costStr) html += '<span class="trading-cost">' + esc(costStr) + '</span>';
         if (isFinished(tradingResult) && tradingResult.totalCostUsd !== undefined) {
@@ -436,7 +445,8 @@
         var html = '<div class="trading-analysts">';
         result.analystReports.forEach(function (r) {
             var outlookClass = r.outlook === 'bullish' ? 'price-up' : r.outlook === 'bearish' ? 'price-down' : '';
-            html += '<div class="trading-analyst-card trading-vim-item">';
+            html += '<div class="trading-analyst-card trading-vim-item" data-vim-row>';
+            html += '<div class="trading-analyst-card-inner" data-vim-item data-vim-action="toggle" data-vim-toggle-class="trading-panel-open">';
             html += '<div class="trading-analyst-header">';
             html += '<span class="trading-analyst-name">' + esc(r.analyst) + '</span>';
             html += '<span class="trading-analyst-outlook ' + outlookClass + '">' + esc(r.outlook || 'neutral') + '</span>';
@@ -448,7 +458,7 @@
                 r.keyPoints.forEach(function (p) { html += '<li>' + esc(p) + '</li>'; });
                 html += '</ul>';
             }
-            html += '</div></div>';
+            html += '</div></div></div>';
         });
         html += '</div>';
         return html;

--- a/internal/server/static/forex.js
+++ b/internal/server/static/forex.js
@@ -124,6 +124,7 @@
 
             container.innerHTML = html;
             renderOverviewChart(hist);
+            if (window.VimNav) window.VimNav.reset();
         }).catch(function (err) {
             console.error('Forex overview error:', err);
             container.innerHTML = '<p class="empty-state">Failed to load overview</p>';
@@ -206,20 +207,19 @@
                 return;
             }
             var m = row.meta;
-            html += '<tr class="peer-row" data-rate-id="' + esc(m.rateId) + '">';
-            html += '<td><span class="sym-link">' + esc(row.ccy) + '</span></td>';
-            html += '<td>' + esc(m.name) + '</td>';
-            html += '<td>' + esc(m.rateLabel) + '</td>';
-            html += '<td data-cell="latest">—</td>';
-            html += '<td data-cell="date">—</td>';
+            html += '<tr class="peer-row" data-rate-id="' + esc(m.rateId) + '" data-vim-row data-vim-action="navigate" data-vim-href="/graph/' + encodeURIComponent(m.rateId) + '">';
+            html += '<td data-vim-item><span class="sym-link">' + esc(row.ccy) + '</span></td>';
+            html += '<td data-vim-item>' + esc(m.name) + '</td>';
+            html += '<td data-vim-item>' + esc(m.rateLabel) + '</td>';
+            html += '<td data-cell="latest" data-vim-item>—</td>';
+            html += '<td data-cell="date" data-vim-item>—</td>';
             html += '</tr>';
         });
         html += '</tbody></table>';
-        html += '<p class="empty-state">Press <kbd>g</kbd> on a row, or click, to open the full series on /economics.</p>';
+        html += '<p class="empty-state">Press <kbd>Enter</kbd> on a row to open the full series on /graph.</p>';
         container.innerHTML = html;
 
-        // Click → /economics?country=... — same drill-down the /economics
-        // page already understands.
+        // Click → /graph/... — same drill-down the /economics page understands.
         container.querySelectorAll('.peer-row').forEach(function (row) {
             row.onclick = function () {
                 var rateId = row.dataset.rateId;
@@ -227,6 +227,7 @@
                 window.location.href = '/graph/' + encodeURIComponent(rateId);
             };
         });
+        if (window.VimNav) window.VimNav.reset();
 
         // Fill the rate values from the cached economics series.
         [fromMeta, toMeta].filter(Boolean).forEach(function (m) {
@@ -254,9 +255,9 @@
     var activeNewsCat = 'forex';
 
     function loadNews() {
-        var html = '<div class="news-sub-tabs" id="news-sub-tabs">';
+        var html = '<div class="news-sub-tabs" id="news-sub-tabs" data-vim-row>';
         NEWS_CATS.forEach(function (c) {
-            html += '<button class="info-sub-tab' + (c.key === activeNewsCat ? ' active' : '') + '" data-cat="' + esc(c.key) + '">' + esc(c.label) + '</button>';
+            html += '<button class="info-sub-tab' + (c.key === activeNewsCat ? ' active' : '') + '" data-cat="' + esc(c.key) + '" data-vim-item>' + esc(c.label) + '</button>';
         });
         html += '</div><div id="news-cards" class="news-cards"><p class="empty-state">Loading...</p></div>';
         container.innerHTML = html;
@@ -286,21 +287,25 @@
         var listEl = document.getElementById('news-cards');
         if (!items || items.length === 0) {
             listEl.innerHTML = '<p class="empty-state">No news</p>';
+            if (window.VimNav) window.VimNav.reset();
             return;
         }
         var html = '';
         items.forEach(function (n) {
             var url = n.url || '#';
             var d = n.publishedDate ? new Date(n.publishedDate).toLocaleString() : '';
-            html += '<div class="news-card">';
+            var title = (n.title || '—').replace(/"/g, '&quot;');
+            html += '<div class="news-card" data-vim-row>';
+            html += '<div class="news-card-inner" data-vim-item data-vim-action="open-reader" data-vim-url="' + esc(url) + '" data-vim-title="' + esc(title) + '">';
             html += '<div class="news-card-title"><a href="' + esc(url) + '" target="_blank" rel="noopener">' + esc(n.title || '—') + '</a></div>';
             html += '<div class="news-card-meta"><span>' + esc(n.site || n.publisher || '') + '</span><span>' + esc(d) + '</span></div>';
             if (n.text || n.snippet) {
                 html += '<div class="news-card-snippet">' + esc((n.text || n.snippet).slice(0, 240)) + '…</div>';
             }
-            html += '</div>';
+            html += '</div></div>';
         });
         listEl.innerHTML = html;
+        if (window.VimNav) window.VimNav.reset();
     }
 
     // ── AI Analysis ──
@@ -313,7 +318,7 @@
             var costInfo = results[0];
             var tradingResult = results[1];
 
-            var html = '<div class="trading-header trading-vim-item" data-trading-vim="btn" tabindex="0">';
+            var html = '<div class="trading-header trading-vim-item" data-trading-vim="btn" data-vim-row>';
             html += '<span class="ai-section-title" style="margin:0">Deep Analysis — Multi-Agent Pipeline</span>';
             html += renderTradingButton(costInfo, tradingResult);
             html += '</div>';
@@ -326,6 +331,7 @@
             container.innerHTML = html;
             wireTradingButton();
             if (tradingResult && !isFinished(tradingResult)) pollTradingStatus();
+            if (window.VimNav) window.VimNav.reset();
         });
     }
 
@@ -338,10 +344,10 @@
         var costStr = costInfo && costInfo.available ? 'Est. $' + costInfo.estimatedCost.toFixed(3) : '';
         var html = '';
         if (isRunning) {
-            html += '<button class="trading-btn trading-btn-running" disabled>'
+            html += '<button class="trading-btn trading-btn-running" disabled data-vim-item>'
                 + '<span class="spinner" style="width:12px;height:12px;display:inline-block"></span> Running…</button>';
         } else {
-            html += '<button class="trading-btn" id="trading-analyze-btn">&#129302; Run Deep Analysis</button>';
+            html += '<button class="trading-btn" id="trading-analyze-btn" data-vim-item>&#129302; Run Deep Analysis</button>';
         }
         if (costStr) html += '<span class="trading-cost">' + esc(costStr) + '</span>';
         if (isFinished(tradingResult) && tradingResult.totalCostUsd !== undefined) {
@@ -386,7 +392,8 @@
         var html = '<div class="trading-analysts">';
         result.analystReports.forEach(function (r) {
             var outlookClass = r.outlook === 'bullish' ? 'price-up' : r.outlook === 'bearish' ? 'price-down' : '';
-            html += '<div class="trading-analyst-card trading-vim-item">';
+            html += '<div class="trading-analyst-card trading-vim-item" data-vim-row>';
+            html += '<div class="trading-analyst-card-inner" data-vim-item data-vim-action="toggle" data-vim-toggle-class="trading-panel-open">';
             html += '<div class="trading-analyst-header">';
             html += '<span class="trading-analyst-name">' + esc(r.analyst) + '</span>';
             html += '<span class="trading-analyst-outlook ' + outlookClass + '">' + esc(r.outlook || 'neutral') + '</span>';
@@ -398,7 +405,7 @@
                 r.keyPoints.forEach(function (p) { html += '<li>' + esc(p) + '</li>'; });
                 html += '</ul>';
             }
-            html += '</div></div>';
+            html += '</div></div></div>';
         });
         html += '</div>';
         return html;

--- a/internal/server/static/fund.js
+++ b/internal/server/static/fund.js
@@ -201,9 +201,9 @@
     var activeNewsCat = 'stock';
 
     function loadNews() {
-        var html = '<div class="news-sub-tabs" id="news-sub-tabs">';
+        var html = '<div class="news-sub-tabs" id="news-sub-tabs" data-vim-row>';
         NEWS_CATS.forEach(function (c) {
-            html += '<button class="info-sub-tab' + (c.key === activeNewsCat ? ' active' : '') + '" data-cat="' + esc(c.key) + '">' + esc(c.label) + '</button>';
+            html += '<button class="info-sub-tab' + (c.key === activeNewsCat ? ' active' : '') + '" data-cat="' + esc(c.key) + '" data-vim-item>' + esc(c.label) + '</button>';
         });
         html += '</div><div id="news-cards" class="news-cards"><p class="empty-state">Loading...</p></div>';
         container.innerHTML = html;
@@ -248,13 +248,15 @@
         items.forEach(function (n) {
             var url = n.url || '#';
             var d = n.publishedDate ? new Date(n.publishedDate).toLocaleString() : '';
-            html += '<div class="news-card">';
+            var title = (n.title || '—').replace(/"/g, '&quot;');
+            html += '<div class="news-card" data-vim-row>';
+            html += '<div class="news-card-inner" data-vim-item data-vim-action="open-reader" data-vim-url="' + esc(url) + '" data-vim-title="' + esc(title) + '">';
             html += '<div class="news-card-title"><a href="' + esc(url) + '" target="_blank" rel="noopener">' + esc(n.title || '—') + '</a></div>';
             html += '<div class="news-card-meta"><span>' + esc(n.site || n.publisher || '') + '</span><span>' + esc(d) + '</span></div>';
             if (n.text || n.snippet) {
                 html += '<div class="news-card-snippet">' + esc((n.text || n.snippet).slice(0, 240)) + '…</div>';
             }
-            html += '</div>';
+            html += '</div></div>';
         });
         listEl.innerHTML = html;
     }
@@ -269,7 +271,7 @@
             var costInfo = results[0];
             var tradingResult = results[1];
 
-            var html = '<div class="trading-header trading-vim-item" data-trading-vim="btn" tabindex="0">';
+            var html = '<div class="trading-header trading-vim-item" data-trading-vim="btn" data-vim-row>';
             html += '<span class="ai-section-title" style="margin:0">Deep Analysis — Multi-Agent Pipeline</span>';
             html += renderTradingButton(costInfo, tradingResult);
             html += '</div>';
@@ -294,10 +296,10 @@
         var costStr = costInfo && costInfo.available ? 'Est. $' + costInfo.estimatedCost.toFixed(3) : '';
         var html = '';
         if (isRunning) {
-            html += '<button class="trading-btn trading-btn-running" disabled>'
+            html += '<button class="trading-btn trading-btn-running" disabled data-vim-item>'
                 + '<span class="spinner" style="width:12px;height:12px;display:inline-block"></span> Running…</button>';
         } else {
-            html += '<button class="trading-btn" id="trading-analyze-btn">&#129302; Run Deep Analysis</button>';
+            html += '<button class="trading-btn" id="trading-analyze-btn" data-vim-item>&#129302; Run Deep Analysis</button>';
         }
         if (costStr) html += '<span class="trading-cost">' + esc(costStr) + '</span>';
         if (isFinished(tradingResult) && tradingResult.totalCostUsd !== undefined) {
@@ -342,7 +344,8 @@
         var html = '<div class="trading-analysts">';
         result.analystReports.forEach(function (r) {
             var outlookClass = r.outlook === 'bullish' ? 'price-up' : r.outlook === 'bearish' ? 'price-down' : '';
-            html += '<div class="trading-analyst-card trading-vim-item">';
+            html += '<div class="trading-analyst-card trading-vim-item" data-vim-row>';
+            html += '<div class="trading-analyst-card-inner" data-vim-item data-vim-action="toggle" data-vim-toggle-class="trading-panel-open">';
             html += '<div class="trading-analyst-header">';
             html += '<span class="trading-analyst-name">' + esc(r.analyst) + '</span>';
             html += '<span class="trading-analyst-outlook ' + outlookClass + '">' + esc(r.outlook || 'neutral') + '</span>';
@@ -354,7 +357,7 @@
                 r.keyPoints.forEach(function (p) { html += '<li>' + esc(p) + '</li>'; });
                 html += '</ul>';
             }
-            html += '</div></div>';
+            html += '</div></div></div>';
         });
         html += '</div>';
         return html;

--- a/internal/server/static/index_page.js
+++ b/internal/server/static/index_page.js
@@ -129,10 +129,16 @@
             html += statCell('200-day Avg', q.priceAvg200 ? fmtPrice(q.priceAvg200) : '—');
             html += '</div>';
 
-            html += '<div id="index-chart-1y" class="crypto-chart"></div>';
+            // Graph row — per the user's vim spec, the chart is its own
+            // row-level element on the Overview tab. Pressing g on it
+            // jumps to /graph/{sym} via the legacy handler.
+            html += '<div class="index-graph-row" data-vim-row>';
+            html += '<div id="index-chart-1y" class="crypto-chart" data-vim-item data-vim-action="navigate" data-vim-href="/graph/' + encodeURIComponent(symbol) + '"></div>';
+            html += '</div>';
 
             container.innerHTML = html;
             renderOverviewChart(hist);
+            if (window.VimNav) window.VimNav.reset();
         }).catch(function (err) {
             console.error('Index overview error:', err);
             container.innerHTML = '<p class="empty-state">Failed to load overview</p>';
@@ -203,12 +209,15 @@
             html += '<th>Ticker</th><th>Name</th><th>Sector</th><th>Sub-Sector</th><th>Added</th>';
             html += '</tr></thead><tbody>';
             rows.forEach(function (r) {
-                html += '<tr class="peer-row" data-symbol="' + esc(r.symbol) + '">';
-                html += '<td><span class="sym-link">' + esc(r.symbol) + '</span></td>';
-                html += '<td>' + esc(r.name || '') + '</td>';
-                html += '<td>' + esc(r.sector || '') + '</td>';
-                html += '<td>' + esc(r.subSector || '') + '</td>';
-                html += '<td>' + esc(r.dateFirstAdded || '') + '</td>';
+                // Each table row is a vim-nav row container; td cells
+                // are the column items walked by w/b/h/l. Enter on any
+                // cell triggers the row's click → /security/{sym}.
+                html += '<tr class="peer-row" data-symbol="' + esc(r.symbol) + '" data-vim-row data-vim-action="navigate" data-vim-href="/security/' + encodeURIComponent(r.symbol) + '">';
+                html += '<td data-vim-item><span class="sym-link">' + esc(r.symbol) + '</span></td>';
+                html += '<td data-vim-item>' + esc(r.name || '') + '</td>';
+                html += '<td data-vim-item>' + esc(r.sector || '') + '</td>';
+                html += '<td data-vim-item>' + esc(r.subSector || '') + '</td>';
+                html += '<td data-vim-item>' + esc(r.dateFirstAdded || '') + '</td>';
                 html += '</tr>';
             });
             html += '</tbody></table>';
@@ -220,6 +229,7 @@
                     if (sym) window.location.href = '/security/' + sym;
                 };
             });
+            if (window.VimNav) window.VimNav.reset();
         });
     }
 
@@ -258,6 +268,7 @@
                         if (sym) window.location.href = '/security/' + sym;
                     };
                 });
+                if (window.VimNav) window.VimNav.reset();
             });
         });
     }
@@ -285,11 +296,11 @@
         html += '<th>Ticker</th><th>Name</th><th>Price</th><th>Change</th>';
         html += '</tr></thead><tbody>';
         rows.forEach(function (q) {
-            html += '<tr class="peer-row" data-symbol="' + esc(q.symbol) + '">';
-            html += '<td><span class="sym-link">' + esc(q.symbol) + '</span></td>';
-            html += '<td>' + esc(nameBySym[q.symbol] || q.name || '') + '</td>';
-            html += '<td>$' + fmtPrice(q.price) + '</td>';
-            html += '<td class="' + pctClass(q.changePercentage) + '">' + pct(q.changePercentage) + '</td>';
+            html += '<tr class="peer-row" data-symbol="' + esc(q.symbol) + '" data-vim-row data-vim-action="navigate" data-vim-href="/security/' + encodeURIComponent(q.symbol) + '">';
+            html += '<td data-vim-item><span class="sym-link">' + esc(q.symbol) + '</span></td>';
+            html += '<td data-vim-item>' + esc(nameBySym[q.symbol] || q.name || '') + '</td>';
+            html += '<td data-vim-item>$' + fmtPrice(q.price) + '</td>';
+            html += '<td data-vim-item class="' + pctClass(q.changePercentage) + '">' + pct(q.changePercentage) + '</td>';
             html += '</tr>';
         });
         html += '</tbody></table>';
@@ -306,9 +317,11 @@
     var activeNewsCat = 'general';
 
     function loadNews() {
-        var html = '<div class="news-sub-tabs" id="news-sub-tabs">';
+        // Sub-tab row: its own data-vim-row so j from main tabs lands here,
+        // and h/l (or w/b) walks across the categories.
+        var html = '<div class="news-sub-tabs" id="news-sub-tabs" data-vim-row>';
         NEWS_CATS.forEach(function (c) {
-            html += '<button class="info-sub-tab' + (c.key === activeNewsCat ? ' active' : '') + '" data-cat="' + esc(c.key) + '">' + esc(c.label) + '</button>';
+            html += '<button class="info-sub-tab' + (c.key === activeNewsCat ? ' active' : '') + '" data-cat="' + esc(c.key) + '" data-vim-item>' + esc(c.label) + '</button>';
         });
         html += '</div><div id="news-cards" class="news-cards"><p class="empty-state">Loading...</p></div>';
         container.innerHTML = html;
@@ -339,21 +352,29 @@
         var listEl = document.getElementById('news-cards');
         if (!items || items.length === 0) {
             listEl.innerHTML = '<p class="empty-state">No news</p>';
+            if (window.VimNav) window.VimNav.reset();
             return;
         }
         var html = '';
         items.forEach(function (n) {
             var url = n.url || '#';
             var d = n.publishedDate ? new Date(n.publishedDate).toLocaleString() : '';
-            html += '<div class="news-card">';
+            var title = (n.title || '—').replace(/"/g, '&quot;');
+            // Each article is its own data-vim-row containing a single
+            // data-vim-item — Enter on it opens the reader. The reader
+            // takes over all keys while open (terminal.js gates VimNav
+            // off when [data-vim-row] is visible AND reader is open).
+            html += '<div class="news-card" data-vim-row>';
+            html += '<div class="news-card-inner" data-vim-item data-vim-action="open-reader" data-vim-url="' + esc(url) + '" data-vim-title="' + esc(title) + '">';
             html += '<div class="news-card-title"><a href="' + esc(url) + '" target="_blank" rel="noopener">' + esc(n.title || '—') + '</a></div>';
             html += '<div class="news-card-meta"><span>' + esc(n.site || n.publisher || '') + '</span><span>' + esc(d) + '</span></div>';
             if (n.text || n.snippet) {
                 html += '<div class="news-card-snippet">' + esc((n.text || n.snippet).slice(0, 240)) + '…</div>';
             }
-            html += '</div>';
+            html += '</div></div>';
         });
         listEl.innerHTML = html;
+        if (window.VimNav) window.VimNav.reset();
     }
 
     // ── AI Analysis ──
@@ -366,7 +387,11 @@
             var costInfo = results[0];
             var tradingResult = results[1];
 
-            var html = '<div class="trading-header trading-vim-item" data-trading-vim="btn" tabindex="0">';
+            // Each card is a row of one item — j/k between cards, Enter
+            // triggers click (button) or toggle (analyst card with body).
+            // The trading-header row's vim-item is the Run button itself;
+            // renderTradingButton emits data-vim-item on the <button>.
+            var html = '<div class="trading-header trading-vim-item" data-trading-vim="btn" data-vim-row>';
             html += '<span class="ai-section-title" style="margin:0">Deep Analysis — Multi-Agent Pipeline</span>';
             html += renderTradingButton(costInfo, tradingResult);
             html += '</div>';
@@ -379,6 +404,7 @@
             container.innerHTML = html;
             wireTradingButton();
             if (tradingResult && !isFinished(tradingResult)) pollTradingStatus();
+            if (window.VimNav) window.VimNav.reset();
         });
     }
 
@@ -391,10 +417,10 @@
         var costStr = costInfo && costInfo.available ? 'Est. $' + costInfo.estimatedCost.toFixed(3) : '';
         var html = '';
         if (isRunning) {
-            html += '<button class="trading-btn trading-btn-running" disabled>'
+            html += '<button class="trading-btn trading-btn-running" disabled data-vim-item>'
                 + '<span class="spinner" style="width:12px;height:12px;display:inline-block"></span> Running…</button>';
         } else {
-            html += '<button class="trading-btn" id="trading-analyze-btn">&#129302; Run Deep Analysis</button>';
+            html += '<button class="trading-btn" id="trading-analyze-btn" data-vim-item>&#129302; Run Deep Analysis</button>';
         }
         if (costStr) html += '<span class="trading-cost">' + esc(costStr) + '</span>';
         if (isFinished(tradingResult) && tradingResult.totalCostUsd !== undefined) {
@@ -439,7 +465,11 @@
         var html = '<div class="trading-analysts">';
         result.analystReports.forEach(function (r) {
             var outlookClass = r.outlook === 'bullish' ? 'price-up' : r.outlook === 'bearish' ? 'price-down' : '';
-            html += '<div class="trading-analyst-card trading-vim-item">';
+            // Whole card is the navigable item AND the row. Enter toggles
+            // its expanded state via data-vim-toggle-class. Each card
+            // sits in its own row so j/k walks between them.
+            html += '<div class="trading-analyst-card trading-vim-item" data-vim-row>';
+            html += '<div class="trading-analyst-card-inner" data-vim-item data-vim-action="toggle" data-vim-toggle-class="trading-panel-open">';
             html += '<div class="trading-analyst-header">';
             html += '<span class="trading-analyst-name">' + esc(r.analyst) + '</span>';
             html += '<span class="trading-analyst-outlook ' + outlookClass + '">' + esc(r.outlook || 'neutral') + '</span>';
@@ -451,7 +481,7 @@
                 r.keyPoints.forEach(function (p) { html += '<li>' + esc(p) + '</li>'; });
                 html += '</ul>';
             }
-            html += '</div></div>';
+            html += '</div></div></div>';
         });
         html += '</div>';
         return html;

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -423,10 +423,10 @@
 
     function loadFinancials(type) {
         // Sub-tab bar with keycap badges
-        var subHtml = '<div class="info-sub-tabs" id="fin-sub-tabs">';
+        var subHtml = '<div class="info-sub-tabs" id="fin-sub-tabs" data-vim-row>';
         finSubTypes.forEach(function (t, i) {
             var active = t.key === type ? ' active' : '';
-            subHtml += '<button class="info-sub-tab' + active + '" data-ftype="' + t.key + '"><span class="tab-key">' + t.hotkey + '</span> ' + t.label + '</button>';
+            subHtml += '<button class="info-sub-tab' + active + '" data-ftype="' + t.key + '" data-vim-item><span class="tab-key">' + t.hotkey + '</span> ' + t.label + '</button>';
         });
         subHtml += '</div><div id="fin-table-container"><p class="empty-state">Loading...</p></div>';
         container.innerHTML = subHtml;
@@ -707,8 +707,8 @@
                     var tip = HELP[field] ? '<span class="help-tip hidden">' + esc(HELP[field]) + '</span>' : '';
                     var format = row[2] || '';
                     var finKey = format === 'calc' ? row[3] + '/' + row[4] : (row[1] || '');
-                    html += '<tr class="fin-row" data-fin-idx="' + rowIdx + '" data-fin-key="' + esc(finKey) + '" data-fin-label="' + esc(row[0]) + '" data-fin-format="' + format + '">';
-                    html += '<td class="fin-label">' + row[0] + tip + '</td>';
+                    html += '<tr class="fin-row" data-fin-idx="' + rowIdx + '" data-fin-key="' + esc(finKey) + '" data-fin-label="' + esc(row[0]) + '" data-fin-format="' + format + '" data-vim-row>';
+                    html += '<td class="fin-label" data-vim-item>' + row[0] + tip + '</td>';
                     data.forEach(function (d) {
                         var val;
                         if (format === 'calc') {
@@ -718,7 +718,7 @@
                         } else {
                             val = fmt(d[row[1]]);
                         }
-                        html += '<td>' + val + '</td>';
+                        html += '<td data-vim-item>' + val + '</td>';
                     });
                     html += '</tr>';
                 });
@@ -794,10 +794,10 @@
     var newsCurrent = 'press-releases'; // remembered across re-entries
 
     function loadNews() {
-        var subHtml = '<div class="info-sub-tabs" id="news-sub-tabs">';
+        var subHtml = '<div class="info-sub-tabs" id="news-sub-tabs" data-vim-row>';
         NEWS_CATS.forEach(function (c) {
             var active = c.key === newsCurrent ? ' active' : '';
-            subHtml += '<button class="info-sub-tab' + active + '" data-cat="' + c.key + '">'
+            subHtml += '<button class="info-sub-tab' + active + '" data-cat="' + c.key + '" data-vim-item>'
                 + c.label + '</button>';
         });
         subHtml += '</div><div id="news-cards-host" class="news-cards-host"></div>';
@@ -845,11 +845,13 @@
                         div.innerHTML = text;
                         var plain = div.textContent || div.innerText || '';
                         if (plain.length > 220) plain = plain.substring(0, 220) + '…';
-                        return '<div class="news-card news-unread">'
+                        var title = (item.title || '').replace(/"/g, '&quot;');
+                        return '<div class="news-card news-unread" data-vim-row>'
+                            + '<div class="news-card-inner" data-vim-item data-vim-action="open-reader" data-vim-url="' + esc(item.url) + '" data-vim-title="' + esc(title) + '">'
                             + '<div class="news-card-title"><a href="' + esc(item.url) + '" onclick="event.preventDefault();if(window._openReader)window._openReader(this.href,this.textContent)">' + esc(item.title) + '</a></div>'
                             + '<div class="news-card-meta"><span>' + esc(item.source || '') + '</span><span>' + date + '</span></div>'
                             + '<div class="news-card-text">' + esc(plain) + '</div>'
-                            + '</div>';
+                            + '</div></div>';
                     }).join('') + '</div>';
             })
             .catch(function () { host.innerHTML = '<p class="empty-state">Failed to load news</p>'; });
@@ -906,19 +908,21 @@
                 html += '</tr></thead><tbody>';
 
                 // Current company
-                html += '<tr class="peer-row peer-current" data-symbol="' + esc(symbol) + '"><td><span class="sym-link">' + esc(symbol) + '</span></td>'
-                    + '<td>' + esc(profile.companyName || '') + '</td>'
-                    + '<td>' + (profile.price ? profile.price.toFixed(2) : '—') + '</td>'
-                    + '<td>' + fmt(profile.marketCap) + '</td>'
-                    + '<td><div class="peer-spark" data-spark-sym="' + esc(symbol) + '"></div></td></tr>';
+                html += '<tr class="peer-row peer-current" data-symbol="' + esc(symbol) + '" data-vim-row data-vim-action="navigate" data-vim-href="/security/' + encodeURIComponent(symbol) + '">'
+                    + '<td data-vim-item><span class="sym-link">' + esc(symbol) + '</span></td>'
+                    + '<td data-vim-item>' + esc(profile.companyName || '') + '</td>'
+                    + '<td data-vim-item>' + (profile.price ? profile.price.toFixed(2) : '—') + '</td>'
+                    + '<td data-vim-item>' + fmt(profile.marketCap) + '</td>'
+                    + '<td data-vim-item><div class="peer-spark" data-spark-sym="' + esc(symbol) + '"></div></td></tr>';
 
                 peers.forEach(function (p) {
                     var cap = p.mktCap || p.marketCap || 0;
-                    html += '<tr class="peer-row" data-symbol="' + esc(p.symbol) + '"><td><span class="sym-link">' + esc(p.symbol) + '</span></td>'
-                        + '<td>' + esc(p.companyName || '') + '</td>'
-                        + '<td>' + (p.price ? p.price.toFixed(2) : '—') + '</td>'
-                        + '<td>' + fmt(cap) + '</td>'
-                        + '<td><div class="peer-spark" data-spark-sym="' + esc(p.symbol) + '"></div></td></tr>';
+                    html += '<tr class="peer-row" data-symbol="' + esc(p.symbol) + '" data-vim-row data-vim-action="navigate" data-vim-href="/security/' + encodeURIComponent(p.symbol) + '">'
+                        + '<td data-vim-item><span class="sym-link">' + esc(p.symbol) + '</span></td>'
+                        + '<td data-vim-item>' + esc(p.companyName || '') + '</td>'
+                        + '<td data-vim-item>' + (p.price ? p.price.toFixed(2) : '—') + '</td>'
+                        + '<td data-vim-item>' + fmt(cap) + '</td>'
+                        + '<td data-vim-item><div class="peer-spark" data-spark-sym="' + esc(p.symbol) + '"></div></td></tr>';
                 });
                 html += '</tbody></table>';
             }
@@ -1103,15 +1107,15 @@
             var html = '<div class="sec-view">';
 
             // Sub-tab row: category filters + Key People view switcher
-            html += '<div class="info-sub-tabs" id="sec-filters">';
+            html += '<div class="info-sub-tabs" id="sec-filters" data-vim-row>';
             categories.forEach(function (cat) {
                 var active = (secView === 'filings' && secFilter === cat.key) ? ' active' : '';
-                html += '<button class="info-sub-tab' + active + '" data-cat="' + cat.key + '" data-view="filings">' + cat.label + '</button>';
+                html += '<button class="info-sub-tab' + active + '" data-cat="' + cat.key + '" data-view="filings" data-vim-item>' + cat.label + '</button>';
             });
             // Visual separator + Key People view switcher
             html += '<span class="sec-tab-sep" aria-hidden="true">|</span>';
             var peopleActive = secView === 'people' ? ' active' : '';
-            html += '<button class="info-sub-tab' + peopleActive + '" data-view="people">Key People</button>';
+            html += '<button class="info-sub-tab' + peopleActive + '" data-view="people" data-vim-item>Key People</button>';
             html += '</div>';
 
             if (secView === 'filings') {
@@ -1131,11 +1135,12 @@
                         var t = typeMap[f.formType] || {};
                         var catClass = 'sec-cat-' + (t.category || 'other');
                         var date = (f.filingDate || '').substring(0, 10);
-                        html += '<tr class="sec-row" data-idx="' + idx + '" data-link="' + esc(f.link || f.finalLink || '') + '">';
-                        html += '<td class="sec-date">' + date + '</td>';
-                        html += '<td><span class="sec-badge ' + catClass + '">' + esc(f.formType) + '</span></td>';
-                        html += '<td class="sec-desc">' + esc(t.title || f.formType) + '</td>';
-                        html += '<td><a href="' + esc(f.link || f.finalLink || '') + '" target="_blank" rel="noopener" class="sec-link">&#8599;</a></td>';
+                        var filingTitle = esc(t.title || f.formType);
+                        html += '<tr class="sec-row" data-idx="' + idx + '" data-link="' + esc(f.link || f.finalLink || '') + '" data-vim-row data-vim-action="open-reader" data-vim-url="' + esc(f.link || f.finalLink || '') + '" data-vim-title="' + filingTitle + '">';
+                        html += '<td class="sec-date" data-vim-item>' + date + '</td>';
+                        html += '<td data-vim-item><span class="sec-badge ' + catClass + '">' + esc(f.formType) + '</span></td>';
+                        html += '<td class="sec-desc" data-vim-item>' + filingTitle + '</td>';
+                        html += '<td data-vim-item><a href="' + esc(f.link || f.finalLink || '') + '" target="_blank" rel="noopener" class="sec-link">&#8599;</a></td>';
                         html += '</tr>';
                     });
                     html += '</tbody></table>';
@@ -1290,12 +1295,15 @@
                 var roleClass = 'kp-event-' + (p.eventType || 'other');
                 var asOf = (p.asOfDate || '').substring(0, 10) || (p.eventDate || '').substring(0, 10) || '—';
                 var form = p.formType ? '<span class="kp-form-badge">' + esc(p.formType) + '</span>' : '';
-                html += '<tr class="kp-row" data-idx="' + (rowIdx++) + '" data-link="' + esc(p.source || '') + '">';
-                html += '<td class="kp-name">' + esc(p.name || '—') + '</td>';
-                html += '<td class="kp-title">' + esc(p.title || '') + '</td>';
-                html += '<td><span class="kp-event ' + roleClass + '">' + esc(p.eventType || 'officer') + '</span></td>';
-                html += '<td class="kp-date">' + esc(asOf) + ' ' + form + '</td>';
-                html += '<td>';
+                var srcUrl = esc(p.source || '');
+                var rowAttrs = ' data-vim-row';
+                if (p.source) rowAttrs += ' data-vim-action="open-reader" data-vim-url="' + srcUrl + '" data-vim-title="' + esc(p.name || '') + '"';
+                html += '<tr class="kp-row" data-idx="' + (rowIdx++) + '" data-link="' + srcUrl + '"' + rowAttrs + '>';
+                html += '<td class="kp-name" data-vim-item>' + esc(p.name || '—') + '</td>';
+                html += '<td class="kp-title" data-vim-item>' + esc(p.title || '') + '</td>';
+                html += '<td data-vim-item><span class="kp-event ' + roleClass + '">' + esc(p.eventType || 'officer') + '</span></td>';
+                html += '<td class="kp-date" data-vim-item>' + esc(asOf) + ' ' + form + '</td>';
+                html += '<td data-vim-item>';
                 if (p.source) {
                     html += '<a class="kp-link" href="' + esc(p.source) + '" target="_blank" rel="noopener">&#8599;</a>';
                 }
@@ -1311,13 +1319,16 @@
                 var date = (p.eventDate || '').substring(0, 10) || '—';
                 var evt = (p.eventType || '').toLowerCase();
                 var evtClass = 'kp-event-' + (evt || 'other');
-                html += '<li class="kp-row" data-idx="' + (rowIdx++) + '" data-link="' + esc(p.source || '') + '">';
-                html += '<span class="kp-date">' + esc(date) + '</span>';
-                html += '<span class="kp-event ' + evtClass + '">' + esc(p.eventType || 'change') + '</span>';
-                html += '<span class="kp-name">' + esc(p.name || '—') + '</span>';
-                html += '<span class="kp-title">' + esc(p.title || '') + '</span>';
+                var srcUrl = esc(p.source || '');
+                var rowAttrs = ' data-vim-row';
+                if (p.source) rowAttrs += ' data-vim-action="open-reader" data-vim-url="' + srcUrl + '" data-vim-title="' + esc(p.name || '') + '"';
+                html += '<li class="kp-row" data-idx="' + (rowIdx++) + '" data-link="' + srcUrl + '"' + rowAttrs + '>';
+                html += '<span class="kp-date" data-vim-item>' + esc(date) + '</span>';
+                html += '<span class="kp-event ' + evtClass + '" data-vim-item>' + esc(p.eventType || 'change') + '</span>';
+                html += '<span class="kp-name" data-vim-item>' + esc(p.name || '—') + '</span>';
+                html += '<span class="kp-title" data-vim-item>' + esc(p.title || '') + '</span>';
                 if (p.source) {
-                    html += '<a class="kp-link" href="' + esc(p.source) + '" target="_blank" rel="noopener">&#8599;</a>';
+                    html += '<a class="kp-link" data-vim-item href="' + esc(p.source) + '" target="_blank" rel="noopener">&#8599;</a>';
                 }
                 html += '</li>';
             });
@@ -1381,7 +1392,7 @@
             var html = '';
 
             // Deep Analysis heading with inline button + cost
-            html += '<div class="trading-header trading-vim-item" data-trading-vim="btn" tabindex="0">';
+            html += '<div class="trading-header trading-vim-item" data-trading-vim="btn" data-vim-row>';
             html += '<span class="ai-section-title" style="margin:0">Deep Analysis — Multi-Agent Pipeline</span>';
             html += renderTradingButton(costInfo, tradingResult);
             html += '</div>';
@@ -1437,10 +1448,10 @@
 
         var html = '';
         if (isRunning) {
-            html += '<button class="trading-btn trading-btn-running" disabled>'
+            html += '<button class="trading-btn trading-btn-running" disabled data-vim-item>'
                 + '<span class="spinner" style="width:12px;height:12px;display:inline-block"></span> Running...</button>';
         } else {
-            html += '<button class="trading-btn" id="trading-analyze-btn">'
+            html += '<button class="trading-btn" id="trading-analyze-btn" data-vim-item>'
                 + '&#129302; Run Deep Analysis</button>';
         }
         if (costStr) html += '<span class="trading-cost">' + esc(costStr) + '</span>';
@@ -1545,8 +1556,9 @@
                                    report.outlook === 'bearish' ? 'price-down' : '';
                 var scoreBar = report.score ? Math.round((report.score + 1) / 2 * 100) : 50;
 
-                html += '<div class="trading-analyst-card trading-vim-item" data-analyst-idx="' + idx + '">';
-                html += '<div class="trading-analyst-header" tabindex="0">';
+                html += '<div class="trading-analyst-card trading-vim-item" data-analyst-idx="' + idx + '" data-vim-row>';
+                html += '<div class="trading-analyst-card-inner" data-vim-item data-vim-action="toggle" data-vim-toggle-class="trading-panel-open">';
+                html += '<div class="trading-analyst-header">';
                 html += '<span class="trading-analyst-name">' + esc(report.analyst) + '</span>';
                 html += '<span class="trading-analyst-outlook ' + outlookClass + '">' + esc(report.outlook || 'neutral') + '</span>';
                 html += '<div class="trading-score-bar"><div class="trading-score-fill" style="width:' + scoreBar + '%"></div></div>';
@@ -1569,7 +1581,7 @@
                     report.sources.forEach(function (s) { html += '<span class="trading-source">' + esc(s) + '</span>'; });
                     html += '</div>';
                 }
-                html += '</div></div>';
+                html += '</div></div></div>';
             });
             html += '</div>';
         }
@@ -1578,8 +1590,9 @@
         if (result.investmentPlan && result.investmentPlan.rating) {
             var plan = result.investmentPlan;
             var ratingClass = 'rating-' + plan.rating.toLowerCase();
-            html += '<div class="trading-analyst-card trading-plan-card trading-vim-item" data-analyst-idx="plan">';
-            html += '<div class="trading-analyst-header" tabindex="0">';
+            html += '<div class="trading-analyst-card trading-plan-card trading-vim-item" data-analyst-idx="plan" data-vim-row>';
+            html += '<div class="trading-analyst-card-inner" data-vim-item data-vim-action="toggle" data-vim-toggle-class="trading-panel-open">';
+            html += '<div class="trading-analyst-header">';
             html += '<span class="trading-analyst-name">Research Verdict</span>';
             html += '<span class="trading-rating ' + ratingClass + '">' + esc(plan.rating) + '</span>';
             if (plan.debateRounds) html += '<span class="trading-plan-rounds">' + plan.debateRounds + ' rounds</span>';
@@ -1622,7 +1635,7 @@
                 html += '</details>';
             }
 
-            html += '</div></div>'; // close trading-analyst-body + trading-analyst-card
+            html += '</div></div></div>'; // close trading-analyst-body + card-inner + card
         }
 
         // Footer — cost + timestamp

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -2500,6 +2500,34 @@ window.onerror = function (msg, src, line, col, err) {
 
     // ── Global Keydown ──
 
+    // Pending 'g' for vim-style 'gg' detection. Single g fires the legacy
+    // graph-jump after 500ms; second g within the window jumps to top of
+    // page via VimNav.
+    var pendingGTimer = null;
+
+    // fireLegacyG runs the historical graph-jump dispatch — used both
+    // when no vim-nav grid is present and on gg timeout.
+    function fireLegacyG(handler) {
+        if (currentView === 'economics' && window._economicsSelectedIdentifier) {
+            var id = window._economicsSelectedIdentifier();
+            if (id) { navigate('graph', id, { skipSecurity: true }); return; }
+        }
+        if (handler && handler.isFinTab && handler.isFinTab()) {
+            var rows = window._finGetRows ? window._finGetRows() : [];
+            var idx = window._finGetSelectedRow ? window._finGetSelectedRow() : -1;
+            if (idx >= 0 && idx < rows.length && selectedSecurity) {
+                var row = rows[idx];
+                var key = row.dataset.finKey || '';
+                if (row.dataset.finFormat !== 'calc' && key && key.indexOf('/') < 0) {
+                    navigate('graph', selectedSecurity + '.' + key, { skipSecurity: true });
+                    return;
+                }
+            }
+        }
+        if (handler && handler.sectorNav) handler.sectorNav('graph');
+        else if (handler && handler.graph) handler.graph();
+    }
+
     // Use capture phase to intercept keys before browser extensions (e.g. Vimium)
     document.addEventListener('keydown', function (e) {
         var active = document.activeElement;
@@ -2546,6 +2574,22 @@ window.onerror = function (msg, src, line, col, err) {
         // ── Normal Mode Keys ──
 
         var handler = vimHandlers[currentView];
+
+        // Declarative vim-nav takes precedence whenever the page has any
+        // [data-vim-row] elements. It owns j/k/h/l/w/b/G/1-9/Enter and
+        // handles gg via a 500ms timer; legacy keys (g, a, d, y, p, etc.)
+        // fall through so per-view handlers keep firing.
+        //
+        // Reader/dropdown modal hijacks remain below this point — they
+        // take precedence over BOTH the new core and the legacy handlers.
+        if (window.VimNav) {
+            // Don't claim h/j/k/l when a modal hijacker would steal them
+            // anyway. Currently only the article reader does this.
+            var readerOpen = false;
+            var readerEl = document.getElementById('article-reader');
+            if (readerEl && !readerEl.classList.contains('hidden')) readerOpen = true;
+            if (!readerOpen && window.VimNav.handleKey(e.key, e)) return;
+        }
 
         switch (e.key) {
             case '/':
@@ -2599,35 +2643,31 @@ window.onerror = function (msg, src, line, col, err) {
                 if (handler && handler.activate) handler.activate();
                 return;
             case 'g':
-                // /economics catalog: navigate to the full graph for the
-                // selected indicator.
-                if (currentView === 'economics' && window._economicsSelectedIdentifier) {
-                    var id = window._economicsSelectedIdentifier();
-                    if (id) {
-                        e.preventDefault();
-                        navigate('graph', id, { skipSecurity: true });
+                // Two-key 'gg' jumps to the first navigable element when
+                // the page has a declarative vim-nav grid; otherwise (or
+                // on a non-g second key / timeout) the legacy g handler
+                // below fires. 500ms is vim's default.
+                e.preventDefault();
+                if (window.VimNav && window.VimNav.hasActiveGrid()) {
+                    if (pendingGTimer !== null) {
+                        clearTimeout(pendingGTimer);
+                        pendingGTimer = null;
+                        window.VimNav.selectFirst();
                         return;
                     }
+                    pendingGTimer = setTimeout(function () {
+                        pendingGTimer = null;
+                        fireLegacyG(handler);
+                    }, 500);
+                    return;
                 }
-                // Financials tab: navigate to /graph/SYMBOL.field for the
-                // selected row. Skip calc rows (margins) — they aren't a raw
-                // field the historical endpoint can fetch.
-                if (handler && handler.isFinTab && handler.isFinTab()) {
-                    var rows = window._finGetRows ? window._finGetRows() : [];
-                    var idx = window._finGetSelectedRow ? window._finGetSelectedRow() : -1;
-                    if (idx >= 0 && idx < rows.length && selectedSecurity) {
-                        var row = rows[idx];
-                        var key = row.dataset.finKey || '';
-                        if (row.dataset.finFormat !== 'calc' && key && key.indexOf('/') < 0) {
-                            e.preventDefault();
-                            navigate('graph', selectedSecurity + '.' + key, { skipSecurity: true });
-                            return;
-                        }
-                    }
-                }
+                fireLegacyG(handler);
+                return;
+            case 'G':
                 e.preventDefault();
-                if (handler && handler.sectorNav) handler.sectorNav('graph');
-                else if (handler && handler.graph) handler.graph();
+                if (window.VimNav && window.VimNav.hasActiveGrid()) {
+                    window.VimNav.selectLast();
+                }
                 return;
             case 'r':
                 e.preventDefault();

--- a/internal/server/static/vim-nav.js
+++ b/internal/server/static/vim-nav.js
@@ -1,0 +1,389 @@
+// vim-nav.js — declarative vim navigation core.
+//
+// Pages opt into vim nav by marking their DOM with two attributes:
+//   data-vim-row     on a container; its descendants carrying
+//                    data-vim-item become one horizontal row.
+//   data-vim-item    on each navigable element.
+//
+// The core scans the DOM, builds a grid (rows × items), and handles
+// the directional keys (j/k/h/l/w/b/1-9/Enter) plus gg/G top/bottom.
+// Bespoke per-view handlers in terminal.js still run for non-nav keys
+// (g for graph-jump, a for :add, d/y/p row ops, etc.) — the core
+// returns true from handleKey only when it claimed the input.
+//
+// Selection state lives on this module (currentRow / currentCol) and
+// is reflected on the DOM via the .vim-selected class. Calling reset()
+// rebuilds the grid (used after page renders re-paint content).
+
+(function () {
+    'use strict';
+
+    var grid = [];           // [{el, items: [...] }, ...]
+    var currentRow = -1;     // -1 = nothing selected yet
+    var currentCol = -1;
+
+    var SELECTED_CLASS = 'vim-selected';
+
+    function buildGrid() {
+        grid = [];
+        var rowEls = document.querySelectorAll('[data-vim-row]');
+        for (var i = 0; i < rowEls.length; i++) {
+            var rowEl = rowEls[i];
+            // Skip rows that aren't visible — display:none parents shouldn't
+            // contribute to the grid (e.g. inactive tab's content tree).
+            if (!isVisible(rowEl)) continue;
+            // Direct descendants with data-vim-item, in DOM order. We
+            // intentionally don't descend through nested data-vim-row
+            // containers — those are their own row.
+            var items = [];
+            var walker = document.createTreeWalker(rowEl, NodeFilter.SHOW_ELEMENT, {
+                acceptNode: function (node) {
+                    if (node === rowEl) return NodeFilter.FILTER_SKIP;
+                    // Stop descending into nested rows — their items
+                    // belong to that row, not this one.
+                    if (node.hasAttribute('data-vim-row')) return NodeFilter.FILTER_REJECT;
+                    if (node.hasAttribute('data-vim-item') && isVisible(node)) {
+                        return NodeFilter.FILTER_ACCEPT;
+                    }
+                    return NodeFilter.FILTER_SKIP;
+                },
+            });
+            var n;
+            while ((n = walker.nextNode())) items.push(n);
+            if (items.length > 0) grid.push({ el: rowEl, items: items });
+        }
+    }
+
+    function isVisible(el) {
+        // Skip elements hidden via display:none. visibility:hidden /
+        // opacity:0 are allowed because they're occasionally used for
+        // transition effects without removing the element from nav.
+        for (var cur = el; cur && cur !== document.body; cur = cur.parentElement) {
+            var s = window.getComputedStyle(cur);
+            if (s && s.display === 'none') return false;
+        }
+        return true;
+    }
+
+    function clearSelection() {
+        document.querySelectorAll('.' + SELECTED_CLASS).forEach(function (el) {
+            el.classList.remove(SELECTED_CLASS);
+        });
+    }
+
+    function applySelection() {
+        clearSelection();
+        if (currentRow < 0 || currentRow >= grid.length) return;
+        var row = grid[currentRow];
+        if (currentCol < 0 || currentCol >= row.items.length) return;
+        var el = row.items[currentCol];
+        el.classList.add(SELECTED_CLASS);
+        el.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    }
+
+    function selectFirst() {
+        buildGrid();
+        if (grid.length === 0) return;
+        currentRow = 0;
+        currentCol = 0;
+        applySelection();
+    }
+
+    function selectLast() {
+        buildGrid();
+        if (grid.length === 0) return;
+        currentRow = grid.length - 1;
+        currentCol = grid[currentRow].items.length - 1;
+        applySelection();
+    }
+
+    // Row down: move to row+1, column 0. j past the last row is a no-op
+    // — by spec the page's last element is the bottom of nav.
+    function moveDown() {
+        buildGrid();
+        if (grid.length === 0) return false;
+        if (currentRow < 0) {
+            currentRow = 0;
+            currentCol = 0;
+        } else if (currentRow < grid.length - 1) {
+            currentRow++;
+            currentCol = 0;
+        } else {
+            return true; // consumed but at end
+        }
+        applySelection();
+        return true;
+    }
+
+    function moveUp() {
+        buildGrid();
+        if (grid.length === 0) return false;
+        if (currentRow < 0) {
+            currentRow = 0;
+            currentCol = 0;
+        } else if (currentRow > 0) {
+            currentRow--;
+            currentCol = 0;
+        } else {
+            return true;
+        }
+        applySelection();
+        return true;
+    }
+
+    function moveRight() {
+        buildGrid();
+        if (grid.length === 0) return false;
+        if (currentRow < 0) {
+            currentRow = 0;
+            currentCol = 0;
+        } else {
+            var row = grid[currentRow];
+            if (currentCol < row.items.length - 1) currentCol++;
+            else return true; // at end of row — by spec h/l doesn't wrap
+        }
+        applySelection();
+        return true;
+    }
+
+    function moveLeft() {
+        buildGrid();
+        if (grid.length === 0) return false;
+        if (currentRow < 0) {
+            currentRow = 0;
+            currentCol = 0;
+        } else if (currentCol > 0) {
+            currentCol--;
+        } else {
+            return true;
+        }
+        applySelection();
+        return true;
+    }
+
+    // w — word forward. Linearised across all rows: end of row wraps
+    // to next row's first item.
+    function wordForward() {
+        buildGrid();
+        if (grid.length === 0) return false;
+        if (currentRow < 0) {
+            currentRow = 0;
+            currentCol = 0;
+        } else {
+            var row = grid[currentRow];
+            if (currentCol < row.items.length - 1) currentCol++;
+            else if (currentRow < grid.length - 1) {
+                currentRow++;
+                currentCol = 0;
+            } else return true;
+        }
+        applySelection();
+        return true;
+    }
+
+    function wordBack() {
+        buildGrid();
+        if (grid.length === 0) return false;
+        if (currentRow < 0) {
+            currentRow = 0;
+            currentCol = 0;
+        } else if (currentCol > 0) {
+            currentCol--;
+        } else if (currentRow > 0) {
+            currentRow--;
+            currentCol = grid[currentRow].items.length - 1;
+        } else return true;
+        applySelection();
+        return true;
+    }
+
+    // Numeric jump: select the nth tab. By convention the tab strip is
+    // row 0 — every page that uses vim-nav puts data-vim-row on the
+    // tab container first. This matches the long-standing "press 5 →
+    // AI tab" affordance regardless of where the user currently is in
+    // the page.
+    function numericJump(n) {
+        buildGrid();
+        if (grid.length === 0) return false;
+        var row = grid[0];
+        if (n < 1 || n > row.items.length) return true;
+        currentRow = 0;
+        currentCol = n - 1;
+        applySelection();
+        return true;
+    }
+
+    // Enter — fire the selected item's primary action.
+    function activate() {
+        if (currentRow < 0 || currentRow >= grid.length) return false;
+        var row = grid[currentRow];
+        if (currentCol < 0 || currentCol >= row.items.length) return false;
+        var el = row.items[currentCol];
+        var action = el.getAttribute('data-vim-action') || 'click';
+        switch (action) {
+            case 'none':
+                return true;
+            case 'click':
+                el.click();
+                return true;
+            case 'toggle':
+                // Toggle a collapsed/expanded state. Convention: the
+                // element carries a sibling class to flip. Default is
+                // .panel-open on the element itself.
+                var cls = el.getAttribute('data-vim-toggle-class') || 'panel-open';
+                el.classList.toggle(cls);
+                return true;
+            case 'open-reader':
+                var url = el.getAttribute('data-vim-url') ||
+                          (el.querySelector('a') && el.querySelector('a').href) || '';
+                var title = el.getAttribute('data-vim-title') ||
+                            (el.textContent || '').trim().slice(0, 200);
+                if (url && window._openReader) window._openReader(url, title);
+                return true;
+            case 'navigate':
+                var href = el.getAttribute('data-vim-href');
+                if (href) window.location.href = href;
+                return true;
+            default:
+                el.click();
+                return true;
+        }
+    }
+
+    // hasActiveGrid is the gate: if the page has any data-vim-row,
+    // VimNav owns the directional keys. Otherwise it returns false
+    // and terminal.js dispatches to legacy handlers untouched.
+    function hasActiveGrid() {
+        return document.querySelector('[data-vim-row]') !== null;
+    }
+
+    var NUMERIC_KEYS = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
+
+    function handleKey(key, e) {
+        if (!hasActiveGrid()) {
+            // No declarative nav on this page — let terminal.js's legacy
+            // handler take the keys.
+            return false;
+        }
+        switch (key) {
+            case 'j':
+                if (e) e.preventDefault();
+                moveDown();
+                return true;
+            case 'k':
+                if (e) e.preventDefault();
+                moveUp();
+                return true;
+            case 'h':
+                if (e) e.preventDefault();
+                moveLeft();
+                return true;
+            case 'l':
+                if (e) e.preventDefault();
+                moveRight();
+                return true;
+            case 'w':
+                if (e) e.preventDefault();
+                wordForward();
+                return true;
+            case 'b':
+                if (e) e.preventDefault();
+                wordBack();
+                return true;
+            case 'Enter':
+                if (currentRow < 0) return false;
+                if (e) e.preventDefault();
+                activate();
+                return true;
+        }
+        if (NUMERIC_KEYS.indexOf(key) >= 0) {
+            if (e) e.preventDefault();
+            numericJump(parseInt(key, 10));
+            return true;
+        }
+        // g / gg / G are handled by terminal.js so the gg-vs-legacy-g
+        // 500ms timer can coexist with per-view graph-jump handlers.
+        return false;
+    }
+
+    function reset() {
+        // Called when a page repaints its content. We rebuild the grid
+        // and try to preserve selection — if the previously selected
+        // element survives the repaint we keep it; otherwise clear.
+        var prevEl = null;
+        if (currentRow >= 0 && grid[currentRow] && grid[currentRow].items[currentCol]) {
+            prevEl = grid[currentRow].items[currentCol];
+        }
+        buildGrid();
+        if (prevEl && document.contains(prevEl)) {
+            // Find the new coordinates for the same element.
+            for (var i = 0; i < grid.length; i++) {
+                var idx = grid[i].items.indexOf(prevEl);
+                if (idx >= 0) {
+                    currentRow = i;
+                    currentCol = idx;
+                    applySelection();
+                    return;
+                }
+            }
+        }
+        currentRow = -1;
+        currentCol = -1;
+        clearSelection();
+    }
+
+    // Auto-reset on DOM mutations to the main content area. Pages render
+    // tab content via container.innerHTML = '...' — there's no clean way
+    // to ask each render path to call reset() without scattering calls
+    // through info.js, crypto.js, etc. A debounced MutationObserver on
+    // #info-content (or document.body as a fallback) catches every paint
+    // without per-page wiring.
+    var resetTimer = null;
+    function scheduleReset() {
+        if (resetTimer) clearTimeout(resetTimer);
+        resetTimer = setTimeout(function () {
+            resetTimer = null;
+            reset();
+        }, 50);
+    }
+
+    function observeMutations() {
+        var target = document.getElementById('info-content') || document.body;
+        if (!target) return;
+        var observer = new MutationObserver(function (mutations) {
+            // Skip mutations that are just our own .vim-selected class
+            // toggles — they'd trigger an infinite loop otherwise.
+            for (var i = 0; i < mutations.length; i++) {
+                var m = mutations[i];
+                if (m.type === 'attributes' && m.attributeName === 'class') {
+                    continue;
+                }
+                scheduleReset();
+                return;
+            }
+        });
+        observer.observe(target, {
+            childList: true,
+            subtree: true,
+            attributes: false,
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', observeMutations);
+    } else {
+        observeMutations();
+    }
+
+    window.VimNav = {
+        handleKey: handleKey,
+        reset: reset,
+        selectFirst: selectFirst,
+        selectLast: selectLast,
+        hasActiveGrid: hasActiveGrid,
+        // For debugging / tests.
+        _state: function () {
+            return { row: currentRow, col: currentCol, gridSize: grid.length };
+        },
+    };
+})();

--- a/internal/server/templates/crypto.html
+++ b/internal/server/templates/crypto.html
@@ -2,11 +2,11 @@
 {{define "content"}}
 <div id="company-panel" class="company-panel"></div>
 <span id="help-indicator" class="help-indicator hidden">? help on</span>
-<div class="info-tabs" id="info-tabs">
-    <button class="info-tab active" data-tab="overview"><span class="tab-key">1</span> Overview</button>
-    <button class="info-tab" data-tab="news"><span class="tab-key">2</span> News</button>
-    <button class="info-tab" data-tab="ai"><span class="tab-key">3</span> AI Analysis</button>
-    <button class="info-tab" data-tab="peers"><span class="tab-key">4</span> Peer Coins</button>
+<div class="info-tabs" id="info-tabs" data-vim-row>
+    <button class="info-tab active" data-tab="overview" data-vim-item><span class="tab-key">1</span> Overview</button>
+    <button class="info-tab" data-tab="news" data-vim-item><span class="tab-key">2</span> News</button>
+    <button class="info-tab" data-tab="ai" data-vim-item><span class="tab-key">3</span> AI Analysis</button>
+    <button class="info-tab" data-tab="peers" data-vim-item><span class="tab-key">4</span> Peer Coins</button>
 </div>
 <div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
     <p class="empty-state">Loading...</p>

--- a/internal/server/templates/etf.html
+++ b/internal/server/templates/etf.html
@@ -2,12 +2,12 @@
 {{define "content"}}
 <div id="company-panel" class="company-panel"></div>
 <span id="help-indicator" class="help-indicator hidden">? help on</span>
-<div class="info-tabs" id="info-tabs">
-    <button class="info-tab active" data-tab="overview"><span class="tab-key">1</span> Overview</button>
-    <button class="info-tab" data-tab="holdings"><span class="tab-key">2</span> Holdings</button>
-    <button class="info-tab" data-tab="sectors"><span class="tab-key">3</span> Sectors</button>
-    <button class="info-tab" data-tab="news"><span class="tab-key">4</span> News</button>
-    <button class="info-tab" data-tab="ai"><span class="tab-key">5</span> AI Analysis</button>
+<div class="info-tabs" id="info-tabs" data-vim-row>
+    <button class="info-tab active" data-tab="overview" data-vim-item><span class="tab-key">1</span> Overview</button>
+    <button class="info-tab" data-tab="holdings" data-vim-item><span class="tab-key">2</span> Holdings</button>
+    <button class="info-tab" data-tab="sectors" data-vim-item><span class="tab-key">3</span> Sectors</button>
+    <button class="info-tab" data-tab="news" data-vim-item><span class="tab-key">4</span> News</button>
+    <button class="info-tab" data-tab="ai" data-vim-item><span class="tab-key">5</span> AI Analysis</button>
 </div>
 <div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
     <p class="empty-state">Loading...</p>

--- a/internal/server/templates/forex.html
+++ b/internal/server/templates/forex.html
@@ -2,11 +2,11 @@
 {{define "content"}}
 <div id="company-panel" class="company-panel"></div>
 <span id="help-indicator" class="help-indicator hidden">? help on</span>
-<div class="info-tabs" id="info-tabs">
-    <button class="info-tab active" data-tab="overview"><span class="tab-key">1</span> Overview</button>
-    <button class="info-tab" data-tab="news"><span class="tab-key">2</span> News</button>
-    <button class="info-tab" data-tab="ai"><span class="tab-key">3</span> AI Analysis</button>
-    <button class="info-tab" data-tab="central-banks"><span class="tab-key">4</span> Central Banks</button>
+<div class="info-tabs" id="info-tabs" data-vim-row>
+    <button class="info-tab active" data-tab="overview" data-vim-item><span class="tab-key">1</span> Overview</button>
+    <button class="info-tab" data-tab="news" data-vim-item><span class="tab-key">2</span> News</button>
+    <button class="info-tab" data-tab="ai" data-vim-item><span class="tab-key">3</span> AI Analysis</button>
+    <button class="info-tab" data-tab="central-banks" data-vim-item><span class="tab-key">4</span> Central Banks</button>
 </div>
 <div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
     <p class="empty-state">Loading...</p>

--- a/internal/server/templates/fund.html
+++ b/internal/server/templates/fund.html
@@ -2,10 +2,10 @@
 {{define "content"}}
 <div id="company-panel" class="company-panel"></div>
 <span id="help-indicator" class="help-indicator hidden">? help on</span>
-<div class="info-tabs" id="info-tabs">
-    <button class="info-tab active" data-tab="overview"><span class="tab-key">1</span> Overview</button>
-    <button class="info-tab" data-tab="news"><span class="tab-key">2</span> News</button>
-    <button class="info-tab" data-tab="ai"><span class="tab-key">3</span> AI Analysis</button>
+<div class="info-tabs" id="info-tabs" data-vim-row>
+    <button class="info-tab active" data-tab="overview" data-vim-item><span class="tab-key">1</span> Overview</button>
+    <button class="info-tab" data-tab="news" data-vim-item><span class="tab-key">2</span> News</button>
+    <button class="info-tab" data-tab="ai" data-vim-item><span class="tab-key">3</span> AI Analysis</button>
 </div>
 <div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
     <p class="empty-state">Loading...</p>

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -2,12 +2,12 @@
 {{define "content"}}
 <div id="company-panel" class="company-panel"></div>
 <span id="help-indicator" class="help-indicator hidden">? help on</span>
-<div class="info-tabs" id="info-tabs">
-    <button class="info-tab active" data-tab="overview"><span class="tab-key">1</span> Overview</button>
-    <button class="info-tab" data-tab="components"><span class="tab-key">2</span> Components</button>
-    <button class="info-tab" data-tab="movers"><span class="tab-key">3</span> Movers</button>
-    <button class="info-tab" data-tab="news"><span class="tab-key">4</span> News</button>
-    <button class="info-tab" data-tab="ai"><span class="tab-key">5</span> AI Analysis</button>
+<div class="info-tabs" id="info-tabs" data-vim-row>
+    <button class="info-tab active" data-tab="overview" data-vim-item><span class="tab-key">1</span> Overview</button>
+    <button class="info-tab" data-tab="components" data-vim-item><span class="tab-key">2</span> Components</button>
+    <button class="info-tab" data-tab="movers" data-vim-item><span class="tab-key">3</span> Movers</button>
+    <button class="info-tab" data-tab="news" data-vim-item><span class="tab-key">4</span> News</button>
+    <button class="info-tab" data-tab="ai" data-vim-item><span class="tab-key">5</span> AI Analysis</button>
 </div>
 <div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
     <p class="empty-state">Loading...</p>

--- a/internal/server/templates/layout.html
+++ b/internal/server/templates/layout.html
@@ -40,6 +40,7 @@
         <div id="clock" class="footer-clocks"></div>
     </footer>
     <script src="/static/lightweight-charts.js"></script>
+    <script src="/static/vim-nav.js?v={{.AssetVersion}}"></script>
     <script src="/static/terminal.js?v={{.AssetVersion}}"></script>
 </body>
 </html>{{end}}

--- a/internal/server/templates/security.html
+++ b/internal/server/templates/security.html
@@ -2,14 +2,14 @@
 {{define "content"}}
 <div id="company-panel" class="company-panel"></div>
 <span id="help-indicator" class="help-indicator hidden">? help on</span>
-<div class="info-tabs" id="info-tabs">
-    <button class="info-tab active" data-tab="overview"><span class="tab-key">1</span> Overview</button>
-    <button class="info-tab" data-tab="financials"><span class="tab-key">2</span> Financials</button>
-    <button class="info-tab" data-tab="estimates"><span class="tab-key">3</span> Estimates</button>
-    <button class="info-tab" data-tab="news"><span class="tab-key">4</span> News</button>
-    <button class="info-tab" data-tab="ai"><span class="tab-key">5</span> AI Analysis</button>
-    <button class="info-tab" data-tab="sector"><span class="tab-key">6</span> Sector</button>
-    <button class="info-tab" data-tab="sec"><span class="tab-key">7</span> SEC</button>
+<div class="info-tabs" id="info-tabs" data-vim-row>
+    <button class="info-tab active" data-tab="overview" data-vim-item><span class="tab-key">1</span> Overview</button>
+    <button class="info-tab" data-tab="financials" data-vim-item><span class="tab-key">2</span> Financials</button>
+    <button class="info-tab" data-tab="estimates" data-vim-item><span class="tab-key">3</span> Estimates</button>
+    <button class="info-tab" data-tab="news" data-vim-item><span class="tab-key">4</span> News</button>
+    <button class="info-tab" data-tab="ai" data-vim-item><span class="tab-key">5</span> AI Analysis</button>
+    <button class="info-tab" data-tab="sector" data-vim-item><span class="tab-key">6</span> Sector</button>
+    <button class="info-tab" data-tab="sec" data-vim-item><span class="tab-key">7</span> SEC</button>
 </div>
 <div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
     <p class="empty-state">Loading...</p>

--- a/tests/e2e/vim_nav_test.go
+++ b/tests/e2e/vim_nav_test.go
@@ -1,0 +1,80 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// vim-nav.js is the declarative navigation core. These tests confirm
+// the static asset is reachable and that each migrated page renders
+// the data-vim-row / data-vim-item markers the core scans for. The
+// behavioural tests (j/k/h/l actually navigating) need a browser and
+// are documented in the PR body.
+
+func TestSmoke_VimNav_AssetReachable(t *testing.T) {
+	resp := get(t, "/static/vim-nav.js")
+	defer resp.Body.Close()
+	assertStatus(t, resp, 200)
+	body, _ := io.ReadAll(resp.Body)
+	s := string(body)
+	for _, want := range []string{"VimNav", "data-vim-row", "data-vim-item"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("expected %q in vim-nav.js, got: %.300s", want, s)
+		}
+	}
+}
+
+// Each migrated page must emit data-vim-row on its tabs container.
+// Server-side template rendering is enough to verify — the JS-emitted
+// per-tab content rows are tested separately at runtime.
+func TestSmoke_VimNav_TabRowMarkup(t *testing.T) {
+	cases := []struct {
+		path string
+	}{
+		{"/security/AAPL"},
+		{"/crypto/BTCUSD"},
+		{"/etf/SPY"},
+		{"/index/^DJI"},
+		{"/forex/USDGBP"},
+		{"/fund/BRHYX"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			resp := get(t, tc.path)
+			defer resp.Body.Close()
+			assertStatus(t, resp, 200)
+			body, _ := io.ReadAll(resp.Body)
+			s := string(body)
+			if !strings.Contains(s, `data-vim-row`) {
+				t.Errorf("expected data-vim-row in %s rendered HTML", tc.path)
+			}
+			if !strings.Contains(s, `data-vim-item`) {
+				t.Errorf("expected data-vim-item in %s rendered HTML", tc.path)
+			}
+		})
+	}
+}
+
+// The layout template must include vim-nav.js BEFORE terminal.js so
+// the VimNav global is defined when terminal.js wires its dispatcher.
+func TestSmoke_VimNav_LoadedBeforeTerminal(t *testing.T) {
+	resp := get(t, "/watchlist") // any page that uses the layout
+	defer resp.Body.Close()
+	assertStatus(t, resp, 200)
+	body, _ := io.ReadAll(resp.Body)
+	s := string(body)
+	vimIdx := strings.Index(s, "vim-nav.js")
+	termIdx := strings.Index(s, "terminal.js")
+	if vimIdx < 0 {
+		t.Fatal("vim-nav.js script tag missing from layout")
+	}
+	if termIdx < 0 {
+		t.Fatal("terminal.js script tag missing from layout")
+	}
+	if vimIdx > termIdx {
+		t.Errorf("vim-nav.js (%d) must come before terminal.js (%d) in layout", vimIdx, termIdx)
+	}
+}


### PR DESCRIPTION
## Summary
The spike for #104. Introduces a tiny **vim-nav.js** core that handles `j` / `k` / `h` / `l` / `w` / `b` / `G` / `1`-`9` / `Enter` against any DOM marked with `data-vim-row` + `data-vim-item`. A 500ms `gg` sequencer in `terminal.js` rounds out the vim-style top-of-page jump. Pages that opt in get vim navigation for free.

## Key map (matches user spec)

```
j / k          row down / up
h / l          column left / right (intra-row)
w / b          word forward / back (linearised across all rows)
1 .. 9         numeric jump to the nth tab (row 0 is always the tabs row)
Enter          fire the selected item's primary action
gg             jump to first navigable element (500ms two-keystroke)
G              jump to last navigable element

Pass-through (per-view handlers still fire):
  Esc, :, /, s, ?, g (legacy graph-jump fallback if gg times out),
  a, d, y, p, \, z, r
```

## Schema
```html
<div class="info-tabs" data-vim-row>
  <button class="info-tab" data-vim-item data-vim-action="click">Overview</button>
</div>

<div class="news-cards">
  <div class="news-card" data-vim-row>
    <div class="news-card-inner" data-vim-item
         data-vim-action="open-reader"
         data-vim-url="https://…"
         data-vim-title="…">…</div>
  </div>
</div>
```

Actions: `click` (default) | `toggle` (uses `data-vim-toggle-class`) | `open-reader` (uses `data-vim-url` + `data-vim-title`) | `navigate` (uses `data-vim-href`) | `none`.

A `MutationObserver` on `#info-content` (or `document.body` as fallback) auto-resets the grid on DOM changes — pages don't need to call `VimNav.reset()` manually after each tab load.

## Pages migrated
- **/security/{sym}** — the complex one. 7 tabs × per-tab content rows. Financial rows with column-aware cells, SEC filings with `open-reader` actions, AI tab analyst cards toggle on Enter.
- **/crypto/{sym}** — tabs + overview + news + AI + peer coins.
- **/etf/{sym}** — Holdings + Sectors get column-aware rows.
- **/forex/{sym}** — Central Banks tab with `navigate` actions.
- **/index/{sym}** — Components + Movers + News with column-aware rows.
- **All News tabs across the above** — sub-tabs row + article rows with open-reader.

## Reader modality
When the article reader is open, the dispatcher skips VimNav and routes through the existing `handleReaderNav` (terminal.js:~3050). Underlying page nav stays blocked. Matches the user's "News panel is its own page" note.

## Legacy handler in info
`vimHandlers.info.move()` (250 lines, 14 special cases) is now dead code for directional keys — VimNav claims them first via the early return. It stays in place for the legacy `g` / `a` / `r` / `?` / `d` / `y` keys until the follow-up issues complete their migrations. Cleanup can land in those PRs.

## Deferred (one issue each)
- #116 — Ideas page (pane-focus migration)
- #117 — Economics page (catalog drill-down)
- #118 — Watchlist page (preserve d/y/p row ops)
- #119 — Top-level News page
- #120 — Graph page (h/l timeline scroll coexistence)

## Test plan
- [x] `make build` — terminal.js + vim-nav.js + 5 page JS files all lint
- [x] `make test` — Go unit suite green
- [x] `make smoke` — full e2e suite green, including 3 new tests:
  - `GET /static/vim-nav.js` reachable, contains VimNav + data-vim-row + data-vim-item
  - Each migrated page emits `data-vim-row` + `data-vim-item` in its rendered HTML
  - `vim-nav.js` loads before `terminal.js` in layout
- [ ] **Manual browser sweep (required before merge)** — couldn't fire dev server locally; please verify on each migrated page:
  - `/index/^DJI` — j/k/h/l/w/b/gg/G across Overview → Components → Movers → News → AI
  - `/etf/SPY` — Holdings & Sectors columns walk with w/b/h/l
  - `/security/AAPL` — every tab including SEC filing rows → reader → reader handles its own keys
  - `/crypto/BTCUSD` and `/forex/USDGBP` — tab nav works (the original visible bug from #104)
  - Reader modality: open an article, j/k scrolls reader, keys don't bleed to the page underneath
  - Legacy keys (`g` on financials → /graph/AAPL.field, `r` refresh, `?` help) still fire

Closes #104