### PR TITLE
feat: paper trading + FMP screener + vim keybindings

### DIFF
--- a/internal/news/news.go
+++ b/internal/news/news.go
@@ -273,6 +273,15 @@ func (c *Client) GetProfile(ctx context.Context, symbol string) (json.RawMessage
 	return c.fetchJSON(ctx, "/stable/profile", params)
 }
 
+// GetCompanyScreener runs FMP's /stable/company-screener with the supplied
+// filter params. Caller is responsible for assembling the url.Values from
+// validated query params; we pass them through verbatim. Returned shape is a
+// JSON array of candidate companies (symbol, companyName, marketCap, sector,
+// industry, beta, price, volume, exchange, country, isEtf/isFund/...).
+func (c *Client) GetCompanyScreener(ctx context.Context, params url.Values) (json.RawMessage, error) {
+	return c.fetchJSON(ctx, "/stable/company-screener", params)
+}
+
 // GetQuote returns the realtime quote for a symbol. Unlike /stable/profile
 // which is empty for crypto / forex, /stable/quote works uniformly across
 // stocks, ETFs, crypto, forex, and indices — and crucially carries the

--- a/internal/paper/sizing.go
+++ b/internal/paper/sizing.go
@@ -1,0 +1,150 @@
+// Package paper implements the rules-enforced manual paper-trading layer:
+// per-instrument position sizing math, ticket validation, and the trade
+// lifecycle (open → mark → close) backed by the SQLite store.
+package paper
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+// InstrumentType discriminates how sizing math should be applied.
+type InstrumentType string
+
+const (
+	InstrumentEquity InstrumentType = "equity"
+	InstrumentFuture InstrumentType = "future"
+	InstrumentOption InstrumentType = "option"
+	InstrumentCFD    InstrumentType = "cfd"
+	InstrumentForex  InstrumentType = "forex"
+)
+
+// Side captures direction. Stop is below entry for long, above for short.
+type Side string
+
+const (
+	SideLong  Side = "long"
+	SideShort Side = "short"
+)
+
+// TicketInput is everything ComputeSize needs to produce a size.
+//
+// Conventions per instrument:
+//   - equity / cfd      : multiplier=1, entry and stop in quote currency per share
+//   - future            : multiplier=contract spec ($/point), e.g. ES=50, CL=1000
+//   - option (defined)  : multiplier=100 (US), entry=premium per share, stop=0
+//   - forex             : multiplier = currency-per-pip * lot-size, e.g. micro EURUSD = $0.10/pip
+type TicketInput struct {
+	InstrumentType InstrumentType
+	Multiplier     float64
+	Side           Side
+	EntryPrice     float64
+	StopPrice      float64
+	AccountSize    float64
+	RiskPct        float64 // fraction, 0.02 = 2%
+}
+
+// SizingResult is the output of ComputeSize.
+type SizingResult struct {
+	Size         float64 // whole units (shares or contracts)
+	RiskAmount   float64 // currency at risk at this size
+	StopDistance float64 // abs(entry - stop) in quote terms
+}
+
+var (
+	ErrInvalidAccount    = errors.New("account size must be positive")
+	ErrInvalidRisk       = errors.New("risk pct must be in (0, 1]")
+	ErrInvalidEntry      = errors.New("entry price must be positive")
+	ErrInvalidStop       = errors.New("stop price must be non-negative")
+	ErrZeroStopDistance  = errors.New("entry equals stop — sizing is undefined")
+	ErrInvalidMultiplier = errors.New("multiplier must be positive")
+	ErrInvalidSide       = errors.New("side must be long or short")
+	ErrSideStopMismatch  = errors.New("long stop must be below entry; short stop must be above entry")
+)
+
+// ComputeSize returns the largest whole-unit position that keeps loss-at-stop ≤ account × risk%.
+//
+// size = floor((account × risk%) / (|entry - stop| × multiplier))
+//
+// For options modelled as defined-risk longs, set stop=0 — the formula then
+// degenerates to size = floor(riskAmount / (premium × 100)) which is the
+// premium-paid sizing rule.
+func ComputeSize(t TicketInput) (SizingResult, error) {
+	if err := validate(t); err != nil {
+		return SizingResult{}, err
+	}
+
+	stopDistance := math.Abs(t.EntryPrice - t.StopPrice)
+	riskBudget := t.AccountSize * t.RiskPct
+	perUnitRisk := stopDistance * t.Multiplier
+
+	size := math.Floor(riskBudget / perUnitRisk)
+	if size < 0 {
+		size = 0
+	}
+
+	return SizingResult{
+		Size:         size,
+		RiskAmount:   size * perUnitRisk,
+		StopDistance: stopDistance,
+	}, nil
+}
+
+func validate(t TicketInput) error {
+	if t.AccountSize <= 0 {
+		return ErrInvalidAccount
+	}
+	if t.RiskPct <= 0 || t.RiskPct > 1 {
+		return ErrInvalidRisk
+	}
+	if t.EntryPrice <= 0 {
+		return ErrInvalidEntry
+	}
+	if t.StopPrice < 0 {
+		return ErrInvalidStop
+	}
+	if t.Multiplier <= 0 {
+		return ErrInvalidMultiplier
+	}
+	if t.Side != SideLong && t.Side != SideShort {
+		return ErrInvalidSide
+	}
+	if math.Abs(t.EntryPrice-t.StopPrice) < 1e-9 {
+		return ErrZeroStopDistance
+	}
+	// Side/stop sanity — options stop=0 is allowed for either side.
+	if t.StopPrice > 0 {
+		if t.Side == SideLong && t.StopPrice >= t.EntryPrice {
+			return ErrSideStopMismatch
+		}
+		if t.Side == SideShort && t.StopPrice <= t.EntryPrice {
+			return ErrSideStopMismatch
+		}
+	}
+	return nil
+}
+
+// DefaultMultiplier returns a reasonable default per instrument.
+// Forex and futures often need user overrides (per contract spec / per lot).
+func DefaultMultiplier(it InstrumentType) float64 {
+	switch it {
+	case InstrumentOption:
+		return 100
+	case InstrumentEquity, InstrumentCFD:
+		return 1
+	default:
+		return 1
+	}
+}
+
+// ParseInstrument is a small helper for handler code.
+func ParseInstrument(s string) (InstrumentType, error) {
+	it := InstrumentType(s)
+	switch it {
+	case InstrumentEquity, InstrumentFuture, InstrumentOption, InstrumentCFD, InstrumentForex:
+		return it, nil
+	default:
+		return "", fmt.Errorf("unknown instrument type %q", s)
+	}
+}

--- a/internal/paper/sizing_test.go
+++ b/internal/paper/sizing_test.go
@@ -1,0 +1,187 @@
+package paper
+
+import (
+	"errors"
+	"math"
+	"testing"
+)
+
+func TestComputeSize(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      TicketInput
+		wantSize   float64
+		wantRisk   float64
+		wantErr    error
+	}{
+		{
+			name: "equity long, 2% of 10k, $5 stop distance, 1.0 multiplier",
+			input: TicketInput{
+				InstrumentType: InstrumentEquity,
+				Multiplier:     1,
+				Side:           SideLong,
+				EntryPrice:     150,
+				StopPrice:      145,
+				AccountSize:    10000,
+				RiskPct:        0.02,
+			},
+			wantSize: 40, // floor(200 / 5) = 40 shares
+			wantRisk: 200,
+		},
+		{
+			name: "equity short, 2% of 10k, $5 stop distance above",
+			input: TicketInput{
+				InstrumentType: InstrumentEquity,
+				Multiplier:     1,
+				Side:           SideShort,
+				EntryPrice:     145,
+				StopPrice:      150,
+				AccountSize:    10000,
+				RiskPct:        0.02,
+			},
+			wantSize: 40,
+			wantRisk: 200,
+		},
+		{
+			name: "ES future, 2% of 10k, 4 points stop, multiplier 50",
+			input: TicketInput{
+				InstrumentType: InstrumentFuture,
+				Multiplier:     50,
+				Side:           SideLong,
+				EntryPrice:     5000,
+				StopPrice:      4996,
+				AccountSize:    10000,
+				RiskPct:        0.02,
+			},
+			wantSize: 1, // floor(200 / (4 * 50)) = floor(1.0) = 1
+			wantRisk: 200,
+		},
+		{
+			name: "Long option, premium-paid sizing, $2.50 premium, multiplier 100",
+			input: TicketInput{
+				InstrumentType: InstrumentOption,
+				Multiplier:     100,
+				Side:           SideLong,
+				EntryPrice:     2.50,
+				StopPrice:      0,
+				AccountSize:    10000,
+				RiskPct:        0.02,
+			},
+			wantSize: 0, // floor(200 / 250) = 0 — can't afford one contract at 2% on 10k
+			wantRisk: 0,
+		},
+		{
+			name: "Long option that fits, $1.50 premium",
+			input: TicketInput{
+				InstrumentType: InstrumentOption,
+				Multiplier:     100,
+				Side:           SideLong,
+				EntryPrice:     1.50,
+				StopPrice:      0,
+				AccountSize:    10000,
+				RiskPct:        0.02,
+			},
+			wantSize: 1, // floor(200 / 150) = 1
+			wantRisk: 150,
+		},
+		{
+			name: "1% risk after settling — half the size",
+			input: TicketInput{
+				InstrumentType: InstrumentEquity,
+				Multiplier:     1,
+				Side:           SideLong,
+				EntryPrice:     150,
+				StopPrice:      145,
+				AccountSize:    10000,
+				RiskPct:        0.01,
+			},
+			wantSize: 20, // floor(100 / 5)
+			wantRisk: 100,
+		},
+		{
+			name: "CFD, treated like equity for sizing",
+			input: TicketInput{
+				InstrumentType: InstrumentCFD,
+				Multiplier:     1,
+				Side:           SideLong,
+				EntryPrice:     50,
+				StopPrice:      48,
+				AccountSize:    5000,
+				RiskPct:        0.02,
+			},
+			wantSize: 50, // floor(100 / 2)
+			wantRisk: 100,
+		},
+		{
+			name: "Forex micro lot EURUSD, $0.10/pip multiplier, 50-pip stop",
+			input: TicketInput{
+				InstrumentType: InstrumentForex,
+				Multiplier:     1000, // micro lot notional in base currency
+				Side:           SideLong,
+				EntryPrice:     1.0850,
+				StopPrice:      1.0800,
+				AccountSize:    10000,
+				RiskPct:        0.02,
+			},
+			// stop distance 0.0050, perUnitRisk = 0.005 * 1000 = 5 per micro lot
+			// size = floor(200 / 5) = 40 micro lots
+			wantSize: 40,
+			wantRisk: 200,
+		},
+
+		// Error paths
+		{
+			name: "negative account",
+			input: TicketInput{
+				InstrumentType: InstrumentEquity, Multiplier: 1, Side: SideLong,
+				EntryPrice: 100, StopPrice: 95, AccountSize: -1, RiskPct: 0.02,
+			},
+			wantErr: ErrInvalidAccount,
+		},
+		{
+			name: "risk over 100%",
+			input: TicketInput{
+				InstrumentType: InstrumentEquity, Multiplier: 1, Side: SideLong,
+				EntryPrice: 100, StopPrice: 95, AccountSize: 10000, RiskPct: 1.5,
+			},
+			wantErr: ErrInvalidRisk,
+		},
+		{
+			name: "long with stop above entry",
+			input: TicketInput{
+				InstrumentType: InstrumentEquity, Multiplier: 1, Side: SideLong,
+				EntryPrice: 100, StopPrice: 105, AccountSize: 10000, RiskPct: 0.02,
+			},
+			wantErr: ErrSideStopMismatch,
+		},
+		{
+			name: "stop equals entry",
+			input: TicketInput{
+				InstrumentType: InstrumentEquity, Multiplier: 1, Side: SideLong,
+				EntryPrice: 100, StopPrice: 100, AccountSize: 10000, RiskPct: 0.02,
+			},
+			wantErr: ErrZeroStopDistance,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ComputeSize(tc.input)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("want error %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if math.Abs(got.Size-tc.wantSize) > 1e-9 {
+				t.Errorf("size: want %v, got %v", tc.wantSize, got.Size)
+			}
+			if math.Abs(got.RiskAmount-tc.wantRisk) > 1e-9 {
+				t.Errorf("risk: want %v, got %v", tc.wantRisk, got.RiskAmount)
+			}
+		})
+	}
+}

--- a/internal/server/paper.go
+++ b/internal/server/paper.go
@@ -1,0 +1,309 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"stocktopus/internal/paper"
+	"stocktopus/internal/store"
+)
+
+// handlePaperPage renders the single-page paper trading surface (ticket + positions + journal).
+func (s *Server) handlePaperPage(w http.ResponseWriter, r *http.Request) {
+	s.renderPage(w, r, "paper.html", map[string]any{
+		"Title":  "Paper",
+		"Active": "paper",
+	})
+}
+
+// --- accounts -----------------------------------------------------------
+
+func (s *Server) handleListPaperAccounts(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.store == nil {
+		_ = json.NewEncoder(w).Encode([]any{})
+		return
+	}
+	accounts, err := s.store.GetPaperAccounts()
+	if err != nil {
+		s.logger.Error("list paper accounts", "error", err)
+		http.Error(w, "list failed", http.StatusInternalServerError)
+		return
+	}
+	if accounts == nil {
+		accounts = []store.PaperAccount{}
+	}
+	_ = json.NewEncoder(w).Encode(accounts)
+}
+
+func (s *Server) handleCreatePaperAccount(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.store == nil {
+		http.Error(w, "store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	var req struct {
+		Name            string  `json:"name"`
+		BaseCurrency    string  `json:"baseCurrency"`
+		StartingBalance float64 `json:"startingBalance"`
+		RiskPct         float64 `json:"riskPct"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	req.Name = strings.TrimSpace(req.Name)
+	if req.Name == "" || req.StartingBalance <= 0 || req.RiskPct <= 0 {
+		http.Error(w, "name, startingBalance and riskPct are required", http.StatusBadRequest)
+		return
+	}
+	if req.BaseCurrency == "" {
+		req.BaseCurrency = "USD"
+	}
+	id, err := s.store.CreatePaperAccount(req.Name, req.BaseCurrency, req.StartingBalance, req.RiskPct)
+	if err != nil {
+		s.logger.Error("create paper account", "error", err)
+		http.Error(w, "create failed", http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
+}
+
+func (s *Server) handleSetPaperAccountSettled(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		http.Error(w, "store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		http.Error(w, "bad id", http.StatusBadRequest)
+		return
+	}
+	var req struct {
+		Settled bool    `json:"settled"`
+		RiskPct float64 `json:"riskPct"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&req)
+	if err := s.store.SetPaperAccountSettled(id, req.Settled); err != nil {
+		http.Error(w, "update failed", http.StatusInternalServerError)
+		return
+	}
+	if req.RiskPct > 0 {
+		if err := s.store.SetPaperAccountRisk(id, req.RiskPct); err != nil {
+			http.Error(w, "update risk failed", http.StatusInternalServerError)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- sizing preview -----------------------------------------------------
+
+// handlePaperSizingPreview computes size + risk for the form input. Used live
+// by the ticket UI on every keystroke.
+func (s *Server) handlePaperSizingPreview(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	var req struct {
+		InstrumentType string  `json:"instrumentType"`
+		Multiplier     float64 `json:"multiplier"`
+		Side           string  `json:"side"`
+		EntryPrice     float64 `json:"entryPrice"`
+		StopPrice      float64 `json:"stopPrice"`
+		AccountSize    float64 `json:"accountSize"`
+		RiskPct        float64 `json:"riskPct"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	it, err := paper.ParseInstrument(req.InstrumentType)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Multiplier == 0 {
+		req.Multiplier = paper.DefaultMultiplier(it)
+	}
+	res, err := paper.ComputeSize(paper.TicketInput{
+		InstrumentType: it,
+		Multiplier:     req.Multiplier,
+		Side:           paper.Side(req.Side),
+		EntryPrice:     req.EntryPrice,
+		StopPrice:      req.StopPrice,
+		AccountSize:    req.AccountSize,
+		RiskPct:        req.RiskPct,
+	})
+	if err != nil {
+		// Validation errors are normal user state; return them as JSON, not 500.
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": err.Error()})
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"size":         res.Size,
+		"riskAmount":   res.RiskAmount,
+		"stopDistance": res.StopDistance,
+	})
+}
+
+// --- trades -------------------------------------------------------------
+
+func (s *Server) handleOpenPaperTrade(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.store == nil {
+		http.Error(w, "store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req struct {
+		AccountID      int64    `json:"accountId"`
+		SketchID       *int64   `json:"sketchId,omitempty"`
+		Symbol         string   `json:"symbol"`
+		InstrumentType string   `json:"instrumentType"`
+		Multiplier     float64  `json:"multiplier"`
+		Side           string   `json:"side"`
+		EntryPrice     float64  `json:"entryPrice"`
+		StopPrice      float64  `json:"stopPrice"`
+		TargetPrice    *float64 `json:"targetPrice,omitempty"`
+		Thesis         string   `json:"thesis"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+
+	account, err := s.store.GetPaperAccount(req.AccountID)
+	if err != nil {
+		http.Error(w, "account not found", http.StatusNotFound)
+		return
+	}
+	it, err := paper.ParseInstrument(req.InstrumentType)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Multiplier == 0 {
+		req.Multiplier = paper.DefaultMultiplier(it)
+	}
+
+	sizing, err := paper.ComputeSize(paper.TicketInput{
+		InstrumentType: it,
+		Multiplier:     req.Multiplier,
+		Side:           paper.Side(req.Side),
+		EntryPrice:     req.EntryPrice,
+		StopPrice:      req.StopPrice,
+		AccountSize:    account.CashBalance,
+		RiskPct:        account.RiskPct,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if sizing.Size < 1 {
+		http.Error(w, "computed size is zero — entry/stop/risk would buy fewer than 1 unit", http.StatusBadRequest)
+		return
+	}
+
+	trade := store.PaperTrade{
+		AccountID:      account.ID,
+		SketchID:       req.SketchID,
+		Symbol:         strings.ToUpper(strings.TrimSpace(req.Symbol)),
+		InstrumentType: string(it),
+		Multiplier:     req.Multiplier,
+		Side:           req.Side,
+		EntryPrice:     req.EntryPrice,
+		StopPrice:      req.StopPrice,
+		TargetPrice:    req.TargetPrice,
+		Size:           sizing.Size,
+		RiskPctAtEntry: account.RiskPct,
+		RiskAmount:     sizing.RiskAmount,
+		OpenedAt:       time.Now().UTC(),
+		Thesis:         req.Thesis,
+	}
+	id, err := s.store.OpenPaperTrade(trade)
+	if err != nil {
+		s.logger.Error("open paper trade", "error", err)
+		http.Error(w, "open failed", http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"id":         id,
+		"size":       sizing.Size,
+		"riskAmount": sizing.RiskAmount,
+	})
+}
+
+func (s *Server) handleListOpenPaperTrades(w http.ResponseWriter, r *http.Request) {
+	s.listPaperTrades(w, r, true)
+}
+
+func (s *Server) handleListClosedPaperTrades(w http.ResponseWriter, r *http.Request) {
+	s.listPaperTrades(w, r, false)
+}
+
+func (s *Server) listPaperTrades(w http.ResponseWriter, r *http.Request, open bool) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.store == nil {
+		_ = json.NewEncoder(w).Encode([]any{})
+		return
+	}
+	accountID, err := strconv.ParseInt(r.URL.Query().Get("accountId"), 10, 64)
+	if err != nil {
+		http.Error(w, "accountId required", http.StatusBadRequest)
+		return
+	}
+	var trades []store.PaperTrade
+	if open {
+		trades, err = s.store.GetOpenPaperTrades(accountID)
+	} else {
+		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+		trades, err = s.store.GetClosedPaperTrades(accountID, limit, offset)
+	}
+	if err != nil {
+		s.logger.Error("list paper trades", "error", err)
+		http.Error(w, "list failed", http.StatusInternalServerError)
+		return
+	}
+	if trades == nil {
+		trades = []store.PaperTrade{}
+	}
+	_ = json.NewEncoder(w).Encode(trades)
+}
+
+func (s *Server) handleClosePaperTrade(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		http.Error(w, "store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		http.Error(w, "bad id", http.StatusBadRequest)
+		return
+	}
+	var req struct {
+		ExitPrice float64 `json:"exitPrice"`
+		Reason    string  `json:"reason"` // 'stop' | 'target' | 'manual'
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	if req.ExitPrice <= 0 || req.Reason == "" {
+		http.Error(w, "exitPrice and reason required", http.StatusBadRequest)
+		return
+	}
+	if err := s.store.ClosePaperTrade(id, req.ExitPrice, req.Reason); err != nil {
+		if errors.Is(err, nil) {
+			http.Error(w, "close failed", http.StatusInternalServerError)
+			return
+		}
+		s.logger.Error("close paper trade", "error", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/server/screener.go
+++ b/internal/server/screener.go
@@ -1,0 +1,284 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// nativeScreenerParams lists the FMP company-screener query parameters we pass
+// through verbatim. Anything not in this set is treated as a custom filter and
+// applied post-fetch against the batch-quote pass.
+var nativeScreenerParams = map[string]bool{
+	"marketCapMoreThan":  true,
+	"marketCapLowerThan": true,
+	"priceMoreThan":      true,
+	"priceLowerThan":     true,
+	"betaMoreThan":       true,
+	"betaLowerThan":      true,
+	"volumeMoreThan":     true,
+	"volumeLowerThan":    true,
+	"dividendMoreThan":   true,
+	"dividendLowerThan":  true,
+	"sector":             true,
+	"industry":           true,
+	"country":            true,
+	"exchange":           true,
+	"isEtf":              true,
+	"isFund":             true,
+	"isActivelyTrading":  true,
+	"limit":              true,
+}
+
+// screenerResult is the per-row payload returned to the UI. It includes both
+// the native screener fields and the derived intraday metrics computed from
+// the batch-quote post-pass.
+type screenerResult struct {
+	Symbol             string  `json:"symbol"`
+	CompanyName        string  `json:"companyName"`
+	Sector             string  `json:"sector"`
+	Industry           string  `json:"industry"`
+	Exchange           string  `json:"exchange"`
+	Country            string  `json:"country"`
+	MarketCap          float64 `json:"marketCap"`
+	Beta               float64 `json:"beta"`
+	Price              float64 `json:"price"`
+	Volume             float64 `json:"volume"`
+	Open               float64 `json:"open"`
+	PreviousClose      float64 `json:"previousClose"`
+	DayHigh            float64 `json:"dayHigh"`
+	DayLow             float64 `json:"dayLow"`
+	ChangeFromOpen     float64 `json:"changeFromOpen"`     // percent
+	ChangeFromPrevDay  float64 `json:"changeFromPrevDay"`  // percent (== FMP changePercentage)
+	ChangeVsMarket     float64 `json:"changeVsMarket"`     // percent points (own change - SPY change)
+}
+
+// batchQuoteRow mirrors the relevant subset of FMP's /stable/batch-quote item.
+type batchQuoteRow struct {
+	Symbol           string  `json:"symbol"`
+	Price            float64 `json:"price"`
+	ChangePercentage float64 `json:"changePercentage"`
+	Volume           float64 `json:"volume"`
+	DayHigh          float64 `json:"dayHigh"`
+	DayLow           float64 `json:"dayLow"`
+	Open             float64 `json:"open"`
+	PreviousClose    float64 `json:"previousClose"`
+}
+
+// screenerCandidate mirrors the FMP company-screener item.
+type screenerCandidate struct {
+	Symbol      string  `json:"symbol"`
+	CompanyName string  `json:"companyName"`
+	MarketCap   float64 `json:"marketCap"`
+	Sector      string  `json:"sector"`
+	Industry    string  `json:"industry"`
+	Beta        float64 `json:"beta"`
+	Price       float64 `json:"price"`
+	Volume      float64 `json:"volume"`
+	Exchange    string  `json:"exchange"`
+	Country     string  `json:"country"`
+}
+
+// handleScreenerAPI: GET /api/screener?<filters>
+//
+// Filters split into two groups:
+//   - Native FMP company-screener params (see nativeScreenerParams): pass through
+//   - Derived/intraday filters (changeFromOpenMin/Max, changeFromPrevDayMin/Max,
+//     changeVsMarketMin/Max): applied client-side against batch-quote data
+//
+// Returns up to `limit` rows (default 50, max 250).
+func (s *Server) handleScreenerAPI(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.news == nil {
+		http.Error(w, "news client unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	q := r.URL.Query()
+
+	// Split native vs custom; build the FMP request.
+	fmpParams := url.Values{}
+	for key, vals := range q {
+		if nativeScreenerParams[key] && len(vals) > 0 && vals[0] != "" {
+			fmpParams.Set(key, vals[0])
+		}
+	}
+	// Sensible defaults for native limit if the user didn't set one.
+	if fmpParams.Get("limit") == "" {
+		fmpParams.Set("limit", "250")
+	}
+
+	ctx := r.Context()
+	rawCandidates, err := s.news.GetCompanyScreener(ctx, fmpParams)
+	if err != nil {
+		s.logger.Error("screener: company-screener fetch", "error", err)
+		http.Error(w, "screener fetch failed", http.StatusBadGateway)
+		return
+	}
+	var candidates []screenerCandidate
+	if err := json.Unmarshal(rawCandidates, &candidates); err != nil {
+		s.logger.Error("screener: candidates unmarshal", "error", err)
+		http.Error(w, "bad upstream response", http.StatusBadGateway)
+		return
+	}
+	if len(candidates) == 0 {
+		_ = json.NewEncoder(w).Encode([]any{})
+		return
+	}
+
+	// Batch-quote the candidates + SPY for the market-relative calc.
+	symbols := make([]string, 0, len(candidates)+1)
+	symbols = append(symbols, "SPY")
+	for _, c := range candidates {
+		symbols = append(symbols, c.Symbol)
+	}
+	quotes, err := s.batchQuotes(ctx, symbols)
+	if err != nil {
+		s.logger.Error("screener: batch-quote fetch", "error", err)
+		http.Error(w, "quote fetch failed", http.StatusBadGateway)
+		return
+	}
+	spy, hasSPY := quotes["SPY"]
+
+	// Custom filter thresholds (any may be missing).
+	custom := parseCustomFilters(q)
+
+	results := make([]screenerResult, 0, len(candidates))
+	for _, c := range candidates {
+		qRow, ok := quotes[c.Symbol]
+		if !ok {
+			continue // skip if no quote (illiquid / suspended / off-hours rounding)
+		}
+		row := buildScreenerResult(c, qRow, spy, hasSPY)
+		if !custom.match(row) {
+			continue
+		}
+		results = append(results, row)
+	}
+
+	// Final limit cap (after custom filters drop rows). Default 50.
+	displayLimit := 50
+	if l, err := strconv.Atoi(q.Get("displayLimit")); err == nil && l > 0 && l <= 250 {
+		displayLimit = l
+	}
+	if len(results) > displayLimit {
+		results = results[:displayLimit]
+	}
+
+	_ = json.NewEncoder(w).Encode(results)
+}
+
+// batchQuotes fetches /stable/batch-quote for the given symbols and returns
+// them keyed by symbol. Chunks at 200 to stay friendly with the URL length.
+func (s *Server) batchQuotes(ctx context.Context, symbols []string) (map[string]batchQuoteRow, error) {
+	out := make(map[string]batchQuoteRow, len(symbols))
+	const chunkSize = 200
+	for i := 0; i < len(symbols); i += chunkSize {
+		end := i + chunkSize
+		if end > len(symbols) {
+			end = len(symbols)
+		}
+		raw, err := s.news.GetBatchQuote(ctx, symbols[i:end])
+		if err != nil {
+			return nil, fmt.Errorf("batch-quote chunk: %w", err)
+		}
+		var rows []batchQuoteRow
+		if err := json.Unmarshal(raw, &rows); err != nil {
+			return nil, fmt.Errorf("batch-quote unmarshal: %w", err)
+		}
+		for _, r := range rows {
+			out[r.Symbol] = r
+		}
+	}
+	return out, nil
+}
+
+// buildScreenerResult fuses screener candidate + quote into the response row,
+// computing the derived intraday metrics. Robust against zero-valued open /
+// previousClose (returns 0 rather than +Inf).
+func buildScreenerResult(c screenerCandidate, q batchQuoteRow, spy batchQuoteRow, hasSPY bool) screenerResult {
+	cfo := 0.0
+	if q.Open != 0 {
+		cfo = (q.Price - q.Open) / q.Open * 100
+	}
+	cfp := q.ChangePercentage
+	cvm := 0.0
+	if hasSPY {
+		cvm = cfp - spy.ChangePercentage
+	}
+	return screenerResult{
+		Symbol:            c.Symbol,
+		CompanyName:       c.CompanyName,
+		Sector:            c.Sector,
+		Industry:          c.Industry,
+		Exchange:          c.Exchange,
+		Country:           c.Country,
+		MarketCap:         c.MarketCap,
+		Beta:              c.Beta,
+		Price:             q.Price,
+		Volume:            q.Volume,
+		Open:              q.Open,
+		PreviousClose:     q.PreviousClose,
+		DayHigh:           q.DayHigh,
+		DayLow:            q.DayLow,
+		ChangeFromOpen:    cfo,
+		ChangeFromPrevDay: cfp,
+		ChangeVsMarket:    cvm,
+	}
+}
+
+// customFilters captures the post-fetch numeric thresholds. Each pointer is
+// nil if the user didn't specify that bound.
+type customFilters struct {
+	cfoMin, cfoMax *float64 // change from open %
+	cfpMin, cfpMax *float64 // change from previous-day close %
+	cvmMin, cvmMax *float64 // change vs market (percent points)
+}
+
+func parseCustomFilters(q url.Values) customFilters {
+	parse := func(k string) *float64 {
+		s := strings.TrimSpace(q.Get(k))
+		if s == "" {
+			return nil
+		}
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return nil
+		}
+		return &f
+	}
+	return customFilters{
+		cfoMin: parse("changeFromOpenMin"),
+		cfoMax: parse("changeFromOpenMax"),
+		cfpMin: parse("changeFromPrevDayMin"),
+		cfpMax: parse("changeFromPrevDayMax"),
+		cvmMin: parse("changeVsMarketMin"),
+		cvmMax: parse("changeVsMarketMax"),
+	}
+}
+
+func (f customFilters) match(r screenerResult) bool {
+	if f.cfoMin != nil && r.ChangeFromOpen < *f.cfoMin {
+		return false
+	}
+	if f.cfoMax != nil && r.ChangeFromOpen > *f.cfoMax {
+		return false
+	}
+	if f.cfpMin != nil && r.ChangeFromPrevDay < *f.cfpMin {
+		return false
+	}
+	if f.cfpMax != nil && r.ChangeFromPrevDay > *f.cfpMax {
+		return false
+	}
+	if f.cvmMin != nil && r.ChangeVsMarket < *f.cvmMin {
+		return false
+	}
+	if f.cvmMax != nil && r.ChangeVsMarket > *f.cvmMax {
+		return false
+	}
+	return true
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -116,7 +116,7 @@ func (s *Server) loadTemplates() error {
 	layoutPath := filepath.Join(templatesDir(), "layout.html")
 	s.pages = make(map[string]*template.Template)
 
-	pageNames := []string{"watchlist", "stock", "security", "crypto", "etf", "fund", "index", "forex", "screener", "feed", "debug", "news", "indices", "ideas", "economics", "economic-graph", "financial-graph"}
+	pageNames := []string{"watchlist", "stock", "security", "crypto", "etf", "fund", "index", "forex", "screener", "feed", "debug", "news", "indices", "ideas", "economics", "economic-graph", "financial-graph", "paper"}
 	for _, page := range pageNames {
 		pagePath := filepath.Join(templatesDir(), page+".html")
 		t, err := template.ParseFiles(layoutPath, pagePath)
@@ -219,6 +219,20 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /ideas/{id}", s.handleIdeas)
 	mux.HandleFunc("GET /economics", s.handleEconomics)
 	mux.HandleFunc("GET /debug", s.handleDebug)
+	mux.HandleFunc("GET /paper", s.handlePaperPage)
+
+	// Screener
+	mux.HandleFunc("GET /api/screener", s.handleScreenerAPI)
+
+	// Paper trading
+	mux.HandleFunc("GET /api/paper/accounts", s.handleListPaperAccounts)
+	mux.HandleFunc("POST /api/paper/accounts", s.handleCreatePaperAccount)
+	mux.HandleFunc("POST /api/paper/accounts/{id}/settled", s.handleSetPaperAccountSettled)
+	mux.HandleFunc("POST /api/paper/sizing/preview", s.handlePaperSizingPreview)
+	mux.HandleFunc("POST /api/paper/trades", s.handleOpenPaperTrade)
+	mux.HandleFunc("GET /api/paper/trades/open", s.handleListOpenPaperTrades)
+	mux.HandleFunc("GET /api/paper/trades/closed", s.handleListClosedPaperTrades)
+	mux.HandleFunc("POST /api/paper/trades/{id}/close", s.handleClosePaperTrade)
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/static/economics.js
+++ b/internal/server/static/economics.js
@@ -17,19 +17,20 @@
     var calendarFiltered = [];
     var calendarFilter = '';
     var calendarImpact = 'all';
-    var calendarIdx = -1;
 
     // Catalog drill-down state.
     //   level: 'cb' (central-bank list) | 'indicators' (one CB's indicator list)
     var catalogLevel = 'cb';
     var catalogCBs = [];
-    var catalogCBIdx = -1;
     var catalogCountry = '';
 
     var catalogRows = [];
     var catalogFiltered = [];
     var catalogFilter = '';
-    var catalogIdx = -1;
+
+    // Selection is owned by vim-nav.js via the .vim-selected class on a
+    // [data-vim-row] element. Page-specific hooks read the selected row
+    // through helpers below; no per-list integer indices kept here.
 
     function $(id) { return document.getElementById(id); }
     function escapeHTML(s) {
@@ -56,7 +57,6 @@
         });
         $('economics-calendar-panel').classList.toggle('hidden', name !== 'calendar');
         $('economics-catalog-panel').classList.toggle('hidden', name !== 'catalog');
-        applyVimSelection();
     }
 
     // ── Calendar filter directive parsing ──
@@ -150,7 +150,7 @@
                 surpriseClass = d > 0 ? 'pos' : (d < 0 ? 'neg' : '');
             }
             var impactClass = 'impact-' + (r.impact || 'Low').toLowerCase();
-            html += '<tr class="economics-row" data-idx="' + i + '">'
+            html += '<tr class="economics-row" data-vim-row data-idx="' + i + '">'
                 + '<td class="economics-date">' + escapeHTML(r.date || '') + '</td>'
                 + '<td class="economics-country">' + escapeHTML(r.country || '') + '</td>'
                 + '<td class="economics-event">' + escapeHTML(r.event || '') + '</td>'
@@ -162,8 +162,6 @@
                 + '</tr>';
         }
         tbody.innerHTML = html;
-        calendarIdx = -1;
-        applyVimSelection();
     }
 
     // ── Catalog tab — level 1: central bank list ──
@@ -189,7 +187,9 @@
         // and reads as "pick a central bank" rather than "row 1 of N".
         var html = '<div class="economics-cb-tiles">';
         catalogCBs.forEach(function (cb, i) {
-            html += '<button type="button" class="economics-cb-tile economics-row" data-idx="' + i + '" data-country="' + escapeHTML(cb.country) + '">'
+            html += '<button type="button" class="economics-cb-tile economics-row" '
+                + 'data-vim-row data-vim-action="click" data-idx="' + i + '" '
+                + 'data-country="' + escapeHTML(cb.country) + '">'
                 + '<span class="cb-tile-country">' + escapeHTML(cb.country) + '</span>'
                 + '<span class="cb-tile-name">' + escapeHTML(cb.name) + '</span>'
                 + '<span class="cb-tile-count">' + cb.indicators + ' indicators</span>'
@@ -197,7 +197,6 @@
         });
         html += '</div>';
         $('economics-cb-list').innerHTML = html;
-        catalogCBIdx = -1;
     }
 
     function enterCentralBank(country, displayName) {
@@ -208,7 +207,6 @@
         $('economics-cb-title').textContent = displayName + ' — ' + country;
         catalogFilter = '';
         $('economics-catalog-filter').value = '';
-        catalogIdx = -1;
         loadCatalog(country);
     }
 
@@ -217,7 +215,6 @@
         catalogCountry = '';
         $('economics-cb-list').classList.remove('hidden');
         $('economics-cb-detail').classList.add('hidden');
-        applyVimSelection();
     }
 
     // ── Catalog tab — level 2: indicator list for one CB ──
@@ -264,7 +261,8 @@
                 var cat = order[i];
                 html += '<tr class="economics-cat-row"><td colspan="5">' + escapeHTML(cat) + '</td></tr>';
                 groups[cat].forEach(function (r) {
-                    html += '<tr class="economics-row economics-catalog-row" data-idx="' + r._idx + '"'
+                    html += '<tr class="economics-row economics-catalog-row" '
+                        + 'data-vim-row data-idx="' + r._idx + '"'
                         + ' data-identifier="' + escapeHTML(r.identifier) + '"'
                         + ' data-code="' + escapeHTML(r.code) + '">'
                         + '<td class="economics-code">' + escapeHTML(r.identifier) + '</td>'
@@ -278,8 +276,6 @@
             html += '</tbody></table>';
         }
         $('economics-catalog-host').innerHTML = html;
-        catalogIdx = -1;
-        applyVimSelection();
     }
 
     // ── Slide-in chart preview (article-reader pane) ──
@@ -392,70 +388,23 @@
         return true;
     }
 
-    // ── Vim selection / cursor ──
-
-    function currentRowSet() {
-        if (activeTab === 'calendar') {
-            return { items: calendarFiltered, container: $('economics-calendar-body'), idx: calendarIdx };
-        }
-        if (catalogLevel === 'cb') {
-            return { items: catalogCBs, container: $('economics-cb-list'), idx: catalogCBIdx };
-        }
-        return { items: catalogFiltered, container: $('economics-catalog-host'), idx: catalogIdx };
-    }
-
-    function applyVimSelection() {
-        document.querySelectorAll('.economics-row.vim-selected').forEach(function (el) {
-            el.classList.remove('vim-selected');
-        });
-        var st = currentRowSet();
-        if (st.idx < 0 || !st.container) return;
-        var row = st.container.querySelector('.economics-row[data-idx="' + st.idx + '"]');
-        if (row) {
-            row.classList.add('vim-selected');
-            row.scrollIntoView({ block: 'nearest' });
-        }
-    }
-
     // ── Public vim hooks ──
+    //
+    // Selection is managed declaratively by vim-nav.js — it applies
+    // .vim-selected to the active [data-vim-row]. These hooks just read
+    // the selected row's data attributes; no per-list state lives here.
 
-    window._economicsMove = function (dir) {
-        if (dir === 'h' || dir === 'l') {
-            if (activeTab === 'catalog' && catalogLevel === 'indicators' && dir === 'h') {
-                backToCentralBanks();
-                return;
-            }
-            var next = activeTab === 'calendar' ? 'catalog' : 'calendar';
-            if ((dir === 'h' && activeTab === 'catalog') || (dir === 'l' && activeTab === 'calendar')) {
-                switchTab(next);
-            }
-            return;
-        }
-        var st = currentRowSet();
-        if (st.items.length === 0) return;
-        var idx = st.idx;
-        if (dir === 'j') idx = Math.min(idx + 1, st.items.length - 1);
-        else if (dir === 'k') idx = Math.max(idx - 1, 0);
-        if (activeTab === 'calendar') calendarIdx = idx;
-        else if (catalogLevel === 'cb') catalogCBIdx = idx;
-        else catalogIdx = idx;
-        applyVimSelection();
-    };
-
-    window._economicsActivate = function () {
-        // Reserved for a future drill-in. Today only the CB-list level uses
-        // Enter — to descend into a CB's indicators.
-        if (activeTab !== 'catalog' || catalogLevel !== 'cb') return;
-        if (catalogCBIdx < 0 || catalogCBIdx >= catalogCBs.length) return;
-        var cb = catalogCBs[catalogCBIdx];
-        enterCentralBank(cb.country, cb.name);
-    };
+    function selectedCatalogRow() {
+        var sel = document.querySelector('.economics-catalog-row.vim-selected');
+        return sel || null;
+    }
 
     window._economicsAddCmd = function () {
         if (activeTab !== 'catalog' || catalogLevel !== 'indicators') return null;
-        if (catalogIdx < 0 || catalogIdx >= catalogFiltered.length) return null;
-        var r = catalogFiltered[catalogIdx];
-        return ':add ' + r.identifier;
+        var row = selectedCatalogRow();
+        if (!row) return null;
+        var identifier = row.getAttribute('data-identifier');
+        return identifier ? ':add ' + identifier : null;
     };
 
     // Toggle behavior: if the eco-chart slide-in is already open for the same
@@ -464,9 +413,11 @@
     var lastPreviewKey = null;
     window._economicsOpenPreview = function (rangeKey) {
         if (activeTab !== 'catalog' || catalogLevel !== 'indicators') return false;
-        if (catalogIdx < 0 || catalogIdx >= catalogFiltered.length) return false;
-        var r = catalogFiltered[catalogIdx];
-        var key = r.identifier + ':' + (rangeKey || '5y');
+        var row = selectedCatalogRow();
+        if (!row) return false;
+        var identifier = row.getAttribute('data-identifier');
+        if (!identifier) return false;
+        var key = identifier + ':' + (rangeKey || '5y');
         var reader = $('article-reader');
         var openOnSame = reader && !reader.classList.contains('hidden')
             && reader.dataset.mode === 'eco-chart'
@@ -477,7 +428,7 @@
             return true;
         }
         lastPreviewKey = key;
-        openPreviewForIdentifier(r.identifier, rangeKey !== 'full');
+        openPreviewForIdentifier(identifier, rangeKey !== 'full');
         return true;
     };
 
@@ -490,8 +441,8 @@
     // Selected-row identifier exposed for the `g` keybinding's navigation hop.
     window._economicsSelectedIdentifier = function () {
         if (activeTab !== 'catalog' || catalogLevel !== 'indicators') return null;
-        if (catalogIdx < 0 || catalogIdx >= catalogFiltered.length) return null;
-        return catalogFiltered[catalogIdx].identifier;
+        var row = selectedCatalogRow();
+        return row ? row.getAttribute('data-identifier') : null;
     };
 
     // ── Wiring ──
@@ -532,7 +483,9 @@
         $('economics-calendar-filter').addEventListener('keydown', exitFilter);
         $('economics-catalog-filter').addEventListener('keydown', exitFilter);
 
-        // Click handlers — CB tile, indicator row, back button
+        // Click handlers — CB tile (mouse path; keyboard goes through
+        // vim-nav's data-vim-action="click" which fires the same handler).
+        // Catalog-row clicks are no-op now: vim-nav owns row selection.
         $('economics-cb-list').addEventListener('click', function (e) {
             var tile = e.target.closest('.economics-cb-tile');
             if (tile) {
@@ -541,15 +494,6 @@
             }
         });
         $('economics-cb-back').addEventListener('click', backToCentralBanks);
-        $('economics-catalog-host').addEventListener('click', function (e) {
-            var row = e.target.closest('.economics-catalog-row');
-            if (!row) return;
-            var idx = parseInt(row.dataset.idx, 10);
-            if (!isNaN(idx)) {
-                catalogIdx = idx;
-                applyVimSelection();
-            }
-        });
 
         loadCalendar();
         loadCentralBanks();

--- a/internal/server/static/paper.js
+++ b/internal/server/static/paper.js
@@ -1,0 +1,290 @@
+(function () {
+    'use strict';
+
+    const state = {
+        accounts: [],
+        activeAccountId: null,
+        debounceTimer: null,
+        lastSizing: null,
+    };
+
+    const $ = (id) => document.getElementById(id);
+
+    // --- account sidebar ------------------------------------------------
+
+    async function loadAccounts() {
+        const res = await fetch('/api/paper/accounts');
+        state.accounts = await res.json();
+        renderAccounts();
+        if (state.accounts.length && !state.activeAccountId) {
+            selectAccount(state.accounts[0].id);
+        }
+    }
+
+    function renderAccounts() {
+        const ul = $('paper-account-list');
+        if (!state.accounts.length) {
+            ul.innerHTML = '<li class="empty-state">No accounts yet. Click "+ New".</li>';
+            return;
+        }
+        ul.innerHTML = state.accounts.map((a) => {
+            const sel = a.id === state.activeAccountId ? ' selected' : '';
+            const settled = a.settled ? ' · settled' : '';
+            return `<li class="paper-account-item${sel}" data-id="${a.id}">
+                <div class="paper-account-name">${escape(a.name)}</div>
+                <div class="paper-account-meta">${a.baseCurrency} ${fmt(a.cashBalance)} · ${(a.riskPct * 100).toFixed(2)}%${settled}</div>
+            </li>`;
+        }).join('');
+        ul.querySelectorAll('.paper-account-item').forEach((el) => {
+            el.addEventListener('click', () => selectAccount(parseInt(el.dataset.id, 10)));
+        });
+    }
+
+    function selectAccount(id) {
+        state.activeAccountId = id;
+        renderAccounts();
+        renderAccountSummary();
+        refreshTrades();
+        previewSizing();
+    }
+
+    function renderAccountSummary() {
+        const a = state.accounts.find((x) => x.id === state.activeAccountId);
+        if (!a) {
+            $('paper-account-summary').innerHTML = '';
+            return;
+        }
+        $('paper-account-summary').innerHTML = `
+            <div class="paper-summary-row"><span>Starting</span><span>${fmt(a.startingBalance)}</span></div>
+            <div class="paper-summary-row"><span>Cash</span><span>${fmt(a.cashBalance)}</span></div>
+            <div class="paper-summary-row"><span>Risk</span><span>${(a.riskPct * 100).toFixed(2)}%</span></div>
+            <div class="paper-summary-row"><span>Settled</span><span>${a.settled ? 'yes' : 'no'}</span></div>
+        `;
+    }
+
+    // --- new account modal (lightweight prompt for v1) ------------------
+
+    $('paper-new-account').addEventListener('click', async () => {
+        const name = prompt('Account name?');
+        if (!name) return;
+        const startingBalance = parseFloat(prompt('Starting balance (in base currency)?', '10000'));
+        if (!(startingBalance > 0)) return alert('Invalid balance.');
+        const riskPct = parseFloat(prompt('Risk per bid (e.g. 0.02 for 2%)?', '0.02'));
+        if (!(riskPct > 0 && riskPct <= 1)) return alert('Risk must be between 0 and 1.');
+        const currency = prompt('Base currency (USD/GBP/EUR)?', 'USD') || 'USD';
+        const res = await fetch('/api/paper/accounts', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, baseCurrency: currency, startingBalance, riskPct }),
+        });
+        if (!res.ok) {
+            alert(`Create failed: ${await res.text()}`);
+            return;
+        }
+        const { id } = await res.json();
+        await loadAccounts();
+        selectAccount(id);
+    });
+
+    // --- ticket form ----------------------------------------------------
+
+    $('paper-instrument').addEventListener('change', () => {
+        const it = $('paper-instrument').value;
+        const showMult = (it === 'future' || it === 'forex' || it === 'option');
+        $('paper-multiplier-row').style.display = showMult ? '' : 'none';
+        if (it === 'option') $('paper-multiplier').value = 100;
+        else if (it === 'future') $('paper-multiplier').value = 50;
+        else $('paper-multiplier').value = 1;
+        previewSizing();
+    });
+
+    ['paper-entry', 'paper-stop', 'paper-side', 'paper-multiplier', 'paper-instrument'].forEach((id) => {
+        $(id).addEventListener('input', () => {
+            clearTimeout(state.debounceTimer);
+            state.debounceTimer = setTimeout(previewSizing, 100);
+        });
+    });
+
+    async function previewSizing() {
+        const account = state.accounts.find((x) => x.id === state.activeAccountId);
+        if (!account) return;
+        const entry = parseFloat($('paper-entry').value);
+        const stop = parseFloat($('paper-stop').value);
+        if (!entry) {
+            setSizingDisplay({ size: null, riskAmount: null, stopDistance: null, error: '' });
+            return;
+        }
+        const payload = {
+            instrumentType: $('paper-instrument').value,
+            multiplier: parseFloat($('paper-multiplier').value) || 0,
+            side: $('paper-side').value,
+            entryPrice: entry,
+            stopPrice: isNaN(stop) ? 0 : stop,
+            accountSize: account.cashBalance,
+            riskPct: account.riskPct,
+        };
+        const res = await fetch('/api/paper/sizing/preview', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const data = await res.json();
+        setSizingDisplay(data);
+    }
+
+    function setSizingDisplay(data) {
+        const sizeEl = $('paper-size-display');
+        const riskEl = $('paper-risk-display');
+        const distEl = $('paper-stopdist-display');
+        const errEl = $('paper-sizing-error');
+        if (data.error) {
+            sizeEl.textContent = riskEl.textContent = distEl.textContent = '—';
+            errEl.textContent = data.error;
+            $('paper-submit').disabled = true;
+            state.lastSizing = null;
+            return;
+        }
+        errEl.textContent = '';
+        if (data.size == null) {
+            sizeEl.textContent = riskEl.textContent = distEl.textContent = '—';
+            $('paper-submit').disabled = true;
+            return;
+        }
+        sizeEl.textContent = data.size;
+        riskEl.textContent = fmt(data.riskAmount);
+        distEl.textContent = (data.stopDistance ?? 0).toFixed(4);
+        $('paper-submit').disabled = !(data.size >= 1);
+        state.lastSizing = data;
+    }
+
+    $('paper-ticket-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        if (!state.activeAccountId) return alert('Select an account.');
+        const target = parseFloat($('paper-target').value);
+        const body = {
+            accountId: state.activeAccountId,
+            symbol: $('paper-symbol').value.trim().toUpperCase(),
+            instrumentType: $('paper-instrument').value,
+            multiplier: parseFloat($('paper-multiplier').value) || 0,
+            side: $('paper-side').value,
+            entryPrice: parseFloat($('paper-entry').value),
+            stopPrice: parseFloat($('paper-stop').value),
+            thesis: $('paper-thesis').value.trim(),
+        };
+        if (!isNaN(target) && target > 0) body.targetPrice = target;
+
+        const res = await fetch('/api/paper/trades', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+            alert(`Open failed: ${await res.text()}`);
+            return;
+        }
+        $('paper-ticket-form').reset();
+        $('paper-multiplier-row').style.display = 'none';
+        setSizingDisplay({ size: null });
+        refreshTrades();
+    });
+
+    // --- positions + journal --------------------------------------------
+
+    async function refreshTrades() {
+        if (!state.activeAccountId) return;
+        const [openR, closedR] = await Promise.all([
+            fetch(`/api/paper/trades/open?accountId=${state.activeAccountId}`),
+            fetch(`/api/paper/trades/closed?accountId=${state.activeAccountId}&limit=50`),
+        ]);
+        renderOpenPositions(await openR.json());
+        renderJournal(await closedR.json());
+    }
+
+    function renderOpenPositions(trades) {
+        const tbody = $('paper-open-table').querySelector('tbody');
+        if (!trades.length) {
+            tbody.innerHTML = '<tr><td colspan="9" class="empty-state">No open positions.</td></tr>';
+            return;
+        }
+        tbody.innerHTML = trades.map((t) => `
+            <tr>
+                <td>${escape(t.symbol)}</td>
+                <td>${t.side}</td>
+                <td>${t.size}</td>
+                <td>${t.entryPrice}</td>
+                <td>${t.stopPrice}</td>
+                <td>${t.targetPrice ?? '—'}</td>
+                <td>${fmt(t.riskAmount)}</td>
+                <td>${formatDate(t.openedAt)}</td>
+                <td><button class="paper-btn-sm paper-close-btn" data-id="${t.id}">Close</button></td>
+            </tr>
+        `).join('');
+        tbody.querySelectorAll('.paper-close-btn').forEach((btn) => {
+            btn.addEventListener('click', () => closeTrade(parseInt(btn.dataset.id, 10)));
+        });
+    }
+
+    async function closeTrade(id) {
+        const exit = parseFloat(prompt('Exit price?'));
+        if (!(exit > 0)) return;
+        const reason = (prompt('Reason (stop/target/manual)?', 'manual') || '').toLowerCase();
+        if (!['stop', 'target', 'manual'].includes(reason)) return alert('Reason must be stop, target, or manual.');
+        const res = await fetch(`/api/paper/trades/${id}/close`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ exitPrice: exit, reason }),
+        });
+        if (!res.ok) {
+            alert(`Close failed: ${await res.text()}`);
+            return;
+        }
+        await loadAccounts();
+        refreshTrades();
+    }
+
+    function renderJournal(trades) {
+        const tbody = $('paper-journal-table').querySelector('tbody');
+        if (!trades.length) {
+            tbody.innerHTML = '<tr><td colspan="9" class="empty-state">No closed trades yet.</td></tr>';
+            return;
+        }
+        tbody.innerHTML = trades.map((t) => {
+            const pnl = t.realizedPnl ?? 0;
+            const r = t.riskAmount ? (pnl / t.riskAmount).toFixed(2) : '—';
+            const reason = (t.status || '').replace('closed_', '');
+            const pnlClass = pnl >= 0 ? 'paper-pnl-pos' : 'paper-pnl-neg';
+            return `<tr>
+                <td>${formatDate(t.closedAt)}</td>
+                <td>${escape(t.symbol)}</td>
+                <td>${t.side}</td>
+                <td>${t.size}</td>
+                <td>${t.entryPrice}</td>
+                <td>${t.exitPrice ?? '—'}</td>
+                <td class="${pnlClass}">${fmt(pnl)}</td>
+                <td class="${pnlClass}">${r}R</td>
+                <td>${reason}</td>
+            </tr>`;
+        }).join('');
+    }
+
+    // --- utils -----------------------------------------------------------
+
+    function escape(s) {
+        return String(s ?? '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+    }
+
+    function fmt(n) {
+        if (n == null || isNaN(n)) return '—';
+        return Number(n).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    }
+
+    function formatDate(s) {
+        if (!s) return '—';
+        const d = new Date(s);
+        if (isNaN(d.getTime())) return s;
+        return d.toISOString().slice(0, 16).replace('T', ' ');
+    }
+
+    // --- bootstrap ------------------------------------------------------
+    loadAccounts();
+})();

--- a/internal/server/static/screener.js
+++ b/internal/server/static/screener.js
@@ -1,0 +1,118 @@
+(function () {
+    'use strict';
+
+    const $ = (id) => document.getElementById(id);
+    const form = $('screener-form');
+    const meta = $('screener-results-meta');
+    const tbody = $('screener-table').querySelector('tbody');
+
+    let lastResults = [];
+    let sortKey = null;
+    let sortDir = 1; // 1 asc, -1 desc
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        await runScreen();
+    });
+
+    $('screener-reset').addEventListener('click', () => {
+        form.reset();
+        tbody.innerHTML = '<tr><td colspan="10" class="empty-state">Filters reset. Press <kbd>Run Screen</kbd>.</td></tr>';
+        meta.textContent = 'no screen run yet';
+        lastResults = [];
+    });
+
+    async function runScreen() {
+        const params = new URLSearchParams();
+        const fd = new FormData(form);
+        for (const [k, v] of fd.entries()) {
+            const trimmed = String(v).trim();
+            if (trimmed !== '') params.set(k, trimmed);
+        }
+
+        meta.textContent = 'running…';
+        tbody.innerHTML = '<tr><td colspan="10" class="empty-state">Loading…</td></tr>';
+
+        const t0 = performance.now();
+        let res;
+        try {
+            res = await fetch(`/api/screener?${params.toString()}`);
+        } catch (err) {
+            meta.textContent = `network error: ${err.message}`;
+            return;
+        }
+        if (!res.ok) {
+            const body = await res.text();
+            meta.textContent = `HTTP ${res.status}`;
+            tbody.innerHTML = `<tr><td colspan="10" class="empty-state">${escape(body)}</td></tr>`;
+            return;
+        }
+        const data = await res.json();
+        const elapsed = (performance.now() - t0) / 1000;
+        lastResults = Array.isArray(data) ? data : [];
+        meta.textContent = `${lastResults.length} result${lastResults.length === 1 ? '' : 's'} · ${elapsed.toFixed(1)}s`;
+        renderRows();
+    }
+
+    function renderRows() {
+        if (!lastResults.length) {
+            tbody.innerHTML = '<tr><td colspan="10" class="empty-state">No matches. Loosen a filter.</td></tr>';
+            return;
+        }
+        const rows = sortKey ? [...lastResults].sort(byKey(sortKey, sortDir)) : lastResults;
+        tbody.innerHTML = rows.map((r) => {
+            const sign = (n) => n > 0 ? 'paper-pnl-pos' : (n < 0 ? 'paper-pnl-neg' : '');
+            const pct = (n) => (n >= 0 ? '+' : '') + n.toFixed(2);
+            return `<tr>
+                <td><a href="/security/${encodeURIComponent(r.symbol)}">${escape(r.symbol)}</a></td>
+                <td title="${escape(r.companyName)}">${truncate(escape(r.companyName), 28)}</td>
+                <td>${escape(r.sector || '')}</td>
+                <td class="num">${fmt(r.price)}</td>
+                <td class="num ${sign(r.changeFromOpen)}">${pct(r.changeFromOpen)}</td>
+                <td class="num ${sign(r.changeFromPrevDay)}">${pct(r.changeFromPrevDay)}</td>
+                <td class="num ${sign(r.changeVsMarket)}">${pct(r.changeVsMarket)}</td>
+                <td class="num">${fmtCompact(r.volume)}</td>
+                <td class="num">${fmtCompact(r.marketCap)}</td>
+                <td class="num">${(r.beta || 0).toFixed(2)}</td>
+            </tr>`;
+        }).join('');
+    }
+
+    // Click a header to sort by that column.
+    $('screener-table').querySelectorAll('thead th').forEach((th, idx) => {
+        const keys = ['symbol', 'companyName', 'sector', 'price', 'changeFromOpen', 'changeFromPrevDay', 'changeVsMarket', 'volume', 'marketCap', 'beta'];
+        th.style.cursor = 'pointer';
+        th.addEventListener('click', () => {
+            const k = keys[idx];
+            if (sortKey === k) sortDir = -sortDir;
+            else { sortKey = k; sortDir = 1; }
+            renderRows();
+        });
+    });
+
+    function byKey(key, dir) {
+        return (a, b) => {
+            const av = a[key], bv = b[key];
+            if (typeof av === 'number' && typeof bv === 'number') return (av - bv) * dir;
+            return String(av || '').localeCompare(String(bv || '')) * dir;
+        };
+    }
+
+    function escape(s) {
+        return String(s ?? '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+    }
+    function truncate(s, n) { return s.length > n ? s.slice(0, n - 1) + '…' : s; }
+    function fmt(n) {
+        if (n == null || isNaN(n)) return '—';
+        return Number(n).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    }
+    function fmtCompact(n) {
+        if (n == null || isNaN(n) || n === 0) return '—';
+        const abs = Math.abs(n);
+        if (abs >= 1e12) return (n / 1e12).toFixed(2) + 'T';
+        if (abs >= 1e9) return (n / 1e9).toFixed(2) + 'B';
+        if (abs >= 1e6) return (n / 1e6).toFixed(2) + 'M';
+        if (abs >= 1e3) return (n / 1e3).toFixed(2) + 'K';
+        return n.toFixed(0);
+    }
+})();

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -3341,3 +3341,507 @@ a, [tabindex] {
     height: calc(100vh - 140px);
     width: 100%;
 }
+
+/* ============================================================
+   Paper trading — /paper
+   ============================================================ */
+
+.terminal-content[data-view="paper"] {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    padding: 0;
+}
+
+.paper-layout {
+    display: flex;
+    height: 100%;
+    flex: 1;
+    min-height: 0;
+    font-size: 12px;
+}
+
+.paper-sidebar {
+    width: 240px;
+    flex-shrink: 0;
+    background: var(--bg-secondary);
+    border-right: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+}
+
+.paper-sidebar-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-primary);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    font-size: 11px;
+}
+
+.paper-account-list {
+    list-style: none;
+    margin: 0;
+    padding: 4px;
+    overflow-y: auto;
+}
+
+.paper-account-item {
+    padding: 8px 12px;
+    border-left: 2px solid transparent;
+    border-bottom: 1px solid var(--bg-tertiary);
+    cursor: pointer;
+}
+
+.paper-account-item:hover {
+    background: var(--bg-tertiary);
+}
+
+.paper-account-item.selected {
+    background: var(--bg-tertiary);
+    border-left-color: var(--blue);
+}
+
+.paper-account-name {
+    color: var(--text-primary);
+    font-weight: 500;
+}
+
+.paper-account-meta {
+    color: var(--text-muted);
+    font-size: 10px;
+    margin-top: 2px;
+}
+
+.paper-account-summary {
+    margin-top: auto;
+    padding: 12px;
+    border-top: 1px solid var(--border);
+    background: var(--bg-primary);
+}
+
+.paper-summary-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 3px 0;
+    color: var(--text-secondary);
+}
+
+.paper-summary-row > span:last-child {
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+}
+
+.paper-main {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px 20px;
+    min-width: 0;
+}
+
+.paper-section {
+    margin-bottom: 28px;
+}
+
+.paper-section h2 {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--orange);
+    margin: 0 0 12px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--border);
+}
+
+/* ---------- Ticket form ---------- */
+
+.paper-ticket {
+    display: grid;
+    grid-template-columns: 120px 1fr 120px 1fr;
+    gap: 10px 12px;
+    align-items: center;
+    max-width: 760px;
+}
+
+.paper-field {
+    display: contents;
+}
+
+.paper-field > label {
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    font-size: 10px;
+    letter-spacing: 0.5px;
+}
+
+.paper-field > input,
+.paper-field > select,
+.paper-field > textarea {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    padding: 6px 8px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    border-radius: 2px;
+    outline: none;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.paper-field > input:focus,
+.paper-field > select:focus,
+.paper-field > textarea:focus {
+    border-color: var(--blue);
+}
+
+/* Thesis spans the full row */
+.paper-field.paper-thesis > label {
+    grid-column: 1;
+}
+.paper-field.paper-thesis > textarea {
+    grid-column: 2 / -1;
+    resize: vertical;
+    min-height: 40px;
+}
+
+.paper-sizing-preview {
+    grid-column: 1 / -1;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    padding: 10px 12px;
+    display: flex;
+    gap: 18px;
+    align-items: center;
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+    flex-wrap: wrap;
+}
+
+.paper-sizing-label {
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    font-size: 10px;
+    letter-spacing: 0.5px;
+    margin-right: 6px;
+}
+
+.paper-sizing-error {
+    color: var(--red);
+    font-size: 11px;
+    margin-left: auto;
+}
+
+.paper-ticket-actions {
+    grid-column: 1 / -1;
+    display: flex;
+    justify-content: flex-end;
+    padding-top: 4px;
+}
+
+.paper-ticket-actions button,
+.paper-btn-sm {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    padding: 6px 14px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    cursor: pointer;
+    border-radius: 2px;
+}
+
+.paper-ticket-actions button:hover:not(:disabled),
+.paper-btn-sm:hover {
+    border-color: var(--orange);
+    color: var(--orange);
+}
+
+.paper-ticket-actions button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.paper-btn-sm {
+    padding: 3px 8px;
+    font-size: 10px;
+}
+
+/* ---------- Tables ---------- */
+
+.paper-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+}
+
+.paper-table thead th {
+    text-align: left;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    font-size: 10px;
+    letter-spacing: 0.5px;
+    font-weight: 500;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-secondary);
+    white-space: nowrap;
+}
+
+.paper-table tbody td {
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--bg-tertiary);
+    color: var(--text-primary);
+    white-space: nowrap;
+}
+
+.paper-table tbody tr:hover td {
+    background: var(--bg-secondary);
+}
+
+.paper-table .empty-state {
+    text-align: center;
+    color: var(--text-muted);
+    padding: 18px;
+    font-style: italic;
+}
+
+.paper-pnl-pos { color: var(--green); }
+.paper-pnl-neg { color: var(--red); }
+
+/* ============================================================
+   Screener — /screener
+   ============================================================ */
+
+.terminal-content[data-view="screener"] {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    padding: 0;
+}
+
+.screener-layout {
+    display: flex;
+    height: 100%;
+    flex: 1;
+    min-height: 0;
+    font-size: 12px;
+}
+
+.screener-filters {
+    width: 280px;
+    flex-shrink: 0;
+    background: var(--bg-secondary);
+    border-right: 1px solid var(--border);
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+}
+
+.screener-filters-header {
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-primary);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    font-size: 11px;
+}
+
+.screener-form {
+    padding: 8px 12px 80px;
+}
+
+.screener-group {
+    margin-bottom: 16px;
+}
+
+.screener-group h4 {
+    margin: 0 0 6px;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: var(--orange);
+    border-bottom: 1px solid var(--bg-tertiary);
+    padding-bottom: 3px;
+}
+
+.screener-group label {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 10px;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    margin-bottom: 6px;
+}
+
+.screener-group label.screener-checkbox {
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 11px;
+    color: var(--text-primary);
+}
+
+.screener-group input[type="number"],
+.screener-group input[type="text"],
+.screener-group select {
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    padding: 4px 6px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    border-radius: 2px;
+    outline: none;
+}
+
+.screener-group input:focus,
+.screener-group select:focus {
+    border-color: var(--blue);
+}
+
+.screener-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+    position: sticky;
+    bottom: 0;
+    background: var(--bg-secondary);
+    padding: 8px 0;
+}
+
+.screener-actions button {
+    flex: 1;
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    padding: 6px 10px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    cursor: pointer;
+    border-radius: 2px;
+}
+
+.screener-actions button:hover {
+    border-color: var(--orange);
+    color: var(--orange);
+}
+
+.screener-actions button#screener-run {
+    background: var(--bg-secondary);
+    border-color: var(--orange);
+    color: var(--orange);
+}
+
+.screener-actions button#screener-run:hover {
+    background: var(--orange);
+    color: var(--bg-primary);
+}
+
+.screener-results {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.screener-results-header {
+    display: flex;
+    align-items: baseline;
+    gap: 14px;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-secondary);
+}
+
+.screener-results-header h2 {
+    margin: 0;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--orange);
+}
+
+.screener-results-meta {
+    color: var(--text-muted);
+    font-size: 11px;
+}
+
+.screener-table-wrap {
+    flex: 1;
+    overflow: auto;
+    padding: 0;
+}
+
+.screener-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+}
+
+.screener-table thead th {
+    position: sticky;
+    top: 0;
+    background: var(--bg-secondary);
+    text-align: left;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    font-size: 10px;
+    letter-spacing: 0.5px;
+    font-weight: 500;
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+    user-select: none;
+}
+
+.screener-table thead th.num,
+.screener-table tbody td.num {
+    text-align: right;
+}
+
+.screener-table tbody td {
+    padding: 5px 10px;
+    border-bottom: 1px solid var(--bg-tertiary);
+    color: var(--text-primary);
+    white-space: nowrap;
+}
+
+.screener-table tbody td a {
+    color: var(--blue);
+    text-decoration: none;
+}
+
+.screener-table tbody td a:hover {
+    color: var(--orange);
+    text-decoration: underline;
+}
+
+.screener-table tbody tr:hover td {
+    background: var(--bg-secondary);
+}
+
+.screener-table .empty-state {
+    text-align: center;
+    color: var(--text-muted);
+    padding: 24px;
+    font-style: italic;
+}
+

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -61,6 +61,7 @@ window.onerror = function (msg, src, line, col, err) {
         ideas:      { path: '/ideas',           needsSecurity: false, usage: 'ideas',               desc: 'sketchpad — comparative graphs across metrics' },
         economics:  { path: '/economics',       needsSecurity: false, usage: 'economics',           desc: 'economic calendar + indicator catalog (FRED + FMP)', aliases: ['eco', 'econ'] },
         screener:   { path: '/screener',        needsSecurity: false, usage: 'screener',            desc: 'filter and scan stocks by criteria' },
+        paper:      { path: '/paper',           needsSecurity: false, usage: 'paper',               desc: 'paper trading — ticket, positions, journal', aliases: ['pa', 'trade'] },
         debug:      { path: '/debug',           needsSecurity: false, usage: 'debug',               desc: 'live server log console' },
         analyze:    { path: '/security/{symbol}#ai', needsSecurity: true, usage: 'analyze <SECURITY>',  desc: 'run deep multi-agent trading analysis', aliases: ['az'] },
     };
@@ -2497,6 +2498,105 @@ window.onerror = function (msg, src, line, col, err) {
                 else if (dir === 'k') console.scrollTop -= 60;
             },
             activate: function () {}
+        },
+        screener: {
+            // Two-pane navigation: filters (left) and results (right).
+            // j/k moves within the focused pane; h/l flips focus between them.
+            // Enter focuses an input (filters) or opens /security/{sym} (results).
+            // 'r' triggers the Run Screen button — refresh semantics.
+            _focus: 'filters',
+            _filterIdx: 0,
+            _resultIdx: 0,
+            getFilters: function () {
+                return Array.from(document.querySelectorAll(
+                    '#screener-form input:not([type=hidden]), #screener-form select, #screener-form button'
+                ));
+            },
+            getResults: function () {
+                return Array.from(document.querySelectorAll('#screener-table tbody tr'))
+                    .filter(function (row) {
+                        // Skip the empty-state placeholder row.
+                        return !row.querySelector('.empty-state');
+                    });
+            },
+            move: function (dir) {
+                if (dir === 'h') {
+                    this._focus = 'filters';
+                    if (this._filterIdx < 0) this._filterIdx = 0;
+                    this._applyFocus();
+                    return;
+                }
+                if (dir === 'l') {
+                    // Only move to results if there ARE results — otherwise
+                    // h/l would silently do nothing and confuse the user.
+                    if (this.getResults().length > 0) {
+                        this._focus = 'results';
+                        if (this._resultIdx < 0) this._resultIdx = 0;
+                        this._applyFocus();
+                    }
+                    return;
+                }
+                if (this._focus === 'filters') {
+                    var items = this.getFilters();
+                    if (items.length === 0) return;
+                    if (this._filterIdx < 0) this._filterIdx = 0;
+                    if (dir === 'j') this._filterIdx = Math.min(this._filterIdx + 1, items.length - 1);
+                    else if (dir === 'k') this._filterIdx = Math.max(this._filterIdx - 1, 0);
+                } else {
+                    var rows = this.getResults();
+                    if (rows.length === 0) {
+                        // Results emptied (e.g. reset) — fall back to filters.
+                        this._focus = 'filters';
+                        this._applyFocus();
+                        return;
+                    }
+                    if (this._resultIdx < 0) this._resultIdx = 0;
+                    if (dir === 'j') this._resultIdx = Math.min(this._resultIdx + 1, rows.length - 1);
+                    else if (dir === 'k') this._resultIdx = Math.max(this._resultIdx - 1, 0);
+                }
+                this._applyFocus();
+            },
+            activate: function () {
+                if (this._focus === 'filters') {
+                    var items = this.getFilters();
+                    var el = items[this._filterIdx];
+                    if (!el) return;
+                    if (el.tagName === 'BUTTON') {
+                        el.click();
+                    } else {
+                        // Focus the input — user is now in insert mode editing
+                        // the value. Escape returns to normal.
+                        el.focus();
+                        if (el.select) el.select();
+                    }
+                } else {
+                    var rows = this.getResults();
+                    var row = rows[this._resultIdx];
+                    if (!row) return;
+                    var link = row.querySelector('a[href]');
+                    if (link) window.location.href = link.href;
+                }
+            },
+            refresh: function () {
+                // 'r' re-runs the screener.
+                var btn = document.getElementById('screener-run');
+                if (btn) btn.click();
+            },
+            _applyFocus: function () {
+                document.querySelectorAll('.vim-selected').forEach(function (e) {
+                    e.classList.remove('vim-selected');
+                });
+                var el;
+                if (this._focus === 'filters') {
+                    el = this.getFilters()[this._filterIdx];
+                } else {
+                    el = this.getResults()[this._resultIdx];
+                }
+                if (el) {
+                    el.classList.add('vim-selected');
+                    el.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+                }
+            },
         }
     };
 
@@ -2514,18 +2614,9 @@ window.onerror = function (msg, src, line, col, err) {
             var id = window._economicsSelectedIdentifier();
             if (id) { navigate('graph', id, { skipSecurity: true }); return; }
         }
-        if (handler && handler.isFinTab && handler.isFinTab()) {
-            var rows = window._finGetRows ? window._finGetRows() : [];
-            var idx = window._finGetSelectedRow ? window._finGetSelectedRow() : -1;
-            if (idx >= 0 && idx < rows.length && selectedSecurity) {
-                var row = rows[idx];
-                var key = row.dataset.finKey || '';
-                if (row.dataset.finFormat !== 'calc' && key && key.indexOf('/') < 0) {
-                    navigate('graph', selectedSecurity + '.' + key, { skipSecurity: true });
-                    return;
-                }
-            }
-        }
+        // Financials row → chart is now bound to 'c' (see case 'c' below).
+        // 'g' on financials no longer triggers it — was confusing muscle-memory
+        // alongside the page-level 'g' for graph-jump on other views.
         if (handler && handler.sectorNav) handler.sectorNav('graph');
         else if (handler && handler.graph) handler.graph();
     }
@@ -2702,6 +2793,23 @@ window.onerror = function (msg, src, line, col, err) {
                 if (handler && handler.jumpToSubTab) { e.preventDefault(); handler.jumpToSubTab(1); }
                 return;
             case 'c':
+                // Financials tab: 'c' on a highlighted metric opens the full
+                // chart page for that metric (was historically 'g', moved here
+                // so the key matches the action — 'c' for chart).
+                if (handler && handler.isFinTab && handler.isFinTab()) {
+                    var finRows = window._finGetRows ? window._finGetRows() : [];
+                    var finIdx = window._finGetSelectedRow ? window._finGetSelectedRow() : -1;
+                    if (finIdx >= 0 && finIdx < finRows.length && selectedSecurity) {
+                        var finRow = finRows[finIdx];
+                        var finKey = finRow.dataset.finKey || '';
+                        if (finRow.dataset.finFormat !== 'calc' && finKey && finKey.indexOf('/') < 0) {
+                            e.preventDefault();
+                            navigate('graph', selectedSecurity + '.' + finKey, { skipSecurity: true });
+                            return;
+                        }
+                    }
+                }
+                // Otherwise: 'c' jumps to sub-tab index 2 (existing behaviour).
                 if (handler && handler.jumpToSubTab) { e.preventDefault(); handler.jumpToSubTab(2); }
                 return;
             case 'f':
@@ -2723,6 +2831,15 @@ window.onerror = function (msg, src, line, col, err) {
                     } else if (window._finOpenChart) {
                         window._finOpenChart();
                     }
+                    return;
+                }
+                // /news: open the article reader (slide-in preview) on the
+                // highlighted card. Same effect as Enter, mapped to 'p' for
+                // muscle-memory parity with the 'p = preview' convention used
+                // on economics + financials.
+                if (currentView === 'news' && handler && handler.activate) {
+                    e.preventDefault();
+                    handler.activate();
                     return;
                 }
                 // Watchlist: move (paste) selected symbol to another list (idea #12).

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -2037,8 +2037,10 @@ window.onerror = function (msg, src, line, col, err) {
             },
         },
         economics: {
-            move: function (dir) { if (window._economicsMove) window._economicsMove(dir); },
-            activate: function () { if (window._economicsActivate) window._economicsActivate(); },
+            // Directional nav owned by vim-nav.js (see economics.html for the
+            // data-vim-row markup). Per-view handler retains only the legacy
+            // keys that fall through the core: `/` to focus filter, plus the
+            // p/g/a handlers wired below via window._economicsOpenPreview etc.
             focusFilter: function () { if (window._economicsFocusFilter) window._economicsFocusFilter(); },
         },
         watchlist: {

--- a/internal/server/templates/economics.html
+++ b/internal/server/templates/economics.html
@@ -3,9 +3,9 @@
 <div class="economics-layout" data-view="economics">
     <header class="page-header economics-header">
         <h2 class="view-title">Economics</h2>
-        <nav class="economics-tabs" id="economics-tabs">
-            <button class="economics-tab active" data-tab="calendar">1 Calendar</button>
-            <button class="economics-tab" data-tab="catalog">2 Catalog</button>
+        <nav class="economics-tabs" id="economics-tabs" data-vim-row>
+            <button class="economics-tab active" data-tab="calendar" data-vim-item data-vim-action="click">Calendar</button>
+            <button class="economics-tab" data-tab="catalog" data-vim-item data-vim-action="click">Catalog</button>
         </nav>
         <span class="economics-hint" id="economics-hint">
             <kbd>h</kbd>/<kbd>l</kbd> tabs · <kbd>j</kbd>/<kbd>k</kbd> rows · <kbd>/</kbd> filter

--- a/internal/server/templates/paper.html
+++ b/internal/server/templates/paper.html
@@ -1,0 +1,98 @@
+{{template "layout" .}}
+{{define "content"}}
+<div class="paper-layout">
+    <aside class="paper-sidebar">
+        <div class="paper-sidebar-header">
+            <span>Paper Accounts</span>
+            <button id="paper-new-account" class="paper-btn-sm">+ New</button>
+        </div>
+        <ul class="paper-account-list" id="paper-account-list">
+            <li class="empty-state">Loading…</li>
+        </ul>
+        <div class="paper-account-summary" id="paper-account-summary"></div>
+    </aside>
+
+    <section class="paper-main">
+        <div class="paper-section">
+            <h2>Trade Ticket</h2>
+            <form id="paper-ticket-form" class="paper-ticket">
+                <div class="paper-field">
+                    <label>Security</label>
+                    <input type="text" id="paper-symbol" placeholder="AAPL" autocomplete="off" required>
+                </div>
+                <div class="paper-field">
+                    <label>Instrument</label>
+                    <select id="paper-instrument">
+                        <option value="equity">Equity</option>
+                        <option value="future">Future</option>
+                        <option value="option">Option (long)</option>
+                        <option value="cfd">CFD</option>
+                        <option value="forex">Forex</option>
+                    </select>
+                </div>
+                <div class="paper-field" id="paper-multiplier-row" style="display:none">
+                    <label>Multiplier</label>
+                    <input type="number" id="paper-multiplier" step="any" value="1">
+                </div>
+                <div class="paper-field">
+                    <label>Side</label>
+                    <select id="paper-side">
+                        <option value="long">Long</option>
+                        <option value="short">Short</option>
+                    </select>
+                </div>
+                <div class="paper-field">
+                    <label>Entry</label>
+                    <input type="number" id="paper-entry" step="any" required>
+                </div>
+                <div class="paper-field">
+                    <label>Stop</label>
+                    <input type="number" id="paper-stop" step="any" required>
+                </div>
+                <div class="paper-field">
+                    <label>Target (optional)</label>
+                    <input type="number" id="paper-target" step="any">
+                </div>
+                <div class="paper-field paper-thesis">
+                    <label>Thesis</label>
+                    <textarea id="paper-thesis" rows="2" placeholder="Why this trade?"></textarea>
+                </div>
+                <div class="paper-sizing-preview" id="paper-sizing-preview">
+                    <span class="paper-sizing-label">Size:</span> <span id="paper-size-display">—</span>
+                    <span class="paper-sizing-label">Risk:</span> <span id="paper-risk-display">—</span>
+                    <span class="paper-sizing-label">Stop dist:</span> <span id="paper-stopdist-display">—</span>
+                    <span class="paper-sizing-error" id="paper-sizing-error"></span>
+                </div>
+                <div class="paper-ticket-actions">
+                    <button type="submit" id="paper-submit" disabled>Open Paper Trade</button>
+                </div>
+            </form>
+        </div>
+
+        <div class="paper-section">
+            <h2>Open Positions</h2>
+            <table class="paper-table" id="paper-open-table">
+                <thead>
+                    <tr>
+                        <th>Security</th><th>Side</th><th>Size</th><th>Entry</th><th>Stop</th><th>Target</th><th>Risk</th><th>Opened</th><th></th>
+                    </tr>
+                </thead>
+                <tbody><tr><td colspan="9" class="empty-state">No open positions.</td></tr></tbody>
+            </table>
+        </div>
+
+        <div class="paper-section">
+            <h2>Journal</h2>
+            <table class="paper-table" id="paper-journal-table">
+                <thead>
+                    <tr>
+                        <th>Closed</th><th>Security</th><th>Side</th><th>Size</th><th>Entry</th><th>Exit</th><th>P&L</th><th>R</th><th>Reason</th>
+                    </tr>
+                </thead>
+                <tbody><tr><td colspan="9" class="empty-state">No closed trades yet.</td></tr></tbody>
+            </table>
+        </div>
+    </section>
+</div>
+<script src="/static/paper.js?v={{.AssetVersion}}"></script>
+{{end}}

--- a/internal/server/templates/screener.html
+++ b/internal/server/templates/screener.html
@@ -1,9 +1,96 @@
 {{template "layout" .}}
 {{define "content"}}
-<div class="page-header">
-    <h1>Screener</h1>
+<div class="screener-layout">
+    <aside class="screener-filters">
+        <div class="screener-filters-header">Filters</div>
+        <form id="screener-form" class="screener-form">
+            <div class="screener-group">
+                <h4>Fundamentals</h4>
+                <label>Market cap ≥<input type="number" name="marketCapMoreThan" step="any" placeholder="e.g. 1000000000"></label>
+                <label>Market cap ≤<input type="number" name="marketCapLowerThan" step="any"></label>
+                <label>Price ≥<input type="number" name="priceMoreThan" step="any"></label>
+                <label>Price ≤<input type="number" name="priceLowerThan" step="any"></label>
+                <label>Beta ≥<input type="number" name="betaMoreThan" step="any"></label>
+                <label>Beta ≤<input type="number" name="betaLowerThan" step="any"></label>
+                <label>Volume ≥<input type="number" name="volumeMoreThan" step="any"></label>
+                <label>Dividend ≥<input type="number" name="dividendMoreThan" step="any"></label>
+            </div>
+
+            <div class="screener-group">
+                <h4>Sector / Exchange</h4>
+                <label>Sector
+                    <select name="sector">
+                        <option value="">(any)</option>
+                        <option>Technology</option>
+                        <option>Healthcare</option>
+                        <option>Financial Services</option>
+                        <option>Communication Services</option>
+                        <option>Consumer Cyclical</option>
+                        <option>Consumer Defensive</option>
+                        <option>Energy</option>
+                        <option>Industrials</option>
+                        <option>Basic Materials</option>
+                        <option>Utilities</option>
+                        <option>Real Estate</option>
+                    </select>
+                </label>
+                <label>Country<input type="text" name="country" placeholder="e.g. US" maxlength="2"></label>
+                <label>Exchange<input type="text" name="exchange" placeholder="e.g. NASDAQ"></label>
+                <label class="screener-checkbox">
+                    <input type="checkbox" name="isActivelyTrading" value="true" checked>
+                    Actively trading only
+                </label>
+            </div>
+
+            <div class="screener-group">
+                <h4>Intraday change</h4>
+                <label>Δ from open ≥ %<input type="number" name="changeFromOpenMin" step="any" placeholder="e.g. 2"></label>
+                <label>Δ from open ≤ %<input type="number" name="changeFromOpenMax" step="any"></label>
+                <label>Δ from prev close ≥ %<input type="number" name="changeFromPrevDayMin" step="any"></label>
+                <label>Δ from prev close ≤ %<input type="number" name="changeFromPrevDayMax" step="any"></label>
+                <label>Δ vs market (SPY) ≥ pp<input type="number" name="changeVsMarketMin" step="any" placeholder="e.g. 1"></label>
+                <label>Δ vs market (SPY) ≤ pp<input type="number" name="changeVsMarketMax" step="any"></label>
+            </div>
+
+            <div class="screener-group">
+                <h4>Output</h4>
+                <label>Show top<input type="number" name="displayLimit" step="1" min="1" max="250" value="50"></label>
+            </div>
+
+            <div class="screener-actions">
+                <button type="submit" id="screener-run">Run Screen</button>
+                <button type="button" id="screener-reset">Reset</button>
+            </div>
+        </form>
+    </aside>
+
+    <section class="screener-results">
+        <div class="screener-results-header">
+            <h2>Results</h2>
+            <span class="screener-results-meta" id="screener-results-meta">no screen run yet</span>
+        </div>
+        <div class="screener-table-wrap">
+            <table class="screener-table" id="screener-table">
+                <thead>
+                    <tr>
+                        <th>Security</th>
+                        <th>Company</th>
+                        <th>Sector</th>
+                        <th class="num">Price</th>
+                        <th class="num">Δ open %</th>
+                        <th class="num">Δ prev %</th>
+                        <th class="num">Δ vs SPY pp</th>
+                        <th class="num">Volume</th>
+                        <th class="num">Mkt cap</th>
+                        <th class="num">Beta</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr><td colspan="10" class="empty-state">Fill in filters on the left and press <kbd>Run Screen</kbd>.</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
 </div>
-<div class="screener">
-    <p class="empty-state">Screener coming in Iteration 4</p>
-</div>
+<script src="/static/screener.js?v={{.AssetVersion}}"></script>
 {{end}}

--- a/internal/store/paper.go
+++ b/internal/store/paper.go
@@ -1,0 +1,345 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// PaperAccount mirrors the paper_accounts row.
+type PaperAccount struct {
+	ID              int64     `json:"id"`
+	Name            string    `json:"name"`
+	BaseCurrency    string    `json:"baseCurrency"`
+	StartingBalance float64   `json:"startingBalance"`
+	CashBalance     float64   `json:"cashBalance"`
+	RiskPct         float64   `json:"riskPct"`
+	Settled         bool      `json:"settled"`
+	CreatedAt       time.Time `json:"createdAt"`
+	UpdatedAt       time.Time `json:"updatedAt"`
+}
+
+// PaperTrade mirrors the paper_trades row. Nullable columns surface as pointers
+// so JSON marshalling sends null rather than zero-value lies.
+type PaperTrade struct {
+	ID              int64      `json:"id"`
+	AccountID       int64      `json:"accountId"`
+	SketchID        *int64     `json:"sketchId,omitempty"`
+	Symbol          string     `json:"symbol"`
+	InstrumentType  string     `json:"instrumentType"`
+	Multiplier      float64    `json:"multiplier"`
+	Side            string     `json:"side"`
+	EntryPrice      float64    `json:"entryPrice"`
+	StopPrice       float64    `json:"stopPrice"`
+	TargetPrice     *float64   `json:"targetPrice,omitempty"`
+	Size            float64    `json:"size"`
+	RiskPctAtEntry  float64    `json:"riskPctAtEntry"`
+	RiskAmount      float64    `json:"riskAmount"`
+	Status          string     `json:"status"`
+	OpenedAt        time.Time  `json:"openedAt"`
+	ClosedAt        *time.Time `json:"closedAt,omitempty"`
+	ExitPrice       *float64   `json:"exitPrice,omitempty"`
+	RealizedPnL     *float64   `json:"realizedPnl,omitempty"`
+	Thesis          string     `json:"thesis"`
+	Notes           string     `json:"notes"`
+}
+
+// CreatePaperAccount inserts a new account and returns its id.
+func (s *Store) CreatePaperAccount(name, currency string, startingBalance, riskPct float64) (int64, error) {
+	res, err := s.db.Exec(`
+		INSERT INTO paper_accounts (name, base_currency, starting_balance, cash_balance, risk_pct)
+		VALUES (?, ?, ?, ?, ?)`,
+		name, currency, startingBalance, startingBalance, riskPct)
+	if err != nil {
+		return 0, fmt.Errorf("insert paper_account: %w", err)
+	}
+	return res.LastInsertId()
+}
+
+// GetPaperAccounts returns every account, newest first.
+func (s *Store) GetPaperAccounts() ([]PaperAccount, error) {
+	rows, err := s.db.Query(`
+		SELECT id, name, base_currency, starting_balance, cash_balance,
+		       risk_pct, settled, created_at, updated_at
+		FROM paper_accounts ORDER BY id DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []PaperAccount
+	for rows.Next() {
+		a, err := scanAccount(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// GetPaperAccount returns one account or sql.ErrNoRows.
+func (s *Store) GetPaperAccount(id int64) (*PaperAccount, error) {
+	row := s.db.QueryRow(`
+		SELECT id, name, base_currency, starting_balance, cash_balance,
+		       risk_pct, settled, created_at, updated_at
+		FROM paper_accounts WHERE id = ?`, id)
+	a, err := scanAccount(row)
+	if err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+// SetPaperAccountRisk updates the risk_pct. Used by the manual settle flip
+// (2% → 1%) but also any ad-hoc adjustment.
+func (s *Store) SetPaperAccountRisk(id int64, riskPct float64) error {
+	_, err := s.db.Exec(`
+		UPDATE paper_accounts SET risk_pct = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ?`, riskPct, id)
+	return err
+}
+
+// SetPaperAccountSettled flips the settled flag.
+func (s *Store) SetPaperAccountSettled(id int64, settled bool) error {
+	v := 0
+	if settled {
+		v = 1
+	}
+	_, err := s.db.Exec(`
+		UPDATE paper_accounts SET settled = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ?`, v, id)
+	return err
+}
+
+// OpenPaperTrade inserts the trade row and an 'opened' event in a single txn.
+// Caller has already done sizing math; we just persist.
+func (s *Store) OpenPaperTrade(t PaperTrade) (int64, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	res, err := tx.Exec(`
+		INSERT INTO paper_trades (
+			account_id, sketch_id, symbol, instrument_type, multiplier, side,
+			entry_price, stop_price, target_price, size,
+			risk_pct_at_entry, risk_amount, status, opened_at, thesis, notes
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?)`,
+		t.AccountID, t.SketchID, t.Symbol, t.InstrumentType, t.Multiplier, t.Side,
+		t.EntryPrice, t.StopPrice, t.TargetPrice, t.Size,
+		t.RiskPctAtEntry, t.RiskAmount, t.OpenedAt.UTC(), t.Thesis, t.Notes,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("insert paper_trade: %w", err)
+	}
+	tradeID, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+
+	if _, err := tx.Exec(`
+		INSERT INTO paper_trade_events (trade_id, event_type, payload)
+		VALUES (?, 'opened', ?)`,
+		tradeID, fmt.Sprintf(`{"entry":%g,"stop":%g,"size":%g}`, t.EntryPrice, t.StopPrice, t.Size),
+	); err != nil {
+		return 0, fmt.Errorf("insert opened event: %w", err)
+	}
+
+	return tradeID, tx.Commit()
+}
+
+// GetOpenPaperTrades returns open positions for the account.
+func (s *Store) GetOpenPaperTrades(accountID int64) ([]PaperTrade, error) {
+	return s.queryPaperTrades(`
+		WHERE account_id = ? AND status = 'open'
+		ORDER BY opened_at DESC`, accountID)
+}
+
+// GetClosedPaperTrades returns closed positions for the journal view.
+func (s *Store) GetClosedPaperTrades(accountID int64, limit, offset int) ([]PaperTrade, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	return s.queryPaperTrades(`
+		WHERE account_id = ? AND status != 'open'
+		ORDER BY closed_at DESC LIMIT `+fmt.Sprintf("%d OFFSET %d", limit, offset),
+		accountID)
+}
+
+// ClosePaperTrade marks the trade closed, writes realized P&L, records event.
+// reason is one of: 'stop' | 'target' | 'manual'.
+func (s *Store) ClosePaperTrade(tradeID int64, exitPrice float64, reason string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	trade, err := s.scanOnePaperTradeTx(tx, tradeID)
+	if err != nil {
+		return err
+	}
+	if trade.Status != "open" {
+		return fmt.Errorf("trade %d is not open", tradeID)
+	}
+
+	pnl := realizedPnL(trade, exitPrice)
+	statusByReason := map[string]string{
+		"stop":   "closed_stop",
+		"target": "closed_target",
+		"manual": "closed_manual",
+	}
+	status, ok := statusByReason[reason]
+	if !ok {
+		return fmt.Errorf("unknown close reason %q", reason)
+	}
+
+	if _, err := tx.Exec(`
+		UPDATE paper_trades
+		SET status = ?, closed_at = ?, exit_price = ?, realized_pnl = ?
+		WHERE id = ?`,
+		status, time.Now().UTC(), exitPrice, pnl, tradeID,
+	); err != nil {
+		return err
+	}
+
+	if _, err := tx.Exec(`
+		UPDATE paper_accounts SET cash_balance = cash_balance + ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ?`, pnl, trade.AccountID); err != nil {
+		return err
+	}
+
+	if _, err := tx.Exec(`
+		INSERT INTO paper_trade_events (trade_id, event_type, payload)
+		VALUES (?, 'closed', ?)`,
+		tradeID, fmt.Sprintf(`{"exit":%g,"pnl":%g,"reason":%q}`, exitPrice, pnl, reason),
+	); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+// realizedPnL = (exit - entry) × size × multiplier × (+1 long / -1 short)
+func realizedPnL(t PaperTrade, exit float64) float64 {
+	dir := 1.0
+	if t.Side == "short" {
+		dir = -1
+	}
+	return (exit - t.EntryPrice) * t.Size * t.Multiplier * dir
+}
+
+// --- internals ----------------------------------------------------------
+
+func (s *Store) queryPaperTrades(whereClause string, args ...any) ([]PaperTrade, error) {
+	q := `SELECT id, account_id, sketch_id, symbol, instrument_type, multiplier, side,
+	             entry_price, stop_price, target_price, size,
+	             risk_pct_at_entry, risk_amount, status, opened_at, closed_at,
+	             exit_price, realized_pnl, thesis, notes
+	      FROM paper_trades ` + whereClause
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []PaperTrade
+	for rows.Next() {
+		t, err := scanPaperTrade(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) scanOnePaperTradeTx(tx *sql.Tx, id int64) (PaperTrade, error) {
+	row := tx.QueryRow(`
+		SELECT id, account_id, sketch_id, symbol, instrument_type, multiplier, side,
+		       entry_price, stop_price, target_price, size,
+		       risk_pct_at_entry, risk_amount, status, opened_at, closed_at,
+		       exit_price, realized_pnl, thesis, notes
+		FROM paper_trades WHERE id = ?`, id)
+	return scanPaperTrade(row)
+}
+
+// rowScanner is anything Scan-able (sql.Row or sql.Rows).
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAccount(r rowScanner) (PaperAccount, error) {
+	var a PaperAccount
+	var settled int
+	var createdAt, updatedAt string
+	if err := r.Scan(&a.ID, &a.Name, &a.BaseCurrency, &a.StartingBalance,
+		&a.CashBalance, &a.RiskPct, &settled, &createdAt, &updatedAt); err != nil {
+		return a, err
+	}
+	a.Settled = settled != 0
+	a.CreatedAt = parseSQLiteTime(createdAt)
+	a.UpdatedAt = parseSQLiteTime(updatedAt)
+	return a, nil
+}
+
+// parseSQLiteTime handles both SQLite's CURRENT_TIMESTAMP format
+// ("2006-01-02 15:04:05") and the mattn/go-sqlite3 driver's time.Time
+// serialization ("2006-01-02 15:04:05.999999999-07:00"), plus RFC3339 as a
+// fallback. Returns zero time only if all attempts fail.
+func parseSQLiteTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	layouts := []string{
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05-07:00",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+		time.RFC3339Nano,
+		time.RFC3339,
+	}
+	for _, l := range layouts {
+		if t, err := time.Parse(l, s); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+func scanPaperTrade(r rowScanner) (PaperTrade, error) {
+	var t PaperTrade
+	var sketchID sql.NullInt64
+	var targetPrice, exitPrice, realizedPnL sql.NullFloat64
+	var closedAt sql.NullString
+	var openedAt string
+
+	if err := r.Scan(
+		&t.ID, &t.AccountID, &sketchID, &t.Symbol, &t.InstrumentType, &t.Multiplier, &t.Side,
+		&t.EntryPrice, &t.StopPrice, &targetPrice, &t.Size,
+		&t.RiskPctAtEntry, &t.RiskAmount, &t.Status, &openedAt, &closedAt,
+		&exitPrice, &realizedPnL, &t.Thesis, &t.Notes,
+	); err != nil {
+		return t, err
+	}
+	if sketchID.Valid {
+		t.SketchID = &sketchID.Int64
+	}
+	if targetPrice.Valid {
+		t.TargetPrice = &targetPrice.Float64
+	}
+	if exitPrice.Valid {
+		t.ExitPrice = &exitPrice.Float64
+	}
+	if realizedPnL.Valid {
+		t.RealizedPnL = &realizedPnL.Float64
+	}
+	t.OpenedAt = parseSQLiteTime(openedAt)
+	if closedAt.Valid {
+		ct := parseSQLiteTime(closedAt.String)
+		t.ClosedAt = &ct
+	}
+	return t, nil
+}

--- a/internal/store/paper_test.go
+++ b/internal/store/paper_test.go
@@ -1,0 +1,221 @@
+package store
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestParseSQLiteTime(t *testing.T) {
+	utc := time.UTC
+	tests := []struct {
+		name  string
+		input string
+		want  time.Time
+		zero  bool
+	}{
+		{
+			name:  "SQLite CURRENT_TIMESTAMP (no tz, no fractional)",
+			input: "2026-05-25 15:57:41",
+			want:  time.Date(2026, 5, 25, 15, 57, 41, 0, utc),
+		},
+		{
+			name:  "mattn/go-sqlite3 default Time format (fractional + zero offset)",
+			input: "2026-05-25 15:57:41.309454+00:00",
+			want:  time.Date(2026, 5, 25, 15, 57, 41, 309454000, utc),
+		},
+		{
+			name:  "mattn/go-sqlite3 with negative offset",
+			input: "2026-05-25 15:57:41.123456-05:00",
+			want:  time.Date(2026, 5, 25, 15, 57, 41, 123456000, time.FixedZone("", -5*3600)),
+		},
+		{
+			name:  "no fractional seconds, with offset",
+			input: "2026-05-25 15:57:41+00:00",
+			want:  time.Date(2026, 5, 25, 15, 57, 41, 0, utc),
+		},
+		{
+			name:  "fractional, no offset",
+			input: "2026-05-25 15:57:41.999999999",
+			want:  time.Date(2026, 5, 25, 15, 57, 41, 999999999, utc),
+		},
+		{
+			name:  "RFC3339 with Z",
+			input: "2026-05-25T15:57:41Z",
+			want:  time.Date(2026, 5, 25, 15, 57, 41, 0, utc),
+		},
+		{
+			name:  "RFC3339Nano",
+			input: "2026-05-25T15:57:41.123456789Z",
+			want:  time.Date(2026, 5, 25, 15, 57, 41, 123456789, utc),
+		},
+		{
+			name:  "empty string yields zero time",
+			input: "",
+			zero:  true,
+		},
+		{
+			name:  "garbage yields zero time",
+			input: "not-a-date-at-all",
+			zero:  true,
+		},
+		{
+			name:  "wrong shape yields zero time",
+			input: "25/05/2026 15:57:41",
+			zero:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseSQLiteTime(tc.input)
+			if tc.zero {
+				if !got.IsZero() {
+					t.Errorf("want zero time, got %v", got)
+				}
+				return
+			}
+			if !got.Equal(tc.want) {
+				t.Errorf("want %v (%v), got %v (%v)",
+					tc.want, tc.want.UnixNano(), got, got.UnixNano())
+			}
+		})
+	}
+}
+
+// TestPaperLifecycleRoundtrip exercises the full open → close path through a
+// real SQLite store. Catches driver-format drift: if a future sqlite3 release
+// changes how it serializes time.Time, this test fails loudly because the
+// round-tripped datetime won't be parseable back into a non-zero time.
+func TestPaperLifecycleRoundtrip(t *testing.T) {
+	store := newTestStore(t)
+	defer store.Close()
+
+	accountID, err := store.CreatePaperAccount("Test", "USD", 10000, 0.02)
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	acc, err := store.GetPaperAccount(accountID)
+	if err != nil {
+		t.Fatalf("get account: %v", err)
+	}
+	if acc.CreatedAt.IsZero() {
+		t.Errorf("account CreatedAt should not be zero (driver-format drift?)")
+	}
+	if acc.UpdatedAt.IsZero() {
+		t.Errorf("account UpdatedAt should not be zero")
+	}
+
+	opened := time.Now().UTC()
+	target := 160.0
+	tradeID, err := store.OpenPaperTrade(PaperTrade{
+		AccountID:      accountID,
+		Symbol:         "AAPL",
+		InstrumentType: "equity",
+		Multiplier:     1,
+		Side:           "long",
+		EntryPrice:     150,
+		StopPrice:      145,
+		TargetPrice:    &target,
+		Size:           40,
+		RiskPctAtEntry: 0.02,
+		RiskAmount:     200,
+		OpenedAt:       opened,
+		Thesis:         "round trip",
+	})
+	if err != nil {
+		t.Fatalf("open trade: %v", err)
+	}
+
+	opens, err := store.GetOpenPaperTrades(accountID)
+	if err != nil {
+		t.Fatalf("get open: %v", err)
+	}
+	if len(opens) != 1 {
+		t.Fatalf("want 1 open trade, got %d", len(opens))
+	}
+	got := opens[0]
+	if got.OpenedAt.IsZero() {
+		t.Errorf("trade OpenedAt should not be zero")
+	}
+	// Round-trip should preserve to at-least-second precision (SQLite + Go's
+	// time-string layouts agree on microseconds; we test second equality to
+	// stay robust against precision rounding either side).
+	if diff := got.OpenedAt.Sub(opened); diff > time.Second || diff < -time.Second {
+		t.Errorf("OpenedAt round-trip drift > 1s: stored=%v, got=%v, diff=%v",
+			opened, got.OpenedAt, diff)
+	}
+
+	if err := store.ClosePaperTrade(tradeID, 155, "target"); err != nil {
+		t.Fatalf("close trade: %v", err)
+	}
+
+	closed, err := store.GetClosedPaperTrades(accountID, 10, 0)
+	if err != nil {
+		t.Fatalf("get closed: %v", err)
+	}
+	if len(closed) != 1 {
+		t.Fatalf("want 1 closed trade, got %d", len(closed))
+	}
+	c := closed[0]
+	if c.ClosedAt == nil || c.ClosedAt.IsZero() {
+		t.Errorf("closed trade ClosedAt should be a non-zero time, got %v", c.ClosedAt)
+	}
+	if c.OpenedAt.IsZero() {
+		t.Errorf("closed trade OpenedAt should be non-zero")
+	}
+	if c.RealizedPnL == nil || *c.RealizedPnL != 200 {
+		t.Errorf("realized P&L: want 200, got %v", c.RealizedPnL)
+	}
+	if c.Status != "closed_target" {
+		t.Errorf("status: want closed_target, got %s", c.Status)
+	}
+
+	acc, err = store.GetPaperAccount(accountID)
+	if err != nil {
+		t.Fatalf("get account after close: %v", err)
+	}
+	if acc.CashBalance != 10200 {
+		t.Errorf("cash balance after close: want 10200, got %v", acc.CashBalance)
+	}
+	if acc.UpdatedAt.IsZero() {
+		t.Errorf("UpdatedAt after close should be non-zero")
+	}
+}
+
+// newTestStore creates a fresh on-disk SQLite store in a temp dir. On-disk
+// (not :memory:) so the connection string mirrors the production path.
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	s, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(dbPath) })
+
+	// Sanity: confirm the sqlite driver is the one we expect.
+	var driverName string
+	if rows, err := s.db.Query("SELECT sqlite_version()"); err == nil {
+		defer rows.Close()
+		for rows.Next() {
+			_ = rows.Scan(&driverName)
+		}
+	}
+	if driverName == "" {
+		t.Skip("sqlite driver not available")
+	}
+	return s
+}
+
+// Compile-time guard that the Store satisfies the interfaces we rely on
+// elsewhere — prevents accidental signature drift breaking handlers.
+var _ = func() {
+	var _ *sql.DB // ensure import is used
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -212,6 +212,55 @@ func (s *Store) migrate() error {
 			type TEXT NOT NULL,           -- stock / crypto / forex / index / etf
 			fetched_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		);
+
+		CREATE TABLE IF NOT EXISTS paper_accounts (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			base_currency TEXT NOT NULL DEFAULT 'USD',
+			starting_balance REAL NOT NULL,
+			cash_balance REAL NOT NULL,
+			risk_pct REAL NOT NULL DEFAULT 0.02,
+			settled INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
+
+		CREATE TABLE IF NOT EXISTS paper_trades (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			account_id INTEGER NOT NULL,
+			sketch_id INTEGER,
+			symbol TEXT NOT NULL,
+			instrument_type TEXT NOT NULL,
+			multiplier REAL NOT NULL DEFAULT 1.0,
+			side TEXT NOT NULL,
+			entry_price REAL NOT NULL,
+			stop_price REAL NOT NULL,
+			target_price REAL,
+			size REAL NOT NULL,
+			risk_pct_at_entry REAL NOT NULL,
+			risk_amount REAL NOT NULL,
+			status TEXT NOT NULL DEFAULT 'open',
+			opened_at DATETIME NOT NULL,
+			closed_at DATETIME,
+			exit_price REAL,
+			realized_pnl REAL,
+			thesis TEXT NOT NULL DEFAULT '',
+			notes TEXT NOT NULL DEFAULT '',
+			FOREIGN KEY (account_id) REFERENCES paper_accounts(id),
+			FOREIGN KEY (sketch_id) REFERENCES sketches(id) ON DELETE SET NULL
+		);
+		CREATE INDEX IF NOT EXISTS idx_paper_trades_account ON paper_trades(account_id);
+		CREATE INDEX IF NOT EXISTS idx_paper_trades_status ON paper_trades(status);
+
+		CREATE TABLE IF NOT EXISTS paper_trade_events (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			trade_id INTEGER NOT NULL,
+			event_type TEXT NOT NULL,
+			payload TEXT NOT NULL DEFAULT '{}',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (trade_id) REFERENCES paper_trades(id) ON DELETE CASCADE
+		);
+		CREATE INDEX IF NOT EXISTS idx_paper_trade_events_trade ON paper_trade_events(trade_id);
 	`)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- **Paper trading discipline layer** (`/paper`): per-instrument position sizing for equity / future / option / CFD / forex, txn-safe SQLite-backed account & trade lifecycle, single-page UI with live size preview, journal with R-multiples. 24 unit tests (13 sizing + 11 datetime/round-trip).
- **FMP-wired stock screener** (`/screener`): native FMP filters pass through (market cap, sector, exchange, etc.) plus three custom intraday filters computed via a batch-quote post-pass — change from open, change from previous close, change vs SPY. Sortable results linking through to `/security/{sym}`.
- **Vim keybindings**: `p` on `/news` opens the article reader for the highlighted card (parity with the `p = preview` convention on economics + financials); financials chart key moved `g → c`; full vim nav on `/screener` with two-pane focus (`h`/`l` flip panes, `j`/`k` within active pane, `Enter` focuses input or opens security, `r` re-runs the screen).

RVOL deferred to a follow-up — it needs per-symbol profile fetches that would push screen runs past acceptable latency without a precomputed cache.

## Test plan

- [ ] `make test` — unit suite green
- [ ] `make smoke` — e2e green
- [ ] Open `/paper`, create a paper account (£10k, 2%), open a trade (AAPL long 150 / stop 145 / target 160), confirm sizing preview reads 40 shares / $200 risk, submit, close at 155, confirm journal shows +$200 / 1.00R and cash balance moves to $10,200.
- [ ] Open `/screener`, leave filters blank, hit Run Screen, confirm rows return within a few seconds; add `change from prev close ≥ 1`, re-run, confirm results all show positive Δ prev %.
- [ ] On `/screener` press `Esc` to enter normal mode; verify `h` highlights a filter input, `j`/`k` cycles filters, `l` jumps to the results table, `j`/`k` cycles rows, `Enter` opens the highlighted security.
- [ ] On `/news`, navigate to a card with `j`/`k`, press `p`, confirm the article reader slides in.
- [ ] On `/security/{AAPL}` → Financials tab, highlight a metric row, press `c`, confirm it navigates to the chart for that metric; press `c` from a non-financials row to confirm the existing sub-tab nav still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
