### PR TITLE
feat(ideas): company info panels with implicit metric grouping

### DIFF
--- a/internal/server/ideas.go
+++ b/internal/server/ideas.go
@@ -118,6 +118,34 @@ func (s *Server) handleDeleteSketch(w http.ResponseWriter, r *http.Request) {
 // distinct without making the client do the bookkeeping.
 var seriesPalette = []string{"#ff8800", "#4499ff", "#00cc66", "#bb88ff", "#ccaa00"}
 
+// companyPrefix returns the equity symbol that a metric belongs to, or "" if
+// the metric isn't equity-derived (commodities, forex, crypto, indices each
+// stand alone). Used for the implicit "group metrics by company" rule.
+//
+//	("price",     "AAPL")          → "AAPL"
+//	("financial", "AAPL.revenue")  → "AAPL"
+//	("financial", "BRK.A.revenue") → "BRK.A"      (rightmost dot is the field)
+//	("commodity", "GCUSD")         → ""
+//	("forex",     "EURUSD")        → ""
+func companyPrefix(kind, identifier string) string {
+	if kind != "price" && kind != "financial" {
+		return ""
+	}
+	id := strings.ToUpper(strings.TrimSpace(identifier))
+	if id == "" {
+		return ""
+	}
+	if kind == "price" {
+		return id
+	}
+	// financial — split on the rightmost dot; everything before is the symbol.
+	dot := strings.LastIndex(id, ".")
+	if dot <= 0 || dot >= len(id)-1 {
+		return ""
+	}
+	return id[:dot]
+}
+
 func pickUnusedColor(existing []store.SketchMetric) string {
 	used := make(map[string]bool, len(existing))
 	for _, m := range existing {
@@ -158,6 +186,23 @@ func (s *Server) handleAddSketchMetric(w http.ResponseWriter, r *http.Request) {
 	if m.Kind == "" || m.Identifier == "" {
 		http.Error(w, "kind and identifier required", http.StatusBadRequest)
 		return
+	}
+	// Enforce 4-metric cap per company on the sketch. Only equity-derived
+	// kinds participate (price/financial) — commodities, forex, crypto, indices
+	// each render as their own panel and aren't grouped.
+	if prefix := companyPrefix(m.Kind, m.Identifier); prefix != "" {
+		if existing, gerr := s.store.GetSketch(id); gerr == nil && existing != nil {
+			n := 0
+			for _, em := range existing.Metrics {
+				if companyPrefix(em.Kind, em.Identifier) == prefix {
+					n++
+				}
+			}
+			if n >= 4 {
+				http.Error(w, fmt.Sprintf("max 4 metrics per company (%s); remove one first", prefix), http.StatusBadRequest)
+				return
+			}
+		}
 	}
 	mid, err := s.store.AddSketchMetric(m)
 	if err != nil {

--- a/internal/server/ideas_info_panels.go
+++ b/internal/server/ideas_info_panels.go
@@ -1,0 +1,148 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"stocktopus/internal/news"
+)
+
+// CompanyInfoPanel is one row in the response of GET /api/sketches/{id}/info-panels.
+// It carries everything the ideas UI needs to render one company's info card:
+// live quote, news pulse, and which of the company's metrics are pinned on this
+// sketch (for the metric-chip strip).
+type CompanyInfoPanel struct {
+	Symbol            string   `json:"symbol"`
+	CompanyName       string   `json:"companyName"`
+	Price             float64  `json:"price"`
+	PreviousClose     float64  `json:"previousClose"`
+	ChangePercentage  float64  `json:"changePercentage"`
+	DayHigh           float64  `json:"dayHigh"`
+	DayLow            float64  `json:"dayLow"`
+	Volume            float64  `json:"volume"`
+	Open              float64  `json:"open"`
+	NewsCount24h      int      `json:"newsCount24h"`
+	PinnedMetrics     []string `json:"pinnedMetrics"`
+}
+
+// handleSketchInfoPanels: GET /api/sketches/{id}/info-panels
+//
+// Walks the sketch's metrics, groups by companyPrefix(), and returns one panel
+// per unique equity symbol. Non-equity metrics (commodities, forex, crypto,
+// indices) are skipped — they're charted but don't get a company card.
+//
+// For each company we batch-quote and fetch news in parallel. News count is
+// computed from the last 24h of stock-category news filtered to the symbol.
+func (s *Server) handleSketchInfoPanels(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.store == nil || s.news == nil {
+		_ = json.NewEncoder(w).Encode([]any{})
+		return
+	}
+	sketchID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		http.Error(w, "bad id", http.StatusBadRequest)
+		return
+	}
+	sk, err := s.store.GetSketch(sketchID)
+	if err != nil {
+		http.Error(w, "sketch not found", http.StatusNotFound)
+		return
+	}
+
+	// Group metrics by company prefix, preserving first-seen order so panels
+	// render in the same order metrics were pinned.
+	type group struct {
+		symbol  string
+		metrics []string
+	}
+	var ordered []*group
+	bySymbol := make(map[string]*group)
+	for _, m := range sk.Metrics {
+		prefix := companyPrefix(m.Kind, m.Identifier)
+		if prefix == "" {
+			continue
+		}
+		g, ok := bySymbol[prefix]
+		if !ok {
+			g = &group{symbol: prefix}
+			bySymbol[prefix] = g
+			ordered = append(ordered, g)
+		}
+		g.metrics = append(g.metrics, m.Identifier)
+	}
+	if len(ordered) == 0 {
+		_ = json.NewEncoder(w).Encode([]any{})
+		return
+	}
+
+	// Batch-quote all companies in one shot — same pattern as the screener.
+	symbols := make([]string, len(ordered))
+	for i, g := range ordered {
+		symbols[i] = g.symbol
+	}
+	ctx := r.Context()
+	quotes, err := s.batchQuotes(ctx, symbols)
+	if err != nil {
+		s.logger.Error("info-panels: batch-quote", "error", err)
+		http.Error(w, "quote fetch failed", http.StatusBadGateway)
+		return
+	}
+
+	// Parallel news fetches + company-name lookups. Fan out per symbol so we
+	// don't serialise N FMP round-trips. Wrap each call with the request
+	// context so the client disconnecting cancels the in-flight work.
+	type enrichment struct {
+		companyName  string
+		newsCount24h int
+	}
+	enrichments := make(map[string]enrichment, len(symbols))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	since := time.Now().UTC().Add(-24 * time.Hour).Format("2006-01-02")
+	until := time.Now().UTC().Format("2006-01-02")
+
+	for _, sym := range symbols {
+		sym := sym
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var en enrichment
+			items, ierr := s.news.GetNewsWithDates(ctx, news.Stock, sym, 0, 50, since, until)
+			if ierr == nil {
+				en.newsCount24h = len(items)
+			}
+			if q, ok := quotes[sym]; ok {
+				en.companyName = q.Name
+			}
+			mu.Lock()
+			enrichments[sym] = en
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	panels := make([]CompanyInfoPanel, 0, len(ordered))
+	for _, g := range ordered {
+		q := quotes[g.symbol]
+		en := enrichments[g.symbol]
+		panels = append(panels, CompanyInfoPanel{
+			Symbol:           g.symbol,
+			CompanyName:      en.companyName,
+			Price:            q.Price,
+			PreviousClose:    q.PreviousClose,
+			ChangePercentage: q.ChangePercentage,
+			DayHigh:          q.DayHigh,
+			DayLow:           q.DayLow,
+			Volume:           q.Volume,
+			Open:             q.Open,
+			NewsCount24h:     en.newsCount24h,
+			PinnedMetrics:    g.metrics,
+		})
+	}
+
+	_ = json.NewEncoder(w).Encode(panels)
+}

--- a/internal/server/ideas_test.go
+++ b/internal/server/ideas_test.go
@@ -1,0 +1,39 @@
+package server
+
+import "testing"
+
+func TestCompanyPrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		kind       string
+		identifier string
+		want       string
+	}{
+		{"price equity", "price", "AAPL", "AAPL"},
+		{"price equity lowercase normalises", "price", "aapl", "AAPL"},
+		{"price equity with whitespace", "price", "  AAPL  ", "AAPL"},
+		{"financial standard", "financial", "AAPL.revenue", "AAPL"},
+		{"financial preserves dot ticker", "financial", "BRK.A.revenue", "BRK.A"},
+		{"financial preserves L-suffix ticker", "financial", "GOOG.L.ebitda", "GOOG.L"},
+		{"financial without field is rejected", "financial", "AAPL", ""},
+		{"financial trailing dot is rejected", "financial", "AAPL.", ""},
+		{"financial leading dot is rejected", "financial", ".revenue", ""},
+		{"commodity has no company", "commodity", "GCUSD", ""},
+		{"forex has no company", "forex", "EURUSD", ""},
+		{"crypto has no company", "crypto", "BTCUSD", ""},
+		{"index has no company", "index", "SPX", ""},
+		{"economic has no company", "economic", "US.FEDFUNDS", ""},
+		{"empty identifier", "price", "", ""},
+		{"unknown kind", "wat", "AAPL", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := companyPrefix(tc.kind, tc.identifier)
+			if got != tc.want {
+				t.Errorf("companyPrefix(%q, %q) = %q, want %q",
+					tc.kind, tc.identifier, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/screener.go
+++ b/internal/server/screener.go
@@ -60,6 +60,7 @@ type screenerResult struct {
 // batchQuoteRow mirrors the relevant subset of FMP's /stable/batch-quote item.
 type batchQuoteRow struct {
 	Symbol           string  `json:"symbol"`
+	Name             string  `json:"name"`
 	Price            float64 `json:"price"`
 	ChangePercentage float64 `json:"changePercentage"`
 	Volume           float64 `json:"volume"`

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -188,6 +188,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("DELETE /api/sketches/{id}", s.handleDeleteSketch)
 	mux.HandleFunc("POST /api/sketches/{id}/metrics", s.handleAddSketchMetric)
 	mux.HandleFunc("DELETE /api/sketches/{id}/metrics/{metricId}", s.handleRemoveSketchMetric)
+	mux.HandleFunc("GET /api/sketches/{id}/info-panels", s.handleSketchInfoPanels)
 	mux.HandleFunc("GET /api/historical/{kind}/{symbol}", s.handleHistorical)
 
 	// Economics

--- a/internal/server/static/ideas.js
+++ b/internal/server/static/ideas.js
@@ -136,7 +136,96 @@
         hostEl.style.display = n ? 'block' : 'none';
         renderLegend();
         renderSidebar();
+        refreshInfoPanels();
     }
+
+    // ── Company info panels ──
+    //
+    // One card per unique equity company on the sketch. The backend groups
+    // metrics by company prefix (price/financial only) and returns enriched
+    // quote + news data per group. Cards re-fetch on every renderSketch()
+    // call (so they update after add/remove) and on a 15s background poll.
+
+    var infoPanelsEl = document.getElementById('ideas-info-panels');
+    var infoPanelsTimer = null;
+    var lastInfoPanels = [];
+
+    function refreshInfoPanels() {
+        if (!currentSketch || !currentSketch.id) {
+            infoPanelsEl.hidden = true;
+            return;
+        }
+        var sketchID = currentSketch.id;
+        fetch('/api/sketches/' + sketchID + '/info-panels')
+            .then(function (r) { return r.ok ? r.json() : []; })
+            .then(function (panels) {
+                // Drop the response if the user switched sketch while we were waiting.
+                if (!currentSketch || currentSketch.id !== sketchID) return;
+                lastInfoPanels = Array.isArray(panels) ? panels : [];
+                renderInfoPanels();
+            })
+            .catch(function () { /* swallow — UI keeps last good render */ });
+    }
+
+    function renderInfoPanels() {
+        if (!lastInfoPanels.length) {
+            infoPanelsEl.hidden = true;
+            infoPanelsEl.innerHTML = '';
+            return;
+        }
+        infoPanelsEl.hidden = false;
+        infoPanelsEl.innerHTML = lastInfoPanels.map(function (p) {
+            var pctClass = p.changePercentage >= 0 ? 'price-up' : 'price-down';
+            var pctStr = (p.changePercentage >= 0 ? '+' : '') + (p.changePercentage || 0).toFixed(2) + '%';
+            var newsBadge = p.newsCount24h > 0
+                ? '<span class="ideas-info-news-badge" title="news items last 24h">' + p.newsCount24h + ' news</span>'
+                : '';
+            var chips = (p.pinnedMetrics || []).map(function (id) {
+                // Strip the symbol prefix from financial chip labels for readability.
+                var label = id.indexOf('.') >= 0 ? id.split('.').slice(1).join('.') : id;
+                return '<span class="ideas-info-chip">' + esc(label) + '</span>';
+            }).join('');
+            return '<div class="ideas-info-card" data-vim-item data-vim-action="navigate" data-vim-href="/security/' + encodeURIComponent(p.symbol) + '">'
+                +    '<div class="ideas-info-head">'
+                +      '<a class="ideas-info-symbol" href="/security/' + encodeURIComponent(p.symbol) + '">' + esc(p.symbol) + '</a>'
+                +      (p.companyName ? '<span class="ideas-info-name">' + esc(p.companyName) + '</span>' : '')
+                +      newsBadge
+                +    '</div>'
+                +    '<div class="ideas-info-quote">'
+                +      '<span class="ideas-info-price">' + fmtPrice(p.price) + '</span>'
+                +      '<span class="ideas-info-pct ' + pctClass + '">' + pctStr + '</span>'
+                +    '</div>'
+                +    '<div class="ideas-info-stats">'
+                +      '<span><label>Open</label>' + fmtPrice(p.open) + '</span>'
+                +      '<span><label>Day H</label>' + fmtPrice(p.dayHigh) + '</span>'
+                +      '<span><label>Day L</label>' + fmtPrice(p.dayLow) + '</span>'
+                +      '<span><label>Vol</label>' + fmtVolume(p.volume) + '</span>'
+                +    '</div>'
+                +    (chips ? '<div class="ideas-info-chips">' + chips + '</div>' : '')
+                +  '</div>';
+        }).join('');
+    }
+
+    function fmtPrice(n) {
+        if (n == null || isNaN(n)) return '—';
+        return Number(n).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    }
+    function fmtVolume(n) {
+        if (n == null || isNaN(n) || n === 0) return '—';
+        var abs = Math.abs(n);
+        if (abs >= 1e9) return (n / 1e9).toFixed(2) + 'B';
+        if (abs >= 1e6) return (n / 1e6).toFixed(2) + 'M';
+        if (abs >= 1e3) return (n / 1e3).toFixed(1) + 'K';
+        return String(n);
+    }
+
+    // 15s poll matches the watchlist poller cadence — keeps perception
+    // of "live" without hammering FMP.
+    function startInfoPanelsPoll() {
+        if (infoPanelsTimer) clearInterval(infoPanelsTimer);
+        infoPanelsTimer = setInterval(refreshInfoPanels, 15000);
+    }
+    startInfoPanelsPoll();
 
     function renderLegend() {
         var metrics = (currentSketch && currentSketch.metrics) || [];

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -3845,3 +3845,131 @@ a, [tabindex] {
     font-style: italic;
 }
 
+/* ============================================================
+   Ideas — company info panels (grid below the chart)
+   ============================================================ */
+
+.ideas-info-panels {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 10px;
+    padding: 12px 0 4px;
+    margin-top: 8px;
+    border-top: 1px solid var(--border);
+}
+
+.ideas-info-panels[hidden] { display: none; }
+
+.ideas-info-card {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 10px 12px;
+    font-size: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    cursor: pointer;
+    transition: border-color 0.1s;
+}
+
+.ideas-info-card:hover {
+    border-color: var(--orange);
+}
+
+.ideas-info-head {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+
+.ideas-info-symbol {
+    color: var(--orange);
+    font-weight: 700;
+    font-size: 14px;
+    text-decoration: none;
+}
+
+.ideas-info-symbol:hover {
+    text-decoration: underline;
+}
+
+.ideas-info-name {
+    color: var(--text-secondary);
+    font-size: 11px;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.ideas-info-news-badge {
+    background: var(--bg-tertiary);
+    color: var(--yellow);
+    border: 1px solid var(--border);
+    padding: 1px 6px;
+    border-radius: 2px;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+
+.ideas-info-quote {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    font-variant-numeric: tabular-nums;
+}
+
+.ideas-info-price {
+    color: var(--text-primary);
+    font-size: 18px;
+    font-weight: 600;
+}
+
+.ideas-info-pct {
+    font-size: 12px;
+    font-weight: 500;
+}
+
+.ideas-info-pct.price-up { color: var(--green); }
+.ideas-info-pct.price-down { color: var(--red); }
+
+.ideas-info-stats {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 6px;
+    font-size: 10px;
+    font-variant-numeric: tabular-nums;
+}
+
+.ideas-info-stats > span {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+
+.ideas-info-stats label {
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    font-size: 9px;
+}
+
+.ideas-info-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 3px;
+    padding-top: 4px;
+    border-top: 1px solid var(--bg-tertiary);
+}
+
+.ideas-info-chip {
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+    padding: 1px 5px;
+    font-size: 10px;
+    border-radius: 2px;
+}
+

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -2895,6 +2895,28 @@ window.onerror = function (msg, src, line, col, err) {
                         ci.setSelectionRange(ci.value.length, ci.value.length);
                     }
                 }
+                // 'a' on /screener result row prefills :add SYMBOL so the user
+                // can confirm with Enter and pin it to the current sketch.
+                // Only fires when focus is on the results list (not the filter pane).
+                if (currentView === 'screener' && handler && handler._focus === 'results') {
+                    var sRows = handler.getResults ? handler.getResults() : [];
+                    var sRow = sRows[handler._resultIdx];
+                    if (sRow) {
+                        var link = sRow.querySelector('a[href]');
+                        if (link) {
+                            // Extract symbol from /security/{SYM} link path.
+                            var href = link.getAttribute('href') || '';
+                            var sym = href.replace(/^\/security\//, '').toUpperCase();
+                            if (sym) {
+                                e.preventDefault();
+                                var sci = document.getElementById('cmd-input');
+                                sci.value = ':add ' + sym;
+                                sci.focus();
+                                sci.setSelectionRange(sci.value.length, sci.value.length);
+                            }
+                        }
+                    }
+                }
                 return;
             case '1': case '2': case '3': case '4': case '5': case '6': case '7':
                 if (handler && handler.jumpToTab) {

--- a/internal/server/templates/ideas.html
+++ b/internal/server/templates/ideas.html
@@ -30,6 +30,7 @@
             <p>No metrics on this sketch yet.</p>
             <p class="empty-hint">Press <kbd>?</kbd> to see the keybindings.</p>
         </div>
+        <div id="ideas-info-panels" class="ideas-info-panels" data-vim-row hidden></div>
     </section>
 </div>
 <script src="/static/ideas.js?v={{.AssetVersion}}" data-sketch-id="{{.SketchID}}"></script>


### PR DESCRIPTION
## Summary

- Pin a company to a sketch (or any of its metrics) and you get a live info card under the chart — symbol, name, price, day change vs prev close, open, day high/low, volume, news-count badge.
- Multiple metrics for the same company group implicitly onto one card (and one chart) up to a hard cap of 4. 5th add returns a usable 400 error.
- `data-vim-item` on each card → vim `Enter` navigates to `/security/{sym}`.
- Screener: `a` on a highlighted result pre-fills `:add SYMBOL` in the command bar (parity with the existing `:add` prefill on financials + economics).
- 15s background poll, immediate refresh on add/remove.
- 16 unit tests on the `companyPrefix` helper (load-bearing for grouping; covers dot-tickers BRK.A / GOOG.L and every non-equity kind).

Deferred to follow-ups:
- #127 pre-market data
- #128 'market-moving news' detection
- #129 socioeconomic / macro effects panel

## Test plan

- [ ] \`make test\` + \`make smoke\` green
- [ ] On \`/ideas\` create a sketch, \`:add AAPL\`, see a card appear with live quote
- [ ] \`:add AAPL.revenue\`, see metric chip appended to the same card; chart now shows both series
- [ ] Add up to 4 metrics for AAPL, confirm 5th add returns 400 with "max 4 metrics per company"
- [ ] \`j\`/\`k\` to a card, press Enter, lands on \`/security/AAPL\`
- [ ] On \`/screener\` Esc, run a screen, \`l\` to results, \`j\` to a row, press \`a\`, see \`:add SYMBOL\` in the command bar; Enter pins it
- [ ] Add \`GCUSD\` (commodity) to a sketch, confirm it does NOT get a company card (charts only)