### PR TITLE
feat(vim): c=chart, p=preview + BDD harness + collapse dual selection state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build test smoke clean setup-agents agent-train lint-js
+.PHONY: dev build test smoke bdd clean setup-agents agent-train lint-js
 
 dev: build
 	./bin/stocktopus
@@ -17,6 +17,9 @@ test:
 
 smoke:
 	go test -tags e2e -v -count=1 ./tests/e2e/
+
+bdd:
+	cd tests/bdd && npm install --silent && npm test
 
 setup-agents:
 	@echo "Installing Ollama (if not present)..."

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -452,23 +452,9 @@
         if (n >= 0 && n < tabs.length) tabs[n].click();
     };
 
-    // Financial table row vim navigation
-    var finSelectedRow = -1;
-    window._finGetRows = function () { return Array.from(document.querySelectorAll('.fin-row')); };
-    window._finGetSelectedRow = function () { return finSelectedRow; };
-    window._finSelectRow = function (idx) {
-        var rows = window._finGetRows();
-        if (rows.length === 0) return;
-        idx = Math.max(0, Math.min(idx, rows.length - 1));
-        finSelectedRow = idx;
-        rows.forEach(function (r, i) { r.classList.toggle('vim-selected', i === idx); });
-        rows[idx].scrollIntoView({ block: 'nearest' });
-    };
-    window._finClearRow = function () {
-        var rows = window._finGetRows();
-        rows.forEach(function (r) { r.classList.remove('vim-selected'); });
-        finSelectedRow = -1;
-    };
+    // Financial row selection lives on the DOM (.vim-selected, owned by
+    // VimNav). Consumers query `.fin-row.vim-selected` directly — no
+    // parallel index state.
 
     // ── Financials Preview Chart Slide-in ──
 
@@ -513,10 +499,8 @@
     }
 
     window._finOpenChart = function () {
-        if (finSelectedRow < 0) return;
-        var rows = window._finGetRows();
-        if (finSelectedRow >= rows.length) return;
-        var row = rows[finSelectedRow];
+        var row = document.querySelector('.fin-row.vim-selected');
+        if (!row) return;
 
         var label  = row.dataset.finLabel || 'Metric';
         var finKey = row.dataset.finKey || '';
@@ -725,7 +709,6 @@
 
                 html += '</tbody></table>';
                 tc.innerHTML = html;
-                finSelectedRow = -1;
             })
             .catch(function () {
                 tc.innerHTML = '<p class="empty-state">Failed to load financials</p>';
@@ -894,7 +877,7 @@
             html += '<div class="sector-header">';
             html += '<span class="sector-name">' + esc(sector) + '</span>';
             if (industry) html += '<span class="sector-industry"> / ' + esc(industry) + '</span>';
-            html += '<span class="sector-hint"> j/k nav · i info · g graph</span>';
+            html += '<span class="sector-hint"> j/k nav · i info · c chart · p preview</span>';
             html += '</div>';
 
             // Peer comparison table with mini sparkline column
@@ -1065,7 +1048,6 @@
 
     var secFormTypes = null; // cached form type reference data
     var secFilter = ''; // current form type filter
-    var secSelectedRow = -1;
     var secView = 'filings'; // 'filings' | 'people'
 
     function loadSEC() {
@@ -1169,7 +1151,6 @@
                         secView = 'filings';
                         secFilter = btn.dataset.cat;
                     }
-                    secSelectedRow = -1;
                     loadSEC();
                 };
             });
@@ -1340,30 +1321,17 @@
         return html;
     }
 
-    // Expose for vim — sec-row in filings view, kp-row in key-people view
-    window._secGetRows = function () { return Array.from(document.querySelectorAll('.sec-row, .kp-row')); };
-    window._secGetSelectedRow = function () { return secSelectedRow; };
-    window._secSelectRow = function (idx) {
-        var rows = window._secGetRows();
-        if (rows.length === 0) return;
-        idx = Math.max(0, Math.min(idx, rows.length - 1));
-        secSelectedRow = idx;
-        rows.forEach(function (r, i) { r.classList.toggle('vim-selected', i === idx); });
-        rows[idx].scrollIntoView({ block: 'nearest' });
-    };
+    // Open the highlighted filing in a new tab. Row selection lives on
+    // the DOM (.vim-selected, owned by VimNav).
     window._secActivate = function () {
-        var rows = window._secGetRows();
-        if (secSelectedRow >= 0 && secSelectedRow < rows.length) {
-            var link = rows[secSelectedRow].dataset.link;
-            if (link) window.open(link, '_blank');
-        }
+        var row = document.querySelector('.sec-row.vim-selected, .kp-row.vim-selected');
+        if (row && row.dataset.link) window.open(row.dataset.link, '_blank');
     };
     window._secCycleFilter = function () {
         var cats = ['', 'periodic', 'event', 'ownership', 'proxy', 'registration'];
         var idx = cats.indexOf(secFilter);
         secFilter = cats[(idx + 1) % cats.length];
         secView = 'filings';
-        secSelectedRow = -1;
         loadSEC();
     };
 

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -2020,6 +2020,98 @@ window.onerror = function (msg, src, line, col, err) {
         items[index].scrollIntoView({ block: 'nearest', behavior: 'smooth' });
     }
 
+    // ── Price preview slide-in ──
+    //
+    // Shared by /watchlist ('p' on a row) and the Sector tab on /security
+    // ('p' on a peer row). Mirrors the financials preview pattern in info.js:
+    // hijacks the article-reader slide-in, renders a 1-year EOD chart via
+    // lightweight-charts, and disposes the chart on close so we don't leak.
+    var pricePreviewChart = null;
+    function disposePricePreviewChart() {
+        if (pricePreviewChart) {
+            try { pricePreviewChart.remove(); } catch (e) {}
+            pricePreviewChart = null;
+        }
+    }
+
+    window._closePricePreview = function () {
+        var reader = document.getElementById('article-reader');
+        if (!reader) return false;
+        if (reader.dataset.mode !== 'price-chart') return false;
+        disposePricePreviewChart();
+        reader.classList.add('hidden');
+        delete reader.dataset.mode;
+        return true;
+    };
+
+    function openPricePreview(symbol) {
+        if (!symbol) return;
+        var reader = document.getElementById('article-reader');
+        var readerTitle = document.getElementById('reader-title');
+        var readerBody = document.getElementById('reader-body');
+        if (!reader || !readerBody) return;
+        reader.classList.remove('hidden');
+        reader.dataset.mode = 'price-chart';
+        if (readerTitle) readerTitle.textContent = symbol + ' — 1y';
+        readerBody.innerHTML = '<div id="price-preview-host" style="width:100%;height:280px"></div>'
+            + '<p id="price-preview-meta" class="empty-state" style="margin-top:8px"></p>';
+
+        fetch('/api/historical/stock/' + encodeURIComponent(symbol))
+            .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+            .then(function (rows) {
+                if (!Array.isArray(rows) || rows.length === 0) {
+                    readerBody.innerHTML = '<p class="empty-state">No price history for ' + symbol + '.</p>';
+                    return;
+                }
+                // FMP returns descending — flip to ascending and trim to last
+                // 252 trading days (~1y) so the preview stays snappy.
+                var asc = rows.slice().reverse();
+                if (asc.length > 252) asc = asc.slice(asc.length - 252);
+                var series = asc.map(function (r) {
+                    return { time: r.date, value: Number(r.price) };
+                }).filter(function (p) { return p.time && !isNaN(p.value); });
+                if (series.length === 0) {
+                    readerBody.innerHTML = '<p class="empty-state">No usable points for ' + symbol + '.</p>';
+                    return;
+                }
+
+                var host = document.getElementById('price-preview-host');
+                if (!window.LightweightCharts || !host) return;
+                disposePricePreviewChart();
+                pricePreviewChart = LightweightCharts.createChart(host, {
+                    layout: { background: { color: '#0a0a0a' }, textColor: '#888888', fontFamily: "'SF Mono','Consolas',monospace", fontSize: 10, attributionLogo: false },
+                    grid: { vertLines: { color: '#1a1a1a' }, horzLines: { color: '#1a1a1a' } },
+                    rightPriceScale: { borderColor: '#2a2a2a' },
+                    timeScale: { borderColor: '#2a2a2a', timeVisible: false, fixLeftEdge: true, fixRightEdge: true },
+                    handleScale: false,
+                    handleScroll: false,
+                });
+                var first = series[0].value;
+                var last = series[series.length - 1].value;
+                var color = last >= first ? '#00cc66' : '#ff4444';
+                var line = pricePreviewChart.addSeries(LightweightCharts.LineSeries, {
+                    color: color, lineWidth: 2,
+                    priceFormat: { type: 'price', precision: 2, minMove: 0.01 },
+                });
+                line.setData(series);
+                pricePreviewChart.timeScale().fitContent();
+
+                var pct = first > 0 ? ((last - first) / first) * 100 : 0;
+                var sign = pct >= 0 ? '+' : '';
+                var meta = document.getElementById('price-preview-meta');
+                if (meta) {
+                    meta.textContent = symbol + ' · '
+                        + series.length + 'd · '
+                        + first.toFixed(2) + ' → ' + last.toFixed(2)
+                        + ' (' + sign + pct.toFixed(1) + '%)';
+                    meta.style.color = color;
+                }
+            })
+            .catch(function () {
+                readerBody.innerHTML = '<p class="empty-state">Failed to load price history for ' + symbol + '.</p>';
+            });
+    }
+
     // ── Per-View Vim Handlers ──
 
     var vimHandlers = {
@@ -2113,7 +2205,7 @@ window.onerror = function (msg, src, line, col, err) {
                 fetch('/api/watchlists/' + wlId + '/symbols/' + encodeURIComponent(sym), { method: 'DELETE' })
                     .then(function () {
                         watchlistBuffer = sym;
-                        flashError('Cut ' + sym + ' — press p to paste into another watchlist');
+                        flashError('Cut ' + sym + ' — press P to paste into another watchlist');
                         refreshWatchlistView();
                     })
                     .catch(function () { flashError('Remove failed'); });
@@ -2140,6 +2232,12 @@ window.onerror = function (msg, src, line, col, err) {
                 // addToWatchlist already calls loadWatchlists internally, but it
                 // doesn't repaint quote rows. Force a full refresh.
                 refreshWatchlistView();
+                return true;
+            },
+            openPreview: function () {
+                var sym = this._selectedSymbol();
+                if (!sym) return false;
+                openPricePreview(sym);
                 return true;
             },
         },
@@ -2233,32 +2331,6 @@ window.onerror = function (msg, src, line, col, err) {
                 var hasSub = this.hasSubTabs();
 
                 if (dir === 'k') {
-                    // SEC tab: filing row navigation
-                    if (this._focus === 'content' && this.isSECTab()) {
-                        var secRows = window._secGetRows ? window._secGetRows() : [];
-                        var secIdx = window._secGetSelectedRow ? window._secGetSelectedRow() : -1;
-                        if (secRows.length > 0 && secIdx > 0) {
-                            window._secSelectRow(secIdx - 1);
-                            return;
-                        }
-                        clearVimSelection();
-                        this._focus = hasSub ? 'sub' : 'main';
-                        this._highlightFocus();
-                        return;
-                    }
-                    // Financials tab: row navigation
-                    if (this._focus === 'content' && this.isFinTab()) {
-                        var finRows = window._finGetRows ? window._finGetRows() : [];
-                        var finIdx = window._finGetSelectedRow ? window._finGetSelectedRow() : -1;
-                        if (finRows.length > 0 && finIdx > 0) {
-                            window._finSelectRow(finIdx - 1);
-                            return;
-                        }
-                        if (window._finClearRow) window._finClearRow();
-                        this._focus = hasSub ? 'sub' : 'main';
-                        this._highlightFocus();
-                        return;
-                    }
                     // AI tab: trading panel navigation
                     if (this._focus === 'content' && this.isAITab()) {
                         if (window._tradingVimHandler && window._tradingVimHandler(dir)) return;
@@ -2318,22 +2390,6 @@ window.onerror = function (msg, src, line, col, err) {
                     // Go straight to content (skip focus-only transition)
                     this._focus = 'content';
                     this._highlightFocus();
-                    if (this.isSECTab()) {
-                        var secRows = window._secGetRows ? window._secGetRows() : [];
-                        if (secRows.length > 0) {
-                            var secIdx = window._secGetSelectedRow ? window._secGetSelectedRow() : -1;
-                            window._secSelectRow(secIdx + 1);
-                        }
-                        return;
-                    }
-                    if (this.isFinTab()) {
-                        var finRows = window._finGetRows ? window._finGetRows() : [];
-                        if (finRows.length > 0) {
-                            var finIdx = window._finGetSelectedRow ? window._finGetSelectedRow() : -1;
-                            window._finSelectRow(finIdx + 1);
-                        }
-                        return;
-                    }
                     if (this.isAITab()) {
                         if (window._tradingVimHandler) window._tradingVimHandler(dir);
                         return;
@@ -2447,6 +2503,7 @@ window.onerror = function (msg, src, line, col, err) {
                 if (!sym) return;
                 if (action === 'info' && window._navigateToSecurity) window._navigateToSecurity(sym);
                 if (action === 'graph' && window._navigateToGraph) window._navigateToGraph(sym);
+                if (action === 'preview') openPricePreview(sym);
             }
         },
         ei: {
@@ -2653,6 +2710,7 @@ window.onerror = function (msg, src, line, col, err) {
                     var mode = reader.dataset.mode;
                     if (mode === 'fin-chart' && window._finCloseChart) window._finCloseChart();
                     else if (mode === 'eco-chart' && window._economicsClosePreview) window._economicsClosePreview();
+                    else if (mode === 'price-chart' && window._closePricePreview) window._closePricePreview();
                     else reader.classList.add('hidden');
                     return;
                 }
@@ -2793,14 +2851,27 @@ window.onerror = function (msg, src, line, col, err) {
                 if (handler && handler.jumpToSubTab) { e.preventDefault(); handler.jumpToSubTab(1); }
                 return;
             case 'c':
+                // Watchlist: 'c' charts the selected security (was 'g' until
+                // declarative vim-nav landed; rebound so the key matches the
+                // action — c for chart). 'g' / 'gg' now only do nav.
+                if (currentView === 'watchlist' && handler && handler.graph) {
+                    e.preventDefault();
+                    handler.graph();
+                    return;
+                }
+                // Sector peers (security info → Sector tab): chart the
+                // highlighted peer row.
+                if (handler && handler.isSectorTab && handler.isSectorTab() && handler.sectorNav) {
+                    e.preventDefault();
+                    handler.sectorNav('graph');
+                    return;
+                }
                 // Financials tab: 'c' on a highlighted metric opens the full
                 // chart page for that metric (was historically 'g', moved here
                 // so the key matches the action — 'c' for chart).
                 if (handler && handler.isFinTab && handler.isFinTab()) {
-                    var finRows = window._finGetRows ? window._finGetRows() : [];
-                    var finIdx = window._finGetSelectedRow ? window._finGetSelectedRow() : -1;
-                    if (finIdx >= 0 && finIdx < finRows.length && selectedSecurity) {
-                        var finRow = finRows[finIdx];
+                    var finRow = document.querySelector('.fin-row.vim-selected');
+                    if (finRow && selectedSecurity) {
                         var finKey = finRow.dataset.finKey || '';
                         if (finRow.dataset.finFormat !== 'calc' && finKey && finKey.indexOf('/') < 0) {
                             e.preventDefault();
@@ -2819,6 +2890,18 @@ window.onerror = function (msg, src, line, col, err) {
                 }
                 return;
             case 'p':
+                // Watchlist: 'p' opens a price chart slide-in for the
+                // highlighted symbol. Cut/paste 'p' moved to capital 'P' so
+                // 'p' = preview is consistent across listings.
+                if (currentView === 'watchlist' && handler && handler.openPreview) {
+                    if (handler.openPreview()) { e.preventDefault(); return; }
+                }
+                // Sector peers: preview the highlighted peer's price chart.
+                if (handler && handler.isSectorTab && handler.isSectorTab() && handler.sectorNav) {
+                    e.preventDefault();
+                    handler.sectorNav('preview');
+                    return;
+                }
                 // /economics catalog: open 5-year slide-in chart preview.
                 if (currentView === 'economics' && window._economicsOpenPreview) {
                     if (window._economicsOpenPreview('5y')) { e.preventDefault(); return; }
@@ -2842,7 +2925,11 @@ window.onerror = function (msg, src, line, col, err) {
                     handler.activate();
                     return;
                 }
-                // Watchlist: move (paste) selected symbol to another list (idea #12).
+                return;
+            case 'P':
+                // Watchlist cut/paste — paste the yanked symbol into the
+                // current list. Capital P mirrors vim's "paste before" and
+                // frees lowercase p for the preview action above.
                 if (handler && handler.pasteSelected) {
                     if (handler.pasteSelected()) e.preventDefault();
                 }
@@ -2868,10 +2955,8 @@ window.onerror = function (msg, src, line, col, err) {
                 // 'a' on a highlighted Financials row prefills :add SYMBOL.field
                 // in the command bar so the user can confirm + send to the sketchpad.
                 if (handler && handler.isFinTab && handler.isFinTab()) {
-                    var rows = window._finGetRows ? window._finGetRows() : [];
-                    var idx = window._finGetSelectedRow ? window._finGetSelectedRow() : -1;
-                    if (idx >= 0 && idx < rows.length) {
-                        var row = rows[idx];
+                    var row = document.querySelector('.fin-row.vim-selected');
+                    if (row) {
                         var key = row.dataset.finKey || '';
                         if (row.dataset.finFormat === 'calc' || !key || key.indexOf('/') >= 0) return;
                         if (!selectedSecurity) return;

--- a/internal/server/static/vim-nav.js
+++ b/internal/server/static/vim-nav.js
@@ -216,6 +216,10 @@
         currentRow = 0;
         currentCol = n - 1;
         applySelection();
+        // Fire the item's primary action — for tab strips that means
+        // the tab actually switches, not just gets highlighted. Without
+        // this, "press 2 → Financials tab" only paints a focus ring.
+        activate();
         return true;
     }
 

--- a/tests/bdd/.gitignore
+++ b/tests/bdd/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.features-gen
+test-results
+playwright-report
+playwright/.cache

--- a/tests/bdd/README.md
+++ b/tests/bdd/README.md
@@ -1,0 +1,71 @@
+# stocktopus BDD tests
+
+Plain-English browser tests for the stocktopus terminal.
+
+## What this is
+
+This folder holds our behaviour-driven tests. Each scenario is written in
+Gherkin (the "Given / When / Then" language) and is run by Playwright,
+which drives a real Chrome browser against the app.
+
+The point: anyone on the team (engineer or not) can read a scenario and
+understand what the product is supposed to do. If a scenario fails, the
+report tells you exactly which sentence broke.
+
+## How to run
+
+You need the stocktopus dev server running first. In another terminal:
+
+```
+make dev
+```
+
+Then, from the repo root:
+
+```
+cd tests/bdd && npm install && npm test
+```
+
+Or from the repo root using the Makefile shortcut:
+
+```
+make bdd
+```
+
+The first run takes a minute while npm pulls Playwright and downloads the
+Chrome binary. After that, runs are fast.
+
+To watch the browser drive the app live:
+
+```
+npm run test:headed
+```
+
+## Where the scenarios live
+
+- `features/` — one `.feature` file per area of the app, written in
+  Gherkin. This is the human-readable spec.
+- `steps/` — JavaScript glue that teaches Playwright what each Gherkin
+  sentence means ("when I press k" -> press the k key).
+- `support/` — shared helpers used by the step files.
+
+The `.features-gen/` folder is generated at test time and is gitignored.
+
+## How to add a scenario
+
+1. Open or create a `.feature` file under `features/`.
+2. Write a scenario in plain English:
+
+   ```
+   Scenario: Add a security to the watchlist
+     Given the terminal is open
+     When I type "AAPL" and press Enter
+     Then "AAPL" appears in the watchlist
+   ```
+
+3. Run `npm test`. If a sentence is new, Playwright will print a stub
+   you can copy into a `steps/` file and fill in.
+
+That's it. Keep scenarios short, focused on user-visible behaviour, and
+written the way a person would describe the feature, not the way the
+code is structured.

--- a/tests/bdd/features/financials-preview.feature
+++ b/tests/bdd/features/financials-preview.feature
@@ -1,0 +1,16 @@
+Feature: Financials metric preview
+  When studying a company's numbers, a quick peek at how a single metric has
+  moved over five years is the difference between a snap judgement and a real
+  read. The preview slide-in must open from the highlighted row with one
+  keystroke, so the analyst never loses their place in the table.
+
+  Background:
+    Given the dev server is reachable
+    And I am on the security page for "AAPL"
+
+  Scenario: Pressing p on a highlighted financials row opens a 5-year preview chart
+    When I press the keys "2jjj"
+    Then a row is highlighted
+    When I press "p"
+    Then the preview slide-in is visible
+    And the preview slide-in title contains "5y"

--- a/tests/bdd/features/security-tabs.feature
+++ b/tests/bdd/features/security-tabs.feature
@@ -1,0 +1,20 @@
+Feature: Numbered tabs on the security page
+  Each section of a security's detail page is reachable by a single digit, so a
+  reader can flick between Overview, Financials, Estimates, News, AI Analysis,
+  Sector, and SEC without ever touching the mouse. Losing these shortcuts would
+  turn a one-keystroke jump into a hunt-and-click, breaking the rhythm of
+  research.
+
+  Background:
+    Given the dev server is reachable
+    And I am on the security page for "AAPL"
+
+  Scenario: Pressing 2 jumps to the Financials tab
+    When I press "2"
+    Then the active tab is "Financials"
+    And the browser URL should match "/security/AAPL"
+
+  Scenario: Pressing 1 returns to the Overview tab
+    When I press "2"
+    And I press "1"
+    Then the active tab is "Overview"

--- a/tests/bdd/features/watchlist-keybindings.feature
+++ b/tests/bdd/features/watchlist-keybindings.feature
@@ -1,0 +1,24 @@
+Feature: Watchlist vim keybindings stay working
+  Power users navigate the watchlist entirely from the keyboard, and they expect
+  the same short, single-letter shortcuts every time they sit down. If these
+  silently regress, muscle memory leads them to the wrong screen and trust in
+  the terminal erodes fast.
+
+  Background:
+    Given the dev server is reachable
+    And the default watchlist has at least one security
+    And I am on the watchlist page
+
+  Scenario: Pressing c on a highlighted security opens its chart page
+    When I press the keys "jc"
+    Then the browser URL should match "/graph/[A-Z]+"
+
+  Scenario: Pressing p on a highlighted security opens a price preview
+    When I press the keys "jp"
+    Then the preview slide-in is visible
+    And the preview slide-in title contains "1y"
+
+  Scenario: Escape closes the preview slide-in
+    When I press the keys "jp"
+    And I press "Escape"
+    Then the preview slide-in is hidden

--- a/tests/bdd/package-lock.json
+++ b/tests/bdd/package-lock.json
@@ -1,0 +1,672 @@
+{
+  "name": "stocktopus-bdd",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "stocktopus-bdd",
+      "version": "0.0.0",
+      "dependencies": {
+        "@playwright/test": "latest",
+        "playwright-bdd": "latest"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@cucumber/cucumber-expressions": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-18.0.1.tgz",
+      "integrity": "sha512-NSid6bI+7UlgMywl5octojY5NXnxR9uq+JisjOrO52VbFsQM6gTWuQFE8syI10KnIBEdPzuEUSVEeZ0VFzRnZA==",
+      "license": "MIT",
+      "dependencies": {
+        "regexp-match-indices": "1.0.2"
+      }
+    },
+    "node_modules/@cucumber/gherkin": {
+      "version": "32.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-32.2.0.tgz",
+      "integrity": "sha512-X8xuVhSIqlUjxSRifRJ7t0TycVWyX58fygJH3wDNmHINLg9sYEkvQT0SO2G5YlRZnYc11TIFr4YPenscvdlBIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/messages": ">=19.1.4 <28"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-9.2.0.tgz",
+      "integrity": "sha512-3nmRbG1bUAZP3fAaUBNmqWO0z0OSkykZZotfLjyhc8KWwDSOrOmMJlBTd474lpA8EWh4JFLAX3iXgynBqBvKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/gherkin": "^31.0.0",
+        "@cucumber/messages": "^27.0.0",
+        "@teppeis/multimaps": "3.0.0",
+        "commander": "13.1.0",
+        "source-map-support": "^0.5.21"
+      },
+      "bin": {
+        "gherkin-utils": "bin/gherkin-utils"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin": {
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-31.0.0.tgz",
+      "integrity": "sha512-wlZfdPif7JpBWJdqvHk1Mkr21L5vl4EfxVUOS4JinWGf3FLRV6IKUekBv5bb5VX79fkDcfDvESzcQ8WQc07Wgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/messages": ">=19.1.4 <=26"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin/node_modules/@cucumber/messages": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-26.0.1.tgz",
+      "integrity": "sha512-DIxSg+ZGariumO+Lq6bn4kOUIUET83A4umrnWmidjGFl8XxkBieUZtsmNbLYgH/gnsmP07EfxxdTr0hOchV1Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "10.0.0",
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.2.2",
+        "uuid": "10.0.0"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@cucumber/html-formatter": {
+      "version": "21.15.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-21.15.1.tgz",
+      "integrity": "sha512-tjxEpP161sQ7xc3VREc94v1ymwIckR3ySViy7lTvfi1jUpyqy2Hd/p4oE3YT1kQ9fFDvUflPwu5ugK5mA7BQLA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@cucumber/messages": ">=18"
+      }
+    },
+    "node_modules/@cucumber/junit-xml-formatter": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/junit-xml-formatter/-/junit-xml-formatter-0.7.1.tgz",
+      "integrity": "sha512-AzhX+xFE/3zfoYeqkT7DNq68wAQfBcx4Dk9qS/ocXM2v5tBv6eFQ+w8zaSfsktCjYzu4oYRH/jh4USD1CYHfaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/query": "^13.0.2",
+        "@teppeis/multimaps": "^3.0.0",
+        "luxon": "^3.5.0",
+        "xmlbuilder": "^15.1.1"
+      },
+      "peerDependencies": {
+        "@cucumber/messages": "*"
+      }
+    },
+    "node_modules/@cucumber/messages": {
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-27.2.0.tgz",
+      "integrity": "sha512-f2o/HqKHgsqzFLdq6fAhfG1FNOQPdBdyMGpKwhb7hZqg0yZtx9BVqkTyuoNk83Fcvk3wjMVfouFXXHNEk4nddA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "10.0.0",
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.2.2",
+        "uuid": "11.0.5"
+      }
+    },
+    "node_modules/@cucumber/query": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/query/-/query-13.6.0.tgz",
+      "integrity": "sha512-tiDneuD5MoWsJ9VKPBmQok31mSX9Ybl+U4wqDoXeZgsXHDURqzM3rnpWVV3bC34y9W6vuFxrlwF/m7HdOxwqRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@teppeis/multimaps": "3.0.0",
+        "lodash.sortby": "^4.7.0"
+      },
+      "peerDependencies": {
+        "@cucumber/messages": "*"
+      }
+    },
+    "node_modules/@cucumber/tag-expressions": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-6.2.0.tgz",
+      "integrity": "sha512-KIF0eLcafHbWOuSDWFw0lMmgJOLdDRWjEL1kfXEWrqHmx2119HxVAr35WuEd9z542d3Yyg+XNqSr+81rIKqEdg==",
+      "license": "MIT"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@teppeis/multimaps": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@teppeis/multimaps/-/multimaps-3.0.0.tgz",
+      "integrity": "sha512-ID7fosbc50TbT0MK0EG12O+gAP3W3Aa/Pz4DaTtQtEvlc9Odaqi0de+xuZ7Li2GtK4HzEX7IuRWS/JmZLksR3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "license": "MIT"
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "license": "MIT"
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-bdd": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/playwright-bdd/-/playwright-bdd-8.5.1.tgz",
+      "integrity": "sha512-lDNaDzW8RvbvsKuR8cZaP9LBnRbG9juCOE3tgwm3pr1O0W1ooGPz7X8xH7zdUbqGgHbdOQ+5XpUTlOJrvpY6Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/cucumber-expressions": "18.0.1",
+        "@cucumber/gherkin": "^32.1.2",
+        "@cucumber/gherkin-utils": "^9.2.0",
+        "@cucumber/html-formatter": "^21.11.0",
+        "@cucumber/junit-xml-formatter": "^0.7.1",
+        "@cucumber/messages": "^27.2.0",
+        "@cucumber/tag-expressions": "^6.2.0",
+        "cli-table3": "0.6.5",
+        "commander": "^13.1.0",
+        "fast-glob": "^3.3.3",
+        "mime-types": "^3.0.2",
+        "xmlbuilder": "15.1.1"
+      },
+      "bin": {
+        "bddgen": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/vitalets"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1.44"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/regexp-match-indices": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regexp-match-indices/-/regexp-match-indices-1.0.2.tgz",
+      "integrity": "sha512-DwZuAkt8NF5mKwGGER1EGh2PRqyvhRhhLviH+R8y8dIuaQROlUfXjt4s9ZTXstIsSkptf06BSvwcEmmfheJJWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "regexp-tree": "^0.1.11"
+      }
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    }
+  }
+}

--- a/tests/bdd/package.json
+++ b/tests/bdd/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "stocktopus-bdd",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Gherkin/Playwright BDD harness for stocktopus",
+  "scripts": {
+    "bddgen": "bddgen",
+    "test": "bddgen && playwright test",
+    "test:headed": "bddgen && playwright test --headed"
+  },
+  "dependencies": {
+    "@playwright/test": "latest",
+    "playwright-bdd": "latest"
+  }
+}

--- a/tests/bdd/playwright.config.js
+++ b/tests/bdd/playwright.config.js
@@ -1,0 +1,25 @@
+const { defineConfig } = require('@playwright/test');
+const { defineBddConfig } = require('playwright-bdd');
+
+const testDir = defineBddConfig({
+  paths: ['./features/**/*.feature'],
+  require: ['./steps/**/*.js'],
+  outputDir: '.features-gen',
+});
+
+module.exports = defineConfig({
+  testDir,
+  fullyParallel: true,
+  retries: 0,
+  timeout: 15000,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:8080',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+});

--- a/tests/bdd/steps/given.js
+++ b/tests/bdd/steps/given.js
@@ -1,0 +1,70 @@
+// Given step definitions for the stocktopus BDD suite.
+//
+// These steps establish preconditions: server reachability, watchlist
+// seeding, and landing on a specific page. They share the page fixture
+// provided by playwright-bdd so subsequent When/Then steps act on the
+// same browser context.
+
+const { createBdd } = require('playwright-bdd');
+const { expect } = require('@playwright/test');
+
+const { Given } = createBdd();
+
+// Ensures the first watchlist returned by the API has at least one
+// symbol. Tolerates both shapes the API may return: plain strings or
+// objects with a `symbol` field. Seeds AAPL when empty.
+async function ensureDefaultWatchlistSeeded(page) {
+  const res = await page.request.get('/api/watchlists');
+  if (!res.ok()) {
+    throw new Error('GET /api/watchlists failed: ' + res.status());
+  }
+  const lists = await res.json();
+  if (!Array.isArray(lists) || lists.length === 0) {
+    throw new Error('No watchlists returned from /api/watchlists');
+  }
+  const first = lists[0];
+  const symbols = Array.isArray(first.symbols) ? first.symbols : [];
+  const normalized = symbols
+    .map((s) => (typeof s === 'string' ? s : (s && s.symbol) || ''))
+    .filter(Boolean);
+  if (normalized.length > 0) {
+    return;
+  }
+  const addRes = await page.request.post(
+    '/api/watchlists/' + first.id + '/symbols',
+    { data: { symbol: 'AAPL' } }
+  );
+  if (!addRes.ok()) {
+    throw new Error(
+      'POST /api/watchlists/' + first.id + '/symbols failed: ' + addRes.status()
+    );
+  }
+}
+
+Given('the dev server is reachable', async ({ page }) => {
+  const response = await page.goto('/');
+  expect(response, 'no response from GET /').not.toBeNull();
+  expect(response.status()).toBeLessThan(500);
+});
+
+Given('the default watchlist has at least one security', async ({ page }) => {
+  await ensureDefaultWatchlistSeeded(page);
+});
+
+Given('I am on the watchlist page', async ({ page }) => {
+  await page.goto('/watchlist');
+  await page.waitForSelector('#quote-body tr', { state: 'visible' });
+});
+
+Given('I am on the security page for {string}', async ({ page }, sym) => {
+  await page.goto('/security/' + sym);
+  await page.waitForSelector('#info-tabs .info-tab.active');
+  // Wait for the Overview tab to finish painting — otherwise its late
+  // render triggers a MutationObserver reset that clobbers selection
+  // state mid-keystroke and the test races itself.
+  await page.waitForSelector('.info-overview', { timeout: 5000 });
+});
+
+module.exports = {
+  ensureDefaultWatchlistSeeded,
+};

--- a/tests/bdd/steps/when-then.js
+++ b/tests/bdd/steps/when-then.js
@@ -1,0 +1,53 @@
+// When/Then step definitions for the stocktopus BDD suite.
+//
+// Keyboard steps delegate to the shared world helpers so timing stays
+// consistent across the suite. Assertion steps lean on Playwright's
+// expect matchers and target the well-known DOM hooks documented in
+// CLAUDE.md (#article-reader, #info-tabs, .vim-selected, etc.).
+
+const { createBdd } = require('playwright-bdd');
+const { expect } = require('@playwright/test');
+
+const { pressKey, pressSequence } = require('../support/world');
+
+const { When, Then } = createBdd();
+
+When('I press {string}', async ({ page }, key) => {
+  await pressKey(page, key);
+  // Extra settle to give navigation / slide-in handlers room to react.
+  await page.waitForTimeout(120);
+});
+
+When('I press the keys {string}', async ({ page }, seq) => {
+  await pressSequence(page, seq);
+  await page.waitForTimeout(120);
+});
+
+Then('the browser URL should match {string}', async ({ page }, pattern) => {
+  await page.waitForLoadState('domcontentloaded');
+  expect(page.url()).toMatch(new RegExp(pattern));
+});
+
+Then('the preview slide-in is visible', async ({ page }) => {
+  const reader = page.locator('#article-reader');
+  await expect(reader).not.toHaveClass(/(^|\s)hidden(\s|$)/, { timeout: 2000 });
+});
+
+Then('the preview slide-in is hidden', async ({ page }) => {
+  const reader = page.locator('#article-reader');
+  await expect(reader).toHaveClass(/(^|\s)hidden(\s|$)/, { timeout: 2000 });
+});
+
+Then('the preview slide-in title contains {string}', async ({ page }, text) => {
+  await expect(page.locator('#reader-title')).toContainText(text);
+});
+
+Then('a row is highlighted', async ({ page }) => {
+  await expect(page.locator('.vim-selected').first()).toBeVisible({
+    timeout: 2000,
+  });
+});
+
+Then('the active tab is {string}', async ({ page }, label) => {
+  await expect(page.locator('#info-tabs .info-tab.active')).toContainText(label);
+});

--- a/tests/bdd/support/world.js
+++ b/tests/bdd/support/world.js
@@ -1,0 +1,29 @@
+// Shared step helpers for the BDD harness.
+//
+// These thin wrappers exist so step definitions can express keyboard
+// interactions in one line and have consistent pacing between keystrokes.
+// The 100ms sleep matches the cadence a human typist would use and gives
+// the terminal UI time to react between events.
+
+const SLEEP_MS = 100;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function pressKey(page, key) {
+  await page.keyboard.press(key);
+  await sleep(SLEEP_MS);
+}
+
+async function pressSequence(page, seq) {
+  for (const ch of seq) {
+    await page.keyboard.press(ch);
+    await sleep(SLEEP_MS);
+  }
+}
+
+module.exports = {
+  pressKey,
+  pressSequence,
+};


### PR DESCRIPTION
## Summary

Three bundled changes that started from one bug report (\`g\` on watchlist no longer opens the chart) and grew into a small clean-up:

1. **Vim keybinding rework**
   - \`c\` opens the chart for the highlighted security on the watchlist *and* sector peers (was \`g\`, which the user said had stopped working).
   - \`p\` opens a price preview slide-in (1y EOD line chart) on the watchlist and sector peers, matching the existing \`p = preview\` convention on /economics and the financials tab.
   - Watchlist paste moves from \`p\` to capital \`P\` (vim \"paste before\"). The cut/paste flow is unchanged otherwise; the only difference is the key.

2. **Two real bugs caught by the BDD harness**
   - \`vim-nav.js#numericJump\` only added \`.vim-selected\` to the tab button — it never clicked. So pressing \`2\` on /security/AAPL painted a focus ring on Financials but didn't switch the tab. Now \`numericJump\` calls \`activate()\` after \`applySelection()\`.
   - \`_finOpenChart\` read a legacy \`finSelectedRow\` index that VimNav never updated, so the financials preview could silently miss the currently-highlighted row. Now reads \`.fin-row.vim-selected\` directly.

3. **Collapse dual selection state (3 → 1)**
   - Deleted \`finSelectedRow\` / \`secSelectedRow\` index variables, the \`_finGetRows / _finGetSelectedRow / _finSelectRow / _finClearRow\` helpers, and the \`_secGetRows / _secGetSelectedRow / _secSelectRow\` helpers.
   - Deleted the SEC / financials branches in \`info.move()\` that called those helpers — dead code, since VimNav has owned j/k on the security page since the declarative migration.
   - Live consumers (\`_finOpenChart\`, \`_secActivate\`, two switch cases in terminal.js) now query \`.fin-row.vim-selected\` / \`.sec-row.vim-selected\` directly. The DOM is the single source of truth.

### BDD harness

New \`tests/bdd/\` directory with a [playwright-bdd](https://www.npmjs.com/package/playwright-bdd) harness. Six Gherkin scenarios across three .feature files (watchlist keybindings, numbered security tabs, financials preview). Each scenario is written for a non-engineer to read.

- \`make bdd\` installs deps + runs the suite. Requires the dev server at \`http://localhost:8080\`.
- See \`tests/bdd/README.md\` for the friendly version.

### What was caught — and how

Writing the scenarios first turned up the two regressions above. They would have shipped silently otherwise; the unit tests don't drive the browser and the existing Go smoke tests check markup but not keypress behaviour.

## Test plan

- [x] \`make build\` — clean
- [x] \`make test\` — Go unit tests pass
- [x] \`make smoke\` — Go e2e suite passes (incl. existing TestSmoke_VimNav_* checks)
- [x] \`make bdd\` — 6/6 scenarios green
- [ ] Manual: watchlist → j → c opens chart page
- [ ] Manual: watchlist → j → p opens price preview, Escape closes
- [ ] Manual: /security/AAPL → 2 switches to Financials, j×3 highlights a row, p opens 5y preview
- [ ] Manual: capital P pastes a cut symbol into the active watchlist

## Follow-ups (not in this PR)

- Migrate the watchlist's last legacy \`vimSelectedIndex\` callers to \`[data-vim-row]\` so \`vimSelect()\` / \`clearVimSelection()\` / the legacy index can be deleted.
- Split \`/api/historical/{kind}/{symbol}\` — three return shapes from one URL pattern is confusing.
- Collapse the \`#article-reader\` mode dispatch (currently fin-chart / eco-chart / price-chart / article) behind a tiny preview-registry.
- Rename \`info\` → \`security\` end-to-end so the URL, server template key, JS view name, and handler all agree.