### PR TITLE
fix(ci): switch release-please to manifest mode

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,12 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          # Manifest mode: release-type + package-name live in
+          # release-please-config.json (alongside changelog-sections etc).
+          # Passing them inline here would tip v4 over with an empty
+          # "release-please failed:" error — `package-name` is no longer
+          # a recognised input in v4.
+          #
           # Conventional commits drive bumps:
           #   feat: …  → minor   (X.Y+1.0)
           #   fix: …   → patch   (X.Y.Z+1)
@@ -25,5 +31,5 @@ jobs:
           # release-please opens (and continually updates) a "chore: release vX.Y.Z"
           # PR that bumps .release-please-manifest.json + CHANGELOG.md. Merging
           # that PR cuts the actual git tag and GitHub release.
-          release-type: go
-          package-name: stocktopus
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

After PR #133 merged, the release-please workflow on master failed with an empty error:

\`\`\`
##[warning]Unexpected input(s) 'package-name', valid inputs are ['token', 'release-type', 'path', 'target-branch', 'config-file', 'manifest-file', 'repo-url', 'github-api-url', 'github-graphql-url', 'fork', 'include-component-in-tag', 'proxy-server', 'skip-github-release', 'skip-github-pull-request', 'skip-labeling', 'changelog-host', 'versioning-strategy', 'release-as']
…
✔ Building strategies by path
❯ .: go
##[error]release-please failed:
\`\`\`

## Root cause

The workflow was mixing two configuration styles:

- **Manifest mode** files live in the repo (\`release-please-config.json\` + \`.release-please-manifest.json\`) — these are what set \`release-type: go\`, \`package-name: stocktopus\`, the changelog section map, etc.
- **Simple mode** inputs were ALSO being passed inline in the workflow (\`release-type: go\`, \`package-name: stocktopus\`).

In release-please-action v4, \`package-name\` is no longer a recognised input — every previous run printed the warning above but kept working. The combination tipped over on the post-#133 push with an empty error message (a known v4 sharp edge when the action can't reconcile inline args against a manifest config).

## Fix

Switch the workflow to pure manifest mode:

\`\`\`yaml
- uses: googleapis/release-please-action@v4
  with:
    config-file: release-please-config.json
    manifest-file: .release-please-manifest.json
\`\`\`

\`release-type\` and \`package-name\` already live in \`release-please-config.json\`, so removing them inline is a no-op for behaviour.

## Test plan

This workflow only runs on \`push\` to master, so it can't be exercised on the PR branch. Once merged, the next push to master should:
- Not print the \`Unexpected input(s) 'package-name'\` warning.
- Open / update the \`chore(master): release vX.Y.Z\` PR successfully.

If it still fails, the next signal is whatever specific error message replaces the empty one — easier to act on than the current "failed:" with no body.