### PR TITLE
feat(ui): incremental UI batch — selection bugs, screener overhaul, ideas timeframes, lowercase tokens

### DIFF
--- a/internal/server/static/crypto.js
+++ b/internal/server/static/crypto.js
@@ -362,7 +362,7 @@
     function loadPeers() {
         var html = '<div class="sector-section-title">Top Coins by Market Cap</div>';
         html += '<table class="fin-table peer-table" id="peer-table"><thead><tr>';
-        html += '<th>Coin</th><th>Name</th><th>Price</th><th>24h</th><th>Market Cap</th><th>1M</th>';
+        html += '<th>Coin</th><th>Name</th><th>Price</th><th>24h</th><th>Market Cap</th><th>1m</th>';
         html += '</tr></thead><tbody>';
         PEER_COINS.forEach(function (sym) {
             var isCurrent = sym === symbol;

--- a/internal/server/static/ideas.js
+++ b/internal/server/static/ideas.js
@@ -193,7 +193,9 @@
                 +    '</div>'
                 +    '<div class="ideas-info-quote">'
                 +      '<span class="ideas-info-price">' + fmtPrice(p.price) + '</span>'
+                +      '<span class="ideas-info-tag">:live:</span>'
                 +      '<span class="ideas-info-pct ' + pctClass + '">' + pctStr + '</span>'
+                +      '<span class="ideas-info-tag">:1d:</span>'
                 +    '</div>'
                 +    '<div class="ideas-info-stats">'
                 +      '<span><label>Open</label>' + fmtPrice(p.open) + '</span>'
@@ -325,6 +327,29 @@
         seriesByID = {};
     }
 
+    var MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+    function dateTickFormatter(time, tickType) {
+        // Render month/day context on the time axis so a reader can tell at
+        // a glance which range they're looking at. Accepts every shape
+        // lightweight-charts hands the formatter (BusinessDay object,
+        // unix-seconds number, ISO string).
+        var d;
+        if (time && typeof time === 'object' && time.year != null) {
+            d = new Date(Date.UTC(time.year, time.month - 1, time.day));
+        } else if (typeof time === 'number') {
+            d = new Date(time * 1000);
+        } else if (typeof time === 'string') {
+            d = new Date(time + 'T00:00:00Z');
+        } else {
+            return '';
+        }
+        if (isNaN(d.getTime())) return '';
+        var T = (window.LightweightCharts && LightweightCharts.TickMarkType) || {};
+        if (tickType === T.Year) return String(d.getUTCFullYear());
+        if (tickType === T.Month) return MONTHS[d.getUTCMonth()] + " '" + String(d.getUTCFullYear()).slice(2);
+        return MONTHS[d.getUTCMonth()] + ' ' + d.getUTCDate();
+    }
+
     function ensureChart() {
         if (chart) return chart;
         if (!window.LightweightCharts || !hostEl) return null;
@@ -333,7 +358,13 @@
             grid: { vertLines: { color: '#1a1a1a' }, horzLines: { color: '#1a1a1a' } },
             crosshair: { mode: LightweightCharts.CrosshairMode.Magnet, vertLine: { color: '#555', style: 2 }, horzLine: { color: '#555', style: 2 } },
             rightPriceScale: { borderColor: '#2a2a2a' },
-            timeScale: { borderColor: '#2a2a2a', timeVisible: false, fixLeftEdge: true, fixRightEdge: true },
+            timeScale: {
+                borderColor: '#2a2a2a',
+                timeVisible: true,
+                fixLeftEdge: true,
+                fixRightEdge: true,
+                tickMarkFormatter: dateTickFormatter,
+            },
         });
         return chart;
     }
@@ -401,6 +432,34 @@
 
         renderLegend();
     }
+
+    // ── Chart timeframe commands (:1d / :1w / :1m / :6m) ──
+    //
+    // Mirror the main /stock chart page's range vocabulary. On the Ideas
+    // sketchpad these don't re-fetch — they just narrow the visible
+    // window on the time scale, since every metric already has its full
+    // history loaded. Falls back to fitContent if any series doesn't
+    // have data in the requested window.
+    var RANGE_DAYS = { '1d': 1, '1w': 7, '1m': 30, '6m': 180, 'all': 0 };
+    window._ideasSetRange = function (range) {
+        if (!chart) return false;
+        var days = RANGE_DAYS[range];
+        if (days == null) return false;
+        if (days === 0) {
+            chart.timeScale().fitContent();
+            return true;
+        }
+        var to = new Date();
+        var from = new Date();
+        from.setUTCDate(from.getUTCDate() - days);
+        var iso = function (d) { return d.toISOString().slice(0, 10); };
+        try {
+            chart.timeScale().setVisibleRange({ from: iso(from), to: iso(to) });
+        } catch (e) {
+            chart.timeScale().fitContent();
+        }
+        return true;
+    };
 
     // Drop a horizontal price line at the last crosshair value (or midpoint if
     // the user hasn't hovered the chart yet). Press 'h' again to add another.

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -886,7 +886,7 @@
 
                 html += '<div class="sector-section-title">Peer Comparison</div>';
                 html += '<table class="fin-table peer-table" id="peer-table"><thead><tr>';
-                html += '<th>Security</th><th>Company</th><th>Price</th><th>Market Cap</th><th>1M</th>';
+                html += '<th>Security</th><th>Company</th><th>Price</th><th>Market Cap</th><th>1m</th>';
                 html += '</tr></thead><tbody>';
 
                 // Current company
@@ -910,7 +910,7 @@
             }
 
             // Performance chart
-            html += '<div class="sector-section-title">6M Performance Comparison</div>';
+            html += '<div class="sector-section-title">6m Performance Comparison</div>';
             html += '<div id="sector-perf-chart" class="sector-perf-chart"></div>';
 
             // Sector news

--- a/internal/server/static/screener.js
+++ b/internal/server/static/screener.js
@@ -15,6 +15,50 @@
         await runScreen();
     });
 
+    // Market-cap shorthand parser. Accepts 1bn / 1b / 250m / 50k /
+    // 1.5bn / plain numbers. Returns a numeric string (or empty for
+    // unparseable input, so the server's existing validation fails
+    // loudly rather than silently coercing junk).
+    function parseShortAmount(raw) {
+        const s = String(raw || '').trim().toLowerCase().replace(/[,_$]/g, '');
+        if (!s) return '';
+        const m = s.match(/^(\d+(?:\.\d+)?)\s*(bn|b|mn|m|k)?$/);
+        if (!m) return s; // pass through unchanged
+        const n = parseFloat(m[1]);
+        switch (m[2]) {
+            case 'bn': case 'b': return String(n * 1e9);
+            case 'mn': case 'm': return String(n * 1e6);
+            case 'k': return String(n * 1e3);
+            default: return String(n);
+        }
+    }
+
+    function toShortAmount(n) {
+        const v = Number(n);
+        if (!isFinite(v) || v === 0) return '';
+        if (v >= 1e9) return (v / 1e9) + 'bn';
+        if (v >= 1e6) return (v / 1e6) + 'm';
+        if (v >= 1e3) return (v / 1e3) + 'k';
+        return String(v);
+    }
+
+    // Wire market-cap preset buttons (penny / small / mid / large / mega).
+    document.querySelectorAll('#marketcap-presets .screener-preset').forEach((btn) => {
+        btn.addEventListener('click', () => {
+            const min = btn.dataset.min;
+            const max = btn.dataset.max;
+            const minIn = form.elements['marketCapMoreThan'];
+            const maxIn = form.elements['marketCapLowerThan'];
+            if (minIn) minIn.value = min ? toShortAmount(min) : '';
+            if (maxIn) maxIn.value = max ? toShortAmount(max) : '';
+            // Reflect which preset is active so the user can see what
+            // they clicked. Clicking again deselects nothing; pick a
+            // different preset to switch.
+            document.querySelectorAll('#marketcap-presets .screener-preset').forEach((b) => b.classList.remove('active'));
+            btn.classList.add('active');
+        });
+    });
+
     $('screener-reset').addEventListener('click', () => {
         form.reset();
         tbody.innerHTML = '<tr><td colspan="10" class="empty-state">Filters reset. Press <kbd>Run Screen</kbd>.</td></tr>';
@@ -26,7 +70,13 @@
         const params = new URLSearchParams();
         const fd = new FormData(form);
         for (const [k, v] of fd.entries()) {
-            const trimmed = String(v).trim();
+            let trimmed = String(v).trim();
+            if (trimmed === '') continue;
+            // Market-cap fields accept shorthand (1bn, 250m, …); convert
+            // to plain numeric before hitting the API.
+            if (k === 'marketCapMoreThan' || k === 'marketCapLowerThan') {
+                trimmed = parseShortAmount(trimmed);
+            }
             if (trimmed !== '') params.set(k, trimmed);
         }
 
@@ -61,7 +111,7 @@
         }
         const rows = sortKey ? [...lastResults].sort(byKey(sortKey, sortDir)) : lastResults;
         tbody.innerHTML = rows.map((r) => {
-            const sign = (n) => n > 0 ? 'paper-pnl-pos' : (n < 0 ? 'paper-pnl-neg' : '');
+            const sign = (n) => n > 0 ? 'price-up' : (n < 0 ? 'price-down' : '');
             const pct = (n) => (n >= 0 ? '+' : '') + n.toFixed(2);
             return `<tr>
                 <td><a href="/security/${encodeURIComponent(r.symbol)}">${escape(r.symbol)}</a></td>

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -3001,11 +3001,17 @@ li.kp-row::before {
     .info-overview-top { grid-template-columns: 1fr; }
 }
 
-/* Ideas — three-pane vim navigation */
-
+/* Active-pane bounding box for multi-column layouts.
+   Used on Ideas (sidebar | main) and Screener (filters | results).
+   The shape emphasises the top edge (the bar over the column the user
+   is currently navigating with j/k) while keeping the side dividers
+   thin — reads as "this is the active column" without taking visual
+   weight from the data inside. */
 .ideas-sidebar.pane-focused,
-.ideas-main.pane-focused {
-    box-shadow: inset 0 0 0 1px var(--orange);
+.ideas-main.pane-focused,
+.screener-filters.pane-focused,
+.screener-results.pane-focused {
+    box-shadow: 0px -2px 0 1px var(--orange);
 }
 
 .ideas-help {
@@ -3702,6 +3708,96 @@ a, [tabindex] {
     padding-bottom: 3px;
 }
 
+/* Collapsible filter sections. <details> sections start closed; the
+   <summary> is the title row + click-target. j/k on the screener
+   sidebar can park on a summary; Enter toggles its open state. The
+   ::-webkit-details-marker selector hides the native disclosure
+   triangle so we own the visual. */
+details.screener-group {
+    border-bottom: 1px solid var(--bg-tertiary);
+    padding: 4px 0;
+}
+details.screener-group > summary {
+    margin: 0;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: var(--orange);
+    padding: 3px 0;
+    cursor: pointer;
+    list-style: none;
+    user-select: none;
+}
+details.screener-group > summary::-webkit-details-marker { display: none; }
+details.screener-group > summary::before {
+    content: '▸ ';
+    display: inline-block;
+    width: 12px;
+    color: var(--text-tertiary, #666);
+    transition: transform 0.1s ease;
+}
+details.screener-group[open] > summary::before {
+    content: '▾ ';
+}
+details.screener-group > summary.vim-selected {
+    background: var(--bg-tertiary);
+}
+
+/* Per-filter contextual help. Hidden by default; '?' on the screener
+   page toggles .help-on on the form to reveal all the tips at once.
+   Reuses the existing .help-tip yellow accent for visual parity. */
+.screener-form .filter-help {
+    display: none;
+    font-size: 10px;
+    color: var(--yellow);
+    line-height: 1.4;
+    margin-top: 2px;
+    font-style: italic;
+    letter-spacing: 0;
+    text-transform: none;
+}
+.screener-form.help-on .filter-help {
+    display: block;
+}
+
+/* Market-cap preset chips. One click fills both market-cap inputs with
+   the bucket's range (expressed as shorthand — '1bn', '200bn'). The
+   user can still type a custom value in the inputs themselves; the
+   parser on submit accepts shorthand too. */
+.screener-presets {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px;
+    margin: 0 0 6px;
+}
+.screener-presets-label {
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-tertiary, #666);
+    margin-right: 2px;
+}
+.screener-preset {
+    font-size: 10px;
+    padding: 2px 6px;
+    border: 1px solid var(--border, #333);
+    background: transparent;
+    color: var(--text-secondary);
+    border-radius: 2px;
+    cursor: pointer;
+    text-transform: lowercase;
+}
+.screener-preset:hover {
+    border-color: var(--orange);
+    color: var(--orange);
+}
+.screener-preset.active {
+    border-color: var(--orange);
+    background: var(--bg-tertiary);
+    color: var(--orange);
+}
+
 .screener-group label {
     display: flex;
     flex-direction: column;
@@ -3962,6 +4058,17 @@ a, [tabindex] {
 
 .ideas-info-pct.price-up { color: var(--green); }
 .ideas-info-pct.price-down { color: var(--red); }
+
+/* Subtle :live: / :1d: micro-tags on the Ideas quote line. They sit
+   adjacent to the value they qualify (price :live:, percent :1d:) and
+   read as secondary metadata, never overpowering the numbers. */
+.ideas-info-tag {
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--text-tertiary, #666);
+    letter-spacing: 0.02em;
+    margin-left: -4px;
+}
 
 .ideas-info-stats {
     display: grid;

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -1435,7 +1435,19 @@ window.onerror = function (msg, src, line, col, err) {
                     var colonCmd = raw.substring(1);
                     var colonLower = colonCmd.toLowerCase();
 
-                    // Chart range: :1, :5, :15, :30, :1h, :4h, :1w, :1m, :3m, :6m
+                    // Ideas sketchpad: :1d / :1w / :1m / :6m / :all narrow
+                    // the chart's visible window. Match the main chart
+                    // page's vocabulary so muscle memory ports over.
+                    if (currentView === 'ideas' && window._ideasSetRange) {
+                        if (window._ideasSetRange(colonLower)) {
+                            input.value = '';
+                            enterNormalMode();
+                            return;
+                        }
+                    }
+
+                    // Main /stock chart range: :1, :5, :15, :30, :1h, :4h,
+                    // :1w, :1m, :3m, :6m
                     var rangeMap = {
                         '1': '1m', '5': '5m', '15': '15m', '30': '30m',
                         '1h': '1h', '4h': '4h',
@@ -1512,7 +1524,17 @@ window.onerror = function (msg, src, line, col, err) {
                         return;
                     }
 
-                    // :save <name> — name + persist the current sketch
+                    // :w <name> — vim-style write: name + persist the current
+                    // sketch. The older :save spelling is still accepted as
+                    // an alias so existing muscle memory keeps working.
+                    if (colonLower === 'w' || colonLower.startsWith('w ')) {
+                        var saveName = colonCmd.substring(1).trim();
+                        input.value = '';
+                        hideCmdDropdown();
+                        enterNormalMode();
+                        if (window._ideasSave) window._ideasSave(saveName);
+                        return;
+                    }
                     if (colonLower === 'save' || colonLower.startsWith('save ')) {
                         var saveName = colonCmd.substring(4).trim();
                         input.value = '';
@@ -2283,10 +2305,15 @@ window.onerror = function (msg, src, line, col, err) {
         },
         watchlist: {
             getItems: function () {
-                // Only visible rows (filtered by active watchlist)
-                var all = document.querySelectorAll('#quote-body tr');
-                return Array.from(all).filter(function (row) {
-                    return row.style.display !== 'none';
+                // Only the tbody's direct <tr> children — lightweight-charts
+                // builds its own nested <table><tr><td> layout inside each
+                // sparkline host, and a broad '#quote-body tr' selector would
+                // include those phantoms in the nav list, so j/k would walk
+                // 'through invisible tree' between visible quote rows.
+                var tbody = document.getElementById('quote-body');
+                if (!tbody) return [];
+                return Array.from(tbody.children).filter(function (row) {
+                    return row.tagName === 'TR' && row.style.display !== 'none';
                 });
             },
             move: function (dir) {
@@ -2710,9 +2737,24 @@ window.onerror = function (msg, src, line, col, err) {
             _filterIdx: 0,
             _resultIdx: 0,
             getFilters: function () {
-                return Array.from(document.querySelectorAll(
-                    '#screener-form input:not([type=hidden]), #screener-form select, #screener-form button'
-                ));
+                // Summaries are nav targets (Enter on one toggles the
+                // section). Inputs inside a closed <details> are skipped so
+                // j/k doesn't walk invisible controls — same family of bug
+                // as the watchlist phantom-row issue, just with collapse.
+                var all = document.querySelectorAll(
+                    '#screener-form summary, ' +
+                    '#screener-form input:not([type=hidden]), ' +
+                    '#screener-form select, ' +
+                    '#screener-form button'
+                );
+                return Array.from(all).filter(function (el) {
+                    var details = el.closest('details');
+                    if (!details) return true;
+                    // <summary> itself is always navigable; everything
+                    // else hides when the details is collapsed.
+                    if (el.tagName === 'SUMMARY') return true;
+                    return details.open;
+                });
             },
             getResults: function () {
                 return Array.from(document.querySelectorAll('#screener-table tbody tr'))
@@ -2763,7 +2805,8 @@ window.onerror = function (msg, src, line, col, err) {
                     var items = this.getFilters();
                     var el = items[this._filterIdx];
                     if (!el) return;
-                    if (el.tagName === 'BUTTON') {
+                    if (el.tagName === 'BUTTON' || el.tagName === 'SUMMARY') {
+                        // Buttons fire, summaries toggle the details open.
                         el.click();
                     } else {
                         // Focus the input — user is now in insert mode editing
@@ -2784,10 +2827,38 @@ window.onerror = function (msg, src, line, col, err) {
                 var btn = document.getElementById('screener-run');
                 if (btn) btn.click();
             },
+            toggleHelp: function () {
+                // '?' shows / hides one-line help under every filter input.
+                var form = document.getElementById('screener-form');
+                if (form) form.classList.toggle('help-on');
+            },
+            openPreview: function () {
+                // 'p' on a selected result row opens the shared price-preview
+                // slide-in (1y EOD chart + mini company panel) — same UX as
+                // /watchlist and sector peers. No-op when focus is on filters
+                // or when no row is selected.
+                if (this._focus !== 'results') return false;
+                var rows = this.getResults();
+                var row = rows[this._resultIdx];
+                if (!row) return false;
+                var link = row.querySelector('a[href]');
+                if (!link) return false;
+                var href = link.getAttribute('href') || '';
+                var sym = href.replace(/^\/security\//, '').toUpperCase();
+                if (!sym) return false;
+                openPricePreview(sym);
+                return true;
+            },
             _applyFocus: function () {
                 document.querySelectorAll('.vim-selected').forEach(function (e) {
                     e.classList.remove('vim-selected');
                 });
+                // Toggle the active-pane bounding box on the filters /
+                // results column so the user sees which side j/k is in.
+                var filtersPane = document.querySelector('.screener-filters');
+                var resultsPane = document.querySelector('.screener-results');
+                if (filtersPane) filtersPane.classList.toggle('pane-focused', this._focus === 'filters');
+                if (resultsPane) resultsPane.classList.toggle('pane-focused', this._focus === 'results');
                 var el;
                 if (this._focus === 'filters') {
                     el = this.getFilters()[this._filterIdx];
@@ -3039,6 +3110,10 @@ window.onerror = function (msg, src, line, col, err) {
                 // highlighted symbol. Cut/paste 'p' moved to capital 'P' so
                 // 'p' = preview is consistent across listings.
                 if (currentView === 'watchlist' && handler && handler.openPreview) {
+                    if (handler.openPreview()) { e.preventDefault(); return; }
+                }
+                // Screener: preview the selected result row's symbol.
+                if (currentView === 'screener' && handler && handler.openPreview) {
                     if (handler.openPreview()) { e.preventDefault(); return; }
                 }
                 // Sector peers: preview the highlighted peer's price chart.

--- a/internal/server/static/vim-nav.js
+++ b/internal/server/static/vim-nav.js
@@ -72,7 +72,16 @@
     }
 
     function clearSelection() {
-        document.querySelectorAll('.' + SELECTED_CLASS).forEach(function (el) {
+        // Only clear .vim-selected from elements VimNav itself painted —
+        // i.e. nodes inside a [data-vim-row] container, or row elements
+        // themselves. Legacy per-view handlers (watchlist, screener, news
+        // cards) set .vim-selected on plain rows that don't carry a
+        // [data-vim-row] attribute; a blanket document-wide sweep would
+        // wipe those every time the MutationObserver fires reset (mode
+        // indicator updates, WS quote ticks, etc.), and the highlight
+        // would seem to fade after a second or two.
+        var sel = '[data-vim-row].' + SELECTED_CLASS + ', [data-vim-row] .' + SELECTED_CLASS;
+        document.querySelectorAll(sel).forEach(function (el) {
             el.classList.remove(SELECTED_CLASS);
         });
     }

--- a/internal/server/templates/ideas.html
+++ b/internal/server/templates/ideas.html
@@ -10,7 +10,7 @@
             <li class="empty-state">Loading…</li>
         </ul>
         <div class="ideas-sidebar-footer">
-            <span class="ideas-hint"><kbd>:save</kbd> to name &amp; persist</span>
+            <span class="ideas-hint"><kbd>:w &lt;name of Idea&gt;</kbd> to name &amp; persist</span>
         </div>
     </aside>
     <section class="ideas-main" id="ideas-main">
@@ -22,7 +22,7 @@
         <div id="ideas-help" class="ideas-help hidden">
             <span class="ideas-help-row"><kbd>:add AAPL</kbd> · <kbd>:add AAPL.revenue</kbd> · <kbd>:add GCUSD</kbd> · <kbd>:add EURUSD</kbd> · <kbd>:add BTCUSD</kbd></span>
             <span class="ideas-help-row">Financials tab → <kbd>a</kbd> on a highlighted row prefills <kbd>:add SYMBOL.field</kbd></span>
-            <span class="ideas-help-row"><kbd>h</kbd>/<kbd>l</kbd> switch panes (list ↔ chart) · <kbd>j</kbd>/<kbd>k</kbd> within pane · <kbd>d</kbd> deletes the selected sketch (list) or metric (chart) · <kbd>\</kbd> drops a price line · <kbd>:cl</kbd> clears lines · <kbd>:save NAME</kbd></span>
+            <span class="ideas-help-row"><kbd>h</kbd>/<kbd>l</kbd> switch panes (list ↔ chart) · <kbd>j</kbd>/<kbd>k</kbd> within pane · <kbd>d</kbd> deletes the selected sketch (list) or metric (chart) · <kbd>\</kbd> drops a price line · <kbd>:cl</kbd> clears lines · <kbd>:w NAME</kbd></span>
         </div>
         <div id="ideas-chart-host" class="ideas-chart-host"></div>
         <div id="ideas-legend" class="ideas-legend"></div>

--- a/internal/server/templates/screener.html
+++ b/internal/server/templates/screener.html
@@ -4,20 +4,28 @@
     <aside class="screener-filters">
         <div class="screener-filters-header">Filters</div>
         <form id="screener-form" class="screener-form">
-            <div class="screener-group">
-                <h4>Fundamentals</h4>
-                <label>Market cap ≥<input type="number" name="marketCapMoreThan" step="any" placeholder="e.g. 1000000000"></label>
-                <label>Market cap ≤<input type="number" name="marketCapLowerThan" step="any"></label>
-                <label>Price ≥<input type="number" name="priceMoreThan" step="any"></label>
-                <label>Price ≤<input type="number" name="priceLowerThan" step="any"></label>
-                <label>Beta ≥<input type="number" name="betaMoreThan" step="any"></label>
-                <label>Beta ≤<input type="number" name="betaLowerThan" step="any"></label>
-                <label>Volume ≥<input type="number" name="volumeMoreThan" step="any"></label>
-                <label>Dividend ≥<input type="number" name="dividendMoreThan" step="any"></label>
-            </div>
+            <details class="screener-group">
+                <summary>Fundamentals</summary>
+                <div class="screener-presets" id="marketcap-presets">
+                    <span class="screener-presets-label">Cap presets</span>
+                    <button type="button" class="screener-preset" data-min="0" data-max="50000000">penny</button>
+                    <button type="button" class="screener-preset" data-min="50000000" data-max="2000000000">small</button>
+                    <button type="button" class="screener-preset" data-min="2000000000" data-max="10000000000">mid</button>
+                    <button type="button" class="screener-preset" data-min="10000000000" data-max="200000000000">large</button>
+                    <button type="button" class="screener-preset" data-min="200000000000" data-max="">mega</button>
+                </div>
+                <label>Market cap ≥<input type="text" name="marketCapMoreThan" placeholder="e.g. 1bn or 1000000000" autocomplete="off"><small class="filter-help">Total share value. Accepts shorthand like 1bn / 250m. Big-cap usually means ≥ $10bn.</small></label>
+                <label>Market cap ≤<input type="text" name="marketCapLowerThan" placeholder="e.g. 200bn" autocomplete="off"><small class="filter-help">Caps the upper end. Use with the lower bound to box a size band.</small></label>
+                <label>Price ≥<input type="number" name="priceMoreThan" step="any"><small class="filter-help">Current share price in USD.</small></label>
+                <label>Price ≤<input type="number" name="priceLowerThan" step="any"><small class="filter-help">Exclude high-priced names — useful when scanning for round-lot affordability.</small></label>
+                <label>Beta ≥<input type="number" name="betaMoreThan" step="any"><small class="filter-help">Sensitivity to market moves. β=1 tracks the market; &gt;1 amplifies; &lt;0 inverse.</small></label>
+                <label>Beta ≤<input type="number" name="betaLowerThan" step="any"><small class="filter-help">Cap the upper end to filter out high-volatility names.</small></label>
+                <label>Volume ≥<input type="number" name="volumeMoreThan" step="any"><small class="filter-help">Minimum daily share volume. Liquidity floor.</small></label>
+                <label>Dividend ≥<input type="number" name="dividendMoreThan" step="any"><small class="filter-help">Annual dividend per share, in USD.</small></label>
+            </details>
 
-            <div class="screener-group">
-                <h4>Sector / Exchange</h4>
+            <details class="screener-group">
+                <summary>Sector / Exchange</summary>
                 <label>Sector
                     <select name="sector">
                         <option value="">(any)</option>
@@ -33,29 +41,31 @@
                         <option>Utilities</option>
                         <option>Real Estate</option>
                     </select>
+                    <small class="filter-help">Economic sector classification (GICS-style).</small>
                 </label>
-                <label>Country<input type="text" name="country" placeholder="e.g. US" maxlength="2"></label>
-                <label>Exchange<input type="text" name="exchange" placeholder="e.g. NASDAQ"></label>
+                <label>Country<input type="text" name="country" placeholder="e.g. US" maxlength="2"><small class="filter-help">2-letter ISO country code (US, GB, JP…).</small></label>
+                <label>Exchange<input type="text" name="exchange" placeholder="e.g. NASDAQ"><small class="filter-help">Exchange code (NASDAQ, NYSE, LSE…).</small></label>
                 <label class="screener-checkbox">
                     <input type="checkbox" name="isActivelyTrading" value="true" checked>
                     Actively trading only
+                    <small class="filter-help">Exclude delisted, suspended, or otherwise inactive tickers.</small>
                 </label>
-            </div>
+            </details>
 
-            <div class="screener-group">
-                <h4>Intraday change</h4>
-                <label>Δ from open ≥ %<input type="number" name="changeFromOpenMin" step="any" placeholder="e.g. 2"></label>
-                <label>Δ from open ≤ %<input type="number" name="changeFromOpenMax" step="any"></label>
-                <label>Δ from prev close ≥ %<input type="number" name="changeFromPrevDayMin" step="any"></label>
-                <label>Δ from prev close ≤ %<input type="number" name="changeFromPrevDayMax" step="any"></label>
-                <label>Δ vs market (SPY) ≥ pp<input type="number" name="changeVsMarketMin" step="any" placeholder="e.g. 1"></label>
-                <label>Δ vs market (SPY) ≤ pp<input type="number" name="changeVsMarketMax" step="any"></label>
-            </div>
+            <details class="screener-group">
+                <summary>Intraday change</summary>
+                <label>Δ from open ≥ %<input type="number" name="changeFromOpenMin" step="any" placeholder="e.g. 2"><small class="filter-help">Percent move since today's open. Catches breakouts.</small></label>
+                <label>Δ from open ≤ %<input type="number" name="changeFromOpenMax" step="any"><small class="filter-help">Caps the upper move so you can find names lagging the open.</small></label>
+                <label>Δ from prev close ≥ %<input type="number" name="changeFromPrevDayMin" step="any"><small class="filter-help">Percent move vs yesterday's close. The headline "day change" number.</small></label>
+                <label>Δ from prev close ≤ %<input type="number" name="changeFromPrevDayMax" step="any"><small class="filter-help">Cap the upper bound — useful for finding sleepers.</small></label>
+                <label>Δ vs market (SPY) ≥ pp<input type="number" name="changeVsMarketMin" step="any" placeholder="e.g. 1"><small class="filter-help">Percentage points the name is above SPY's day move. Relative strength.</small></label>
+                <label>Δ vs market (SPY) ≤ pp<input type="number" name="changeVsMarketMax" step="any"><small class="filter-help">Cap relative strength upper bound.</small></label>
+            </details>
 
-            <div class="screener-group">
-                <h4>Output</h4>
-                <label>Show top<input type="number" name="displayLimit" step="1" min="1" max="250" value="50"></label>
-            </div>
+            <details class="screener-group">
+                <summary>Output</summary>
+                <label>Show top<input type="number" name="displayLimit" step="1" min="1" max="250" value="50"><small class="filter-help">Max rows in the result table. 1–250.</small></label>
+            </details>
 
             <div class="screener-actions">
                 <button type="submit" id="screener-run">Run Screen</button>

--- a/internal/server/templates/stock.html
+++ b/internal/server/templates/stock.html
@@ -11,10 +11,10 @@
         <button class="chart-range-btn chart-intraday-btn" data-range="4h" data-interval="4hour">4h</button>
         <button class="chart-auto-refresh active" id="chart-auto-refresh" title="Auto-refresh">&#8635;</button>
         <span class="chart-range-sep">|</span>
-        <button class="chart-range-btn chart-eod-btn active" data-range="1W">1W</button>
-        <button class="chart-range-btn chart-eod-btn" data-range="1M">1M</button>
-        <button class="chart-range-btn chart-eod-btn" data-range="3M">3M</button>
-        <button class="chart-range-btn chart-eod-btn" data-range="6M">6M</button>
+        <button class="chart-range-btn chart-eod-btn active" data-range="1W">1w</button>
+        <button class="chart-range-btn chart-eod-btn" data-range="1M">1m</button>
+        <button class="chart-range-btn chart-eod-btn" data-range="3M">3m</button>
+        <button class="chart-range-btn chart-eod-btn" data-range="6M">6m</button>
         <span class="chart-range-sep">|</span>
         <button class="chart-toggle" id="toggle-sma" data-indicator="sma" title=":sma">SMA</button>
         <button class="chart-toggle" id="toggle-ema" data-indicator="ema" title=":ema">EMA</button>

--- a/tests/bdd/features/screener-ux.feature
+++ b/tests/bdd/features/screener-ux.feature
@@ -1,0 +1,31 @@
+Feature: Screener UX — collapsible filters, help text, preview, presets
+  The screener is a sidebar full of filter inputs feeding a results table.
+  Quietly losing UX affordances here (the keyboard preview, the size presets,
+  the help-toggle that explains what each filter means) makes the page feel
+  like a wall of unlabeled controls. These scenarios keep the discoverable
+  bits discoverable.
+
+  Background:
+    Given the dev server is reachable
+    And I am on the screener page
+
+  Scenario: Filter groups start collapsed
+    Then every filter group is collapsed
+
+  Scenario: Market cap presets fill the minimum and maximum inputs
+    When I open the "Fundamentals" filter group
+    And I click the "large" market cap preset
+    Then the market cap minimum input contains "10bn"
+    And the market cap maximum input contains "200bn"
+
+  Scenario: Shorthand market-cap input is parsed on submit
+    When I open the "Fundamentals" filter group
+    And I type "1bn" into the market cap minimum input
+    And I run the screen
+    Then the screener request used "marketCapMoreThan=1000000000"
+
+  Scenario: Pressing ? toggles per-filter help text
+    When I open the "Fundamentals" filter group
+    Then no filter help text is visible
+    When I press "?"
+    Then filter help text is visible

--- a/tests/bdd/features/watchlist-keybindings.feature
+++ b/tests/bdd/features/watchlist-keybindings.feature
@@ -22,3 +22,17 @@ Feature: Watchlist vim keybindings stay working
     When I press the keys "jp"
     And I press "Escape"
     Then the preview slide-in is hidden
+
+  Scenario: Highlight on the selected row survives background DOM updates
+    When I press "j"
+    Then a row is highlighted
+    When the page receives a background DOM update
+    Then a row is highlighted
+
+  Scenario: Each j press lands on a real security row, not a phantom inside a sparkline
+    When I press "j"
+    Then the highlighted row has a data-symbol
+    When I press "j"
+    Then the highlighted row has a data-symbol
+    When I press "j"
+    Then the highlighted row has a data-symbol

--- a/tests/bdd/steps/given.js
+++ b/tests/bdd/steps/given.js
@@ -56,6 +56,21 @@ Given('I am on the watchlist page', async ({ page }) => {
   await page.waitForSelector('#quote-body tr', { state: 'visible' });
 });
 
+Given('I am on the screener page', async ({ page }) => {
+  // Capture every /api/screener request so later steps can assert on the
+  // exact URL the form submits (used by the shorthand-parsing scenario).
+  page.__screenerRequests = [];
+  page.on('request', (req) => {
+    if (req.url().includes('/api/screener')) {
+      page.__screenerRequests.push(req.url());
+    }
+  });
+  await page.goto('/screener');
+  await page.waitForSelector('#screener-form');
+  // <details> elements are closed by default; give them a tick to settle.
+  await page.waitForTimeout(150);
+});
+
 Given('I am on the security page for {string}', async ({ page }, sym) => {
   await page.goto('/security/' + sym);
   await page.waitForSelector('#info-tabs .info-tab.active');

--- a/tests/bdd/steps/when-then.js
+++ b/tests/bdd/steps/when-then.js
@@ -113,6 +113,90 @@ When('I switch to the previous watchlist tab', async ({ page }) => {
   await page.waitForTimeout(300);
 });
 
+Then('the highlighted row has a data-symbol', async ({ page }) => {
+  // Regression net for the phantom-row bug: legacy getItems() on
+  // /watchlist used '#quote-body tr' which matched lightweight-charts'
+  // nested layout <tr>s inside each sparkline host. j/k then walked
+  // 'through invisible tree' between visible quote rows.
+  const sym = await page.evaluate(() => {
+    const sel = document.querySelector('.vim-selected');
+    return sel ? sel.querySelector('[data-symbol]')?.dataset.symbol || null : null;
+  });
+  expect(sym, 'highlighted row should carry a data-symbol').toBeTruthy();
+});
+
+When('the page receives a background DOM update', async ({ page }) => {
+  // Simulate the kind of mutation that normally happens on this page —
+  // the vim-mode footer text changes on focus/blur, the poller swaps a
+  // quote cell, etc. The fix under test scopes vim-nav.js's
+  // clearSelection so these mutations don't strip selection from a row
+  // managed by a legacy per-view handler.
+  await page.evaluate(() => {
+    const el = document.getElementById('vim-mode') || document.body;
+    const original = el.textContent;
+    el.textContent = original + ' ';
+    el.textContent = original;
+  });
+  // The MutationObserver in vim-nav.js debounces by 50ms; wait long
+  // enough for the reset to fire (or, with the fix, to no-op).
+  await page.waitForTimeout(200);
+});
+
+// ── Screener UX assertions ──
+
+Then('every filter group is collapsed', async ({ page }) => {
+  const groups = page.locator('details.screener-group');
+  const count = await groups.count();
+  expect(count, 'expected at least one filter group').toBeGreaterThan(0);
+  for (let i = 0; i < count; i++) {
+    const open = await groups.nth(i).getAttribute('open');
+    expect(open, `group ${i} should be closed by default`).toBeNull();
+  }
+});
+
+When('I open the {string} filter group', async ({ page }, name) => {
+  await page.locator('details.screener-group', { has: page.locator('summary', { hasText: name }) })
+    .locator('summary').click();
+  await page.waitForTimeout(120);
+});
+
+When('I click the {string} market cap preset', async ({ page }, label) => {
+  await page.locator('#marketcap-presets .screener-preset', { hasText: label }).click();
+});
+
+Then('the market cap minimum input contains {string}', async ({ page }, value) => {
+  await expect(page.locator('input[name="marketCapMoreThan"]')).toHaveValue(value);
+});
+
+Then('the market cap maximum input contains {string}', async ({ page }, value) => {
+  await expect(page.locator('input[name="marketCapLowerThan"]')).toHaveValue(value);
+});
+
+When('I type {string} into the market cap minimum input', async ({ page }, text) => {
+  const input = page.locator('input[name="marketCapMoreThan"]');
+  await input.fill(text);
+});
+
+When('I run the screen', async ({ page }) => {
+  await page.locator('#screener-run').click();
+  await page.waitForTimeout(400);
+});
+
+Then('the screener request used {string}', async ({ page }, expected) => {
+  const requests = page.__screenerRequests || [];
+  expect(requests.length, 'no screener requests recorded').toBeGreaterThan(0);
+  const last = requests[requests.length - 1];
+  expect(last).toContain(expected);
+});
+
+Then('no filter help text is visible', async ({ page }) => {
+  await expect(page.locator('.filter-help').first()).not.toBeVisible();
+});
+
+Then('filter help text is visible', async ({ page }) => {
+  await expect(page.locator('.filter-help').first()).toBeVisible({ timeout: 2000 });
+});
+
 Then("the first watchlist row's sparkline canvas is the host's width",
   async ({ page }) => {
     // Regression net for the display:none → 0x0 canvas bug. The canvas


### PR DESCRIPTION
## Summary

Eleven items from \`watchlist-reader-ui-handoff-incremental.md\` plus two real bugs surfaced during testing. Lands in front of the incoming design-language unification work — naming conventions and active-state primitives in this PR should be re-checked against \`design-language-unification.md\` during the next sweep.

### Bug fixes

**#8 (handoff) — selection highlight fades after a few seconds.** Reproduced across multiple pages (watchlist, screener, news). Root cause: \`vim-nav.js#clearSelection\` did a document-wide \`.vim-selected\` sweep. Every MutationObserver-triggered reset (mode-indicator textContent changes, WS quote ticks, etc.) stripped highlights set by legacy per-view handlers — those live outside \`[data-vim-row]\` containers. **Fix:** scope the sweep to \`[data-vim-row].vim-selected, [data-vim-row] .vim-selected\`. + BDD regression.

**Bonus — watchlist j/k walks invisible rows between visible ones.** Same family as the earlier \`filterWatchlistView\` fix: \`watchlist.getItems()\` used \`#quote-body tr\` which matched lightweight-charts' internal layout \`<tr>\`s nested inside each sparkline host. **Fix:** scope to tbody's direct \`<tr>\` children only. + BDD regression.

### UI changes

| # | Item | Change |
|---|---|---|
| 5 | Lowercase duration tokens | Stock chart range buttons (\`1W\`→\`1w\`), peer-table headers, sector tab title. \`data-range\` attribute kept uppercase internally to avoid colliding with intraday \`1m\` = 1 minute. |
| 1 | Ideas \`:save\` → \`:w <name of Idea>\` | Hint + help row updated. \`:w\` wired as real command; \`:save\` kept as alias for muscle memory. |
| 4 | Ideas \`:live:\` / \`:1d:\` micro-tags | New \`<span class=\"ideas-info-tag\">\` adjacent to price + percent. Secondary text style, 10px, low-emphasis. |
| 2 | Ideas chart x-axis date labels | \`timeVisible: true\` + \`tickMarkFormatter\` matching the main chart's \"Jan 5\", \"Mar '26\" format. |
| 3 | Ideas chart \`:1d / :1w / :1m / :6m / :all\` | New \`_ideasSetRange\` narrows the visible window via \`setVisibleRange\` — no re-fetch. |
| — | Active-pane bounding box | Your \`box-shadow: 0px -2px 0 1px var(--orange)\` applied to \`.pane-focused\` on Ideas + Screener. Screener pane class wired to the existing \`_focus\` state machine. |

### Screener overhaul

| # | Item | Change |
|---|---|---|
| 9 | \`p\` opens preview | New \`screener.openPreview()\` calls the shared \`openPricePreview()\` from the selected result row's symbol. |
| 10 | Δ% sign colouring | Normalised from \`paper-pnl-pos/neg\` to canonical \`price-up/price-down\` for parity with watchlist / ideas. |
| 7 | Collapsible filter groups | \`<div class=\"screener-group\">\` → native \`<details>\`, closed by default. \`<summary>\` is a nav target; Enter on a summary toggles the group via native click. |
| — | Same phantom-control gotcha as above | \`getFilters()\` skips inputs whose closest \`<details>\` is collapsed so j/k doesn't walk invisible controls. |
| 6 | Market-cap presets + \`bn\` shorthand | Five preset chips (\`penny / small / mid / large / mega\`) fill both market-cap inputs with the bucket's bounds as shorthand. New \`parseShortAmount()\` accepts \`1bn / 250m / 50k\` and converts to numeric at submit time. Inputs switched to \`type=\"text\"\`. |
| 11 | \`?\` toggles help text | Inline \`<small class=\"filter-help\">\` on every label, hidden by default. \`screener.toggleHelp()\` flips a \`.help-on\` class on the form. |

### BDD coverage

New \`screener-ux.feature\` with four scenarios:
- Filter groups start collapsed
- Market cap presets fill the minimum and maximum inputs
- Shorthand market-cap input is parsed on submit
- Pressing \`?\` toggles per-filter help text

Extended \`watchlist-keybindings.feature\`:
- Highlight on the selected row survives background DOM updates
- Each \`j\` press lands on a real security row, not a phantom inside a sparkline

Twelve new step phrases across \`given.js\` + \`when-then.js\`. Suite serialized (\`workers: 1\`) from the previous PR.

## Test plan

- [x] \`make build\` clean
- [x] \`make test\` — Go unit tests green
- [x] \`make smoke\` — Go e2e green
- [x] \`make bdd\` — 17/17 scenarios green
- [x] Manual: \`/watchlist\` — j/k steps cleanly between symbols, no phantom hops
- [x] Manual: \`/screener\` — load page, all four groups closed; open Fundamentals, click each preset; type \`1bn\` and run; press \`?\` to flip help; press \`h\`/\`l\` to flip pane focus (orange top bar follows)
- [x] Manual: \`/ideas\` — \`:w foo\` saves the current sketchpad; \`:6m\` narrows the chart window; x-axis shows date labels
- [x] Manual: any page with selection — wait a few seconds; highlight no longer fades

## Follow-ups

Two new handoff files in the working tree, not in this PR:
- \`design-language-unification.md\` — incoming tokens + \`st-*\` primitives + ternary grid; multi-phase. Some classes I just shipped (\`.pane-focused\`, \`.filter-help\`, \`.ideas-info-tag\`, \`.screener-preset.active\`) will be remapped during that work.
- \`watchlist-reader-ui-handoff.md\` and \`watchlist-reader-ui-handoff-incremental.md\` — both fully consumed by PR #136 + this one.