### PR TITLE
refactor(ui): add design tokens, ternary grid, and st-* primitives (Info, Watchlist, Economics, Graph)

### DIFF
--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -431,7 +431,14 @@
     // ── Range Buttons ──
     function setActiveRangeBtn(range) {
         var bar = document.getElementById('chart-range-bar');
-        if (bar) bar.querySelectorAll('.chart-range-btn').forEach(function (b) { b.classList.toggle('active', b.dataset.range === range); });
+        if (!bar) return;
+        bar.querySelectorAll('.chart-range-btn').forEach(function (b) {
+            var on = b.dataset.range === range;
+            // Dual-write legacy + design-system active class so the
+            // pill rule and the legacy rule stay aligned during migration.
+            b.classList.toggle('active', on);
+            b.classList.toggle('st-tab--active', on);
+        });
     }
     var rangeBar = document.getElementById('chart-range-bar');
     if (rangeBar) rangeBar.querySelectorAll('.chart-range-btn').forEach(function (btn) { btn.onclick = function () { setRange(btn.dataset.range); }; });

--- a/internal/server/static/economics.js
+++ b/internal/server/static/economics.js
@@ -53,7 +53,11 @@
     function switchTab(name) {
         activeTab = name;
         document.querySelectorAll('#economics-tabs .economics-tab').forEach(function (btn) {
-            btn.classList.toggle('active', btn.dataset.tab === name);
+            var on = btn.dataset.tab === name;
+            // Dual-write legacy + design-system active class so both
+            // selectors stay in sync during migration.
+            btn.classList.toggle('active', on);
+            btn.classList.toggle('st-tab--active', on);
         });
         $('economics-calendar-panel').classList.toggle('hidden', name !== 'calendar');
         $('economics-catalog-panel').classList.toggle('hidden', name !== 'catalog');

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -195,8 +195,12 @@
     if (tabs) {
         tabs.querySelectorAll('.info-tab').forEach(function (tab) {
             tab.onclick = function () {
-                tabs.querySelectorAll('.info-tab').forEach(function (t) { t.classList.remove('active'); });
-                tab.classList.add('active');
+                tabs.querySelectorAll('.info-tab').forEach(function (t) {
+                    // Dual-write both legacy and design-system active classes
+                    // so consumers can pick either selector during migration.
+                    t.classList.remove('active', 'st-tab--active');
+                });
+                tab.classList.add('active', 'st-tab--active');
                 loadTab(tab.dataset.tab);
             };
         });
@@ -423,18 +427,20 @@
 
     function loadFinancials(type) {
         // Sub-tab bar with keycap badges
-        var subHtml = '<div class="info-sub-tabs" id="fin-sub-tabs" data-vim-row>';
+        var subHtml = '<div class="info-sub-tabs st-tab-row st-tab-row--blue" id="fin-sub-tabs" data-vim-row>';
         finSubTypes.forEach(function (t, i) {
-            var active = t.key === type ? ' active' : '';
-            subHtml += '<button class="info-sub-tab' + active + '" data-ftype="' + t.key + '" data-vim-item><span class="tab-key">' + t.hotkey + '</span> ' + t.label + '</button>';
+            var active = t.key === type ? ' active st-tab--active' : '';
+            subHtml += '<button class="info-sub-tab st-tab' + active + '" data-ftype="' + t.key + '" data-vim-item><span class="tab-key">' + t.hotkey + '</span> ' + t.label + '</button>';
         });
         subHtml += '</div><div id="fin-table-container"><p class="empty-state">Loading...</p></div>';
         container.innerHTML = subHtml;
 
         container.querySelectorAll('.info-sub-tab').forEach(function (btn) {
             btn.onclick = function () {
-                container.querySelectorAll('.info-sub-tab').forEach(function (b) { b.classList.remove('active'); });
-                btn.classList.add('active');
+                container.querySelectorAll('.info-sub-tab').forEach(function (b) {
+                    b.classList.remove('active', 'st-tab--active');
+                });
+                btn.classList.add('active', 'st-tab--active');
                 history.replaceState(history.state, '', location.pathname + '#financials-' + btn.dataset.ftype);
                 loadFinancialTable(btn.dataset.ftype);
             };
@@ -777,10 +783,10 @@
     var newsCurrent = 'press-releases'; // remembered across re-entries
 
     function loadNews() {
-        var subHtml = '<div class="info-sub-tabs" id="news-sub-tabs" data-vim-row>';
+        var subHtml = '<div class="info-sub-tabs st-tab-row st-tab-row--blue" id="news-sub-tabs" data-vim-row>';
         NEWS_CATS.forEach(function (c) {
-            var active = c.key === newsCurrent ? ' active' : '';
-            subHtml += '<button class="info-sub-tab' + active + '" data-cat="' + c.key + '" data-vim-item>'
+            var active = c.key === newsCurrent ? ' active st-tab--active' : '';
+            subHtml += '<button class="info-sub-tab st-tab' + active + '" data-cat="' + c.key + '" data-vim-item>'
                 + c.label + '</button>';
         });
         subHtml += '</div><div id="news-cards-host" class="news-cards-host"></div>';
@@ -788,8 +794,10 @@
 
         container.querySelectorAll('#news-sub-tabs .info-sub-tab').forEach(function (btn) {
             btn.onclick = function () {
-                container.querySelectorAll('#news-sub-tabs .info-sub-tab').forEach(function (b) { b.classList.remove('active'); });
-                btn.classList.add('active');
+                container.querySelectorAll('#news-sub-tabs .info-sub-tab').forEach(function (b) {
+                    b.classList.remove('active', 'st-tab--active');
+                });
+                btn.classList.add('active', 'st-tab--active');
                 newsCurrent = btn.dataset.cat;
                 loadNewsCategory(newsCurrent);
             };
@@ -884,14 +892,14 @@
             if (peers.length > 0) {
                 peers.sort(function (a, b) { return (b.mktCap || b.marketCap || 0) - (a.mktCap || a.marketCap || 0); });
 
-                html += '<div class="sector-section-title">Peer Comparison</div>';
-                html += '<table class="fin-table peer-table" id="peer-table"><thead><tr>';
+                html += '<div class="sector-section-title st-section-title">Peer Comparison</div>';
+                html += '<table class="fin-table peer-table st-table" id="peer-table"><thead><tr>';
                 html += '<th>Security</th><th>Company</th><th>Price</th><th>Market Cap</th><th>1m</th>';
                 html += '</tr></thead><tbody>';
 
                 // Current company
                 html += '<tr class="peer-row peer-current" data-symbol="' + esc(symbol) + '" data-vim-row data-vim-action="navigate" data-vim-href="/security/' + encodeURIComponent(symbol) + '">'
-                    + '<td><span class="sym-link">' + esc(symbol) + '</span></td>'
+                    + '<td><span class="sym-link st-link-sym">' + esc(symbol) + '</span></td>'
                     + '<td>' + esc(profile.companyName || '') + '</td>'
                     + '<td>' + (profile.price ? profile.price.toFixed(2) : '—') + '</td>'
                     + '<td>' + fmt(profile.marketCap) + '</td>'
@@ -900,7 +908,7 @@
                 peers.forEach(function (p) {
                     var cap = p.mktCap || p.marketCap || 0;
                     html += '<tr class="peer-row" data-symbol="' + esc(p.symbol) + '" data-vim-row data-vim-action="navigate" data-vim-href="/security/' + encodeURIComponent(p.symbol) + '">'
-                        + '<td><span class="sym-link">' + esc(p.symbol) + '</span></td>'
+                        + '<td><span class="sym-link st-link-sym">' + esc(p.symbol) + '</span></td>'
                         + '<td>' + esc(p.companyName || '') + '</td>'
                         + '<td>' + (p.price ? p.price.toFixed(2) : '—') + '</td>'
                         + '<td>' + fmt(cap) + '</td>'
@@ -1088,15 +1096,15 @@
             var html = '<div class="sec-view">';
 
             // Sub-tab row: category filters + Key People view switcher
-            html += '<div class="info-sub-tabs" id="sec-filters" data-vim-row>';
+            html += '<div class="info-sub-tabs st-tab-row st-tab-row--blue" id="sec-filters" data-vim-row>';
             categories.forEach(function (cat) {
-                var active = (secView === 'filings' && secFilter === cat.key) ? ' active' : '';
-                html += '<button class="info-sub-tab' + active + '" data-cat="' + cat.key + '" data-view="filings" data-vim-item>' + cat.label + '</button>';
+                var active = (secView === 'filings' && secFilter === cat.key) ? ' active st-tab--active' : '';
+                html += '<button class="info-sub-tab st-tab' + active + '" data-cat="' + cat.key + '" data-view="filings" data-vim-item>' + cat.label + '</button>';
             });
             // Visual separator + Key People view switcher
             html += '<span class="sec-tab-sep" aria-hidden="true">|</span>';
-            var peopleActive = secView === 'people' ? ' active' : '';
-            html += '<button class="info-sub-tab' + peopleActive + '" data-view="people" data-vim-item>Key People</button>';
+            var peopleActive = secView === 'people' ? ' active st-tab--active' : '';
+            html += '<button class="info-sub-tab st-tab' + peopleActive + '" data-view="people" data-vim-item>Key People</button>';
             html += '</div>';
 
             if (secView === 'filings') {

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -1,17 +1,343 @@
 :root {
+    /* ── Surfaces ── */
     --bg-primary: #0a0a0a;
     --bg-secondary: #111111;
     --bg-tertiary: #1a1a1a;
     --border: #2a2a2a;
+
+    /* ── Text ── */
     --text-primary: #e0e0e0;
     --text-secondary: #888888;
+    --text-tertiary: #666666;
     --text-muted: #555555;
-    --orange: #ff8800;
+
+    /* ── Market semantics (unchanged) ── */
     --green: #00cc66;
     --red: #ff4444;
-    --blue: #4499ff;
     --yellow: #ccaa00;
+
+    /* ── Brand accents (saturated). --orange / --blue are aliases for
+       gradual migration; new code should reach for --accent-orange /
+       --accent-blue directly. ── */
+    --accent-orange: #ff9a1a;
+    --accent-blue: #2db8ff;
+    --orange: var(--accent-orange);
+    --blue: var(--accent-blue);
+
+    /* ── Lines / rails (weight-1 brand strokes) ── */
+    --line-default: 1px solid var(--border);
+    --line-accent-orange: 1px solid var(--accent-orange);
+    --line-accent-blue: 1px solid var(--accent-blue);
+    --rail-accent-orange: 2px solid var(--accent-orange);
+    --rail-accent-blue: 2px solid var(--accent-blue);
+
+    /* Left-rail box-shadows (note: distinct from --rail-*, which are
+       border shorthands and cannot be inlined inside a box-shadow
+       declaration). Use these on row-selected highlights. */
+    --rail-shadow-orange: inset 2px 0 0 var(--accent-orange);
+    --rail-shadow-blue: inset 2px 0 0 var(--accent-blue);
+
+    /* ── Brand surfaces (opaque-ish; reserve low-alpha for hover only). ── */
+    --accent-orange-surface: color-mix(in srgb, var(--accent-orange) 18%, var(--bg-primary));
+    --accent-orange-surface-strong: color-mix(in srgb, var(--accent-orange) 35%, var(--bg-primary));
+    --accent-orange-surface-solid: color-mix(in srgb, var(--accent-orange) 88%, #000000);
+    --accent-blue-surface: color-mix(in srgb, var(--accent-blue) 18%, var(--bg-primary));
+    --accent-blue-surface-strong: color-mix(in srgb, var(--accent-blue) 35%, var(--bg-primary));
+    --accent-blue-surface-solid: color-mix(in srgb, var(--accent-blue) 88%, #000000);
+    --accent-orange-hover: color-mix(in srgb, var(--accent-orange) 12%, transparent);
+    --accent-blue-hover: color-mix(in srgb, var(--accent-blue) 12%, transparent);
+
+    /* Tab strip focus (row chrome only — much lighter than table selection) */
+    --tab-row-focus-bg: color-mix(in srgb, var(--accent-orange) 10%, transparent);
+    --tab-row-focus-bg-blue: color-mix(in srgb, var(--accent-blue) 10%, transparent);
+
+    /* Selected/current tab pill (50% accent fill — no underline) */
+    --tab-selected-fill-orange: color-mix(in srgb, var(--accent-orange) 50%, transparent);
+    --tab-selected-fill-blue: color-mix(in srgb, var(--accent-blue) 50%, transparent);
+
+    /* ── Selection (one source of truth for row + tab + pane state) ── */
+    --select-row-bg: var(--accent-orange-surface-strong);
+    --select-row-rail: var(--rail-shadow-orange);
+    --select-sub-row-bg: var(--accent-blue-surface-strong);
+    --select-sub-row-rail: var(--rail-shadow-blue);
+    --pane-focus-line: 2px solid var(--accent-orange);
+
+    /* ── Ternary unit (spacing atom = 3px). Snap padding/gap to these. ── */
+    --u: 3px;
+    --space-1: var(--u);                  /*  3 */
+    --space-2: calc(var(--u) * 2);        /*  6 */
+    --space-3: calc(var(--u) * 3);        /*  9 */
+    --space-4: calc(var(--u) * 4);        /* 12 */
+    --space-5: calc(var(--u) * 5);        /* 15 */
+    --space-6: calc(var(--u) * 6);        /* 18 */
+    --space-8: calc(var(--u) * 8);        /* 24 */
+    --space-10: calc(var(--u) * 10);      /* 30 */
+    --space-15: calc(var(--u) * 15);      /* 45 */
+
+    /* ── 1 : 3 split (chrome : content) ── */
+    --layout-chrome: 1fr;
+    --layout-content: 3fr;
+    --layout-split: var(--layout-chrome) var(--layout-content);
+
+    /* ── Emphasis thirds (replace ad-hoc 0.25 / 0.15 fills) ── */
+    --emphasis-1: 33%;
+    --emphasis-2: 66%;
+    --emphasis-3: 100%;
+
+    /* ── Motion (×3 ms cadence) ── */
+    --duration-1: 90ms;
+    --duration-2: 180ms;
+    --duration-3: 270ms;
+    --duration-select: var(--duration-2);
+    --ease-select: cubic-bezier(0.4, 0, 0.2, 1);
+
+    /* ── Type tiers (three chrome + one hero). Aliases keep old names
+       working; new code should use the numbered tier. ── */
+    --text-1: 10px;
+    --text-2: 12px;
+    --text-3: 13px;
+    --text-hero: 16px;
+    --text-xs: var(--text-1);
+    --text-sm: var(--text-2);
+    --text-md: var(--text-3);
+    --text-lg: var(--text-hero);
+    --line-height-tight: 1.333;   /* 4/3 */
+    --line-height-body: 1.5;      /* 3/2 */
+
+    /* ── Radius (two stops; favour over 2/4/6 mix) ── */
+    --radius-sm: 3px;
+    --radius-md: 6px;
+
     --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+}
+
+/* ────────────────────────────────────────────────────────────────
+   Design system primitives (st-*)
+
+   Reusable classes that codify the unified visual language. Pages
+   dual-write these alongside legacy class names during migration;
+   legacy rules retire only once every consumer has switched. See
+   `design-language-unification.md` for the full spec.
+
+   Naming:
+     .st-<thing>            base
+     .st-<thing>--<mod>     modifier (BEM-style)
+   ──────────────────────────────────────────────────────────────── */
+
+/* Tabs — strip baseline + 50% pill that slides in/out on select (no underline). */
+.st-tab-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    border-bottom: none;
+    box-shadow: inset 0 -1px 0 var(--border);
+    margin-bottom: var(--space-4);
+    padding-bottom: 0;
+}
+
+.st-tab,
+.info-tab,
+.info-sub-tab {
+    position: relative;
+    z-index: 0;
+    isolation: isolate;
+    background: transparent;
+    border: none;
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    margin: 0;
+    box-shadow: none;
+    cursor: pointer;
+    transition: color var(--duration-select) var(--ease-select);
+}
+
+.st-tab {
+    font-size: var(--text-2);
+    padding: var(--space-1) var(--space-3);
+}
+
+/* Animated fill — slides in from the left, out on deselect. */
+.st-tab::before,
+.info-tab::before,
+.info-sub-tab::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    z-index: -1;
+    background: var(--tab-selected-fill-orange);
+    transform: scaleX(0);
+    transform-origin: left center;
+    opacity: 0;
+    transition:
+        transform var(--duration-select) var(--ease-select),
+        opacity var(--duration-select) var(--ease-select);
+}
+
+.st-tab-row--blue .st-tab::before,
+.info-sub-tabs .info-sub-tab::before,
+.info-sub-tabs .st-tab::before {
+    background: var(--tab-selected-fill-blue);
+}
+
+.st-tab:hover,
+.info-tab:hover,
+.info-sub-tab:hover {
+    color: var(--text-primary);
+}
+
+.st-tab--active,
+.st-tab.vim-selected,
+.info-tab.active,
+.info-tab.vim-selected {
+    color: var(--accent-orange);
+    box-shadow: none;
+}
+
+.st-tab--active::before,
+.st-tab.vim-selected::before,
+.info-tab.active::before,
+.info-tab.vim-selected::before,
+.info-sub-tab.active::before,
+.info-sub-tab.vim-selected::before {
+    transform: scaleX(1);
+    opacity: 1;
+}
+
+.st-tab-row--blue .st-tab--active,
+.st-tab-row--blue .st-tab.vim-selected,
+.info-sub-tab.active,
+.info-sub-tab.vim-selected,
+.info-sub-tabs .st-tab.active,
+.info-sub-tabs .st-tab.vim-selected {
+    color: var(--accent-blue);
+    box-shadow: none;
+}
+
+/* Hotkey badge lives inside the pill — no opaque chip punching a hole. */
+.st-tab--active .tab-key,
+.st-tab.vim-selected .tab-key,
+.info-tab.active .tab-key,
+.info-tab.vim-selected .tab-key,
+.info-sub-tab.active .tab-key,
+.info-sub-tab.vim-selected .tab-key {
+    background: transparent;
+    border-color: color-mix(in srgb, currentColor 55%, var(--border));
+    color: inherit;
+}
+
+/* Selected row — rail (1) + surface (2/3). Mirrors .vim-selected
+   so JS-driven and CSS-only selection feel identical. */
+.st-row-selected {
+    background: var(--select-row-bg) !important;
+    box-shadow: var(--select-row-rail);
+    transition:
+        background var(--duration-select) var(--ease-select),
+        box-shadow var(--duration-select) var(--ease-select);
+}
+.st-row-selected--blue {
+    background: var(--select-sub-row-bg) !important;
+    box-shadow: var(--select-sub-row-rail);
+    transition:
+        background var(--duration-select) var(--ease-select),
+        box-shadow var(--duration-select) var(--ease-select);
+}
+
+/* Active pane (multi-column layouts) — top edge bar in brand orange.
+   Used by Ideas (sidebar / main) and Screener (filters / results). */
+.st-pane-active {
+    box-shadow: 0 -2px 0 1px var(--accent-orange);
+}
+
+/* Form inputs. Default border is muted; focus picks up brand blue
+   so the focused control is unambiguous even at a glance. */
+.st-input {
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    border: var(--line-default);
+    border-radius: var(--radius-sm);
+    font-family: var(--font-mono);
+    font-size: var(--text-3);
+    padding: var(--space-2) var(--space-3);
+    outline: none;
+}
+.st-input:focus {
+    border-color: var(--accent-blue);
+}
+
+/* Chips / tags. Three semantic variants — orange (workspace), blue
+   (security identity), muted (neutral metadata). Use sparingly: a
+   page with five chip variants stops feeling intentional. */
+.st-chip {
+    display: inline-block;
+    font-size: var(--text-1);
+    font-weight: 600;
+    padding: 1px var(--space-2);
+    border-radius: var(--radius-sm);
+    border: 1px solid transparent;
+    letter-spacing: 0.02em;
+}
+.st-chip--orange {
+    color: var(--accent-orange);
+    background: var(--accent-orange-surface-solid);
+    border-color: var(--accent-orange);
+}
+.st-chip--blue {
+    color: var(--accent-blue);
+    background: var(--accent-blue-surface-solid);
+    border-color: var(--accent-blue);
+}
+.st-chip--muted {
+    color: var(--text-secondary);
+    background: var(--bg-tertiary);
+    border-color: var(--border);
+}
+
+/* Security symbol link — blue, bold, terminal-style. The canonical
+   visual contract for "this string is a tradable identifier". */
+.st-link-sym {
+    color: var(--accent-blue);
+    font-weight: 700;
+    cursor: pointer;
+    text-decoration: none;
+}
+.st-link-sym:hover {
+    text-decoration: underline;
+}
+
+/* Section titles. Compact, all-caps, brand orange — the heading
+   pattern used by screener groups and chart sub-sections. */
+.st-section-title {
+    font-size: var(--text-1);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--accent-orange);
+}
+
+/* Shared table chrome. Pages adopt by adding `st-table` alongside
+   their existing class so visual parity follows automatically. */
+.st-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--text-2);
+}
+.st-table thead th {
+    text-align: left;
+    color: var(--text-secondary);
+    font-size: var(--text-1);
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    padding: var(--space-2) var(--space-3);
+    border-bottom: var(--line-default);
+}
+.st-table tbody td {
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+}
+.st-table tbody tr:hover {
+    background: var(--bg-secondary);
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -433,26 +759,26 @@ body {
 }
 
 .reader-ticker {
-    font-size: 11px;
+    font-size: var(--text-sm);
     font-weight: 700;
-    color: var(--blue);
-    background: rgba(68, 153, 255, 0.1);
-    border: 1px solid rgba(68, 153, 255, 0.3);
-    border-radius: 3px;
+    color: var(--accent-blue);
+    background: var(--accent-blue-hover);
+    border: var(--line-accent-blue);
+    border-radius: var(--radius-sm);
     padding: 1px 6px;
     cursor: pointer;
 }
 
 .reader-ticker:hover {
-    background: rgba(68, 153, 255, 0.2);
+    background: var(--accent-blue-surface);
 }
 
 .reader-sector-badge {
-    font-size: 10px;
-    color: var(--orange);
-    background: rgba(255, 136, 0, 0.1);
-    border: 1px solid rgba(255, 136, 0, 0.2);
-    border-radius: 3px;
+    font-size: var(--text-1);
+    color: var(--accent-orange);
+    background: var(--accent-orange-hover);
+    border: var(--line-accent-orange);
+    border-radius: var(--radius-sm);
     padding: 1px 6px;
 }
 
@@ -542,8 +868,8 @@ body {
 }
 
 .footer-mode.insert {
-    color: var(--orange);
-    background: rgba(255, 136, 0, 0.15);
+    color: var(--accent-orange);
+    background: var(--accent-orange-surface);
 }
 
 .footer-view {
@@ -658,22 +984,32 @@ body {
     margin-bottom: 8px;
 }
 
+/* Watchlist tabs — each list has its own user-chosen colour, which
+   serves as identity. Adopting the orange pill from .st-tab--active
+   would override that, so the watchlist deliberately stays on a
+   parallel visual language: rounded, bordered in the list's colour,
+   filled with a soft tint of that same colour on active.
+   currentColor picks up the inline style colour set per tab. */
 .wl-tab {
-    font-size: 11px;
-    padding: 3px 10px;
+    font-size: var(--text-sm);
+    padding: var(--space-1) var(--space-3);
     border: 1px solid;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     cursor: pointer;
     opacity: 0.6;
+    transition:
+        opacity var(--duration-select) var(--ease-select),
+        background var(--duration-select) var(--ease-select);
 }
 
 .wl-tab:hover {
-    opacity: 0.8;
+    opacity: 0.85;
 }
 
 .wl-tab-active {
     opacity: 1;
     font-weight: 700;
+    background: color-mix(in srgb, currentColor 18%, var(--bg-primary));
 }
 
 /* ── Add Security Form (Watchlist) ── */
@@ -821,35 +1157,20 @@ body {
 }
 
 
+/* Legacy info-tab rules converged onto the flat st-tab look. */
 .info-tabs {
     display: flex;
-    gap: 4px;
-    margin-bottom: 12px;
-    border-bottom: 1px solid var(--border);
-    padding-bottom: 8px;
+    align-items: center;
+    gap: var(--space-2);
+    margin-bottom: var(--space-4);
+    border-bottom: none;
+    box-shadow: inset 0 -1px 0 var(--border);
+    padding-bottom: 0;
 }
 
 .info-tab {
-    background: transparent;
-    border: 1px solid transparent;
-    border-radius: 4px;
-    color: var(--text-secondary);
-    font-family: var(--font-mono);
-    font-size: 12px;
-    padding: 5px 12px;
-    cursor: pointer;
-}
-
-.info-tab:hover {
-    color: var(--text-primary);
-    background: var(--bg-tertiary);
-}
-
-.info-tab.active {
-    color: var(--orange);
-    border-color: var(--orange);
-    background: var(--bg-tertiary);
-    box-shadow: inset 0 -2px 0 var(--orange);
+    font-size: var(--text-2);
+    padding: var(--space-1) var(--space-3);
 }
 
 .info-content {
@@ -911,35 +1232,21 @@ body {
     margin: 0;
 }
 
+/* Sub-tab strip — same baseline geometry as .st-tab-row. */
 .info-sub-tabs {
     display: flex;
-    gap: 4px;
-    margin-bottom: 12px;
-    border-bottom: 1px solid var(--border);
-    padding-bottom: 8px;
+    align-items: center;
+    gap: var(--space-2);
+    margin-bottom: var(--space-4);
+    border-bottom: none;
+    box-shadow: inset 0 -1px 0 var(--border);
+    padding-bottom: 0;
 }
 
+/* Sub-tabs — blue variant (fill + slide from shared .info-sub-tab rules). */
 .info-sub-tab {
-    background: transparent;
-    border: 1px solid transparent;
-    border-radius: 4px;
-    color: var(--text-secondary);
-    font-family: var(--font-mono);
-    font-size: 11px;
-    padding: 4px 10px;
-    cursor: pointer;
-}
-
-.info-sub-tab:hover {
-    color: var(--text-primary);
-    background: var(--bg-tertiary);
-}
-
-.info-sub-tab.active {
-    color: var(--blue);
-    border-color: var(--blue);
-    background: var(--bg-tertiary);
-    box-shadow: inset 0 -2px 0 var(--blue);
+    font-size: var(--text-1);
+    padding: var(--space-1) var(--space-3);
 }
 
 .fin-table {
@@ -1011,11 +1318,13 @@ body {
 }
 
 .info-tabs.tab-row-focused {
-    border-bottom-color: var(--orange) !important;
+    background: var(--tab-row-focus-bg);
+    box-shadow: inset 0 -1px 0 var(--border);
 }
 
 .info-sub-tabs.tab-row-focused {
-    border-bottom-color: var(--blue) !important;
+    background: var(--tab-row-focus-bg-blue);
+    box-shadow: inset 0 -1px 0 var(--border);
 }
 
 .help-tip {
@@ -1462,7 +1771,7 @@ body {
 }
 
 @keyframes info-pulse-fade {
-    0% { color: var(--orange); text-shadow: 0 0 6px rgba(255, 136, 0, 0.5); }
+    0% { color: var(--accent-orange); text-shadow: 0 0 6px color-mix(in srgb, var(--accent-orange) 50%, transparent); }
     100% { color: inherit; text-shadow: none; }
 }
 
@@ -1628,25 +1937,21 @@ body {
 
 /* ── Stock / Graph View ── */
 
+/* Chart range bar — blue tab-strip variant. Intraday + EOD ranges share
+   the .st-tab pill animation; auto-refresh + indicator toggles inside
+   the same bar keep their own bespoke styles (they're filters, not
+   selectors). */
 .chart-range-bar {
     display: flex;
-    gap: 4px;
+    align-items: center;
+    gap: var(--space-2);
+    box-shadow: inset 0 -1px 0 var(--border);
 }
 
 .chart-range-btn {
-    background: transparent;
-    border: 1px solid transparent;
-    border-radius: 4px;
-    color: var(--text-secondary);
-    font-family: var(--font-mono);
-    font-size: 12px;
-    padding: 4px 10px;
-    cursor: pointer;
-}
-
-.chart-range-btn:hover {
-    color: var(--text-primary);
-    background: var(--bg-tertiary);
+    /* Geometry on ternary grid; pill + colour flow from .st-tab rules. */
+    font-size: var(--text-2);
+    padding: var(--space-1) var(--space-3);
 }
 
 .chart-auto-refresh {
@@ -1680,10 +1985,12 @@ body {
     line-height: 1;
 }
 
+/* Legacy .chart-range-btn.active retained as a token bridge — when
+   markup hasn't been dual-written yet, the colour change still lands.
+   Box-shadow + bg flow from the shared pill rules at the top of the
+   file. */
 .chart-range-btn.active {
-    color: var(--orange);
-    border-color: var(--orange);
-    background: var(--bg-tertiary);
+    color: var(--accent-blue);
 }
 
 .chart-toggle {
@@ -2058,31 +2365,63 @@ body {
 
 /* ── Vim Selection ── */
 
-/* Soft orange fill (25% of #ff8800) — the whole element lights up
- * when navigated to. No outline; the fill alone is the indicator.
- * Works uniformly for tabs, table rows, news cards, etc. */
+/* Selection = LINE (1) + SURFACE (2/3). The line is the left rail;
+ * the surface is an opaque-ish brand fill (emphasis-2, i.e. 66%
+ * toward the bg). The previous 25% rgba wash read as muddy on
+ * dark backgrounds and is now reserved for :hover only. */
 .vim-selected {
-    background: rgba(255, 136, 0, 0.25) !important;
+    background: color-mix(in srgb, var(--accent-orange) var(--emphasis-2), var(--bg-primary)) !important;
+    box-shadow: var(--rail-shadow-orange);
+    transition:
+        background var(--duration-select) var(--ease-select),
+        box-shadow var(--duration-select) var(--ease-select),
+        color var(--duration-select) var(--ease-select);
 }
 
 /* Row-level cue: when any item inside a row container is selected,
  * the whole row gets the same fill. For tab strips this means the
  * entire nav row lights up, not just the focused tab. */
 [data-vim-row]:has(.vim-selected) {
-    background: rgba(255, 136, 0, 0.25);
+    background: color-mix(in srgb, var(--accent-orange) var(--emphasis-2), var(--bg-primary));
 }
 
-/* Sub-tabs use blue instead of orange so they're visually
- * distinguishable from the main tab row when the user is
- * navigating between strips. Matches the .info-sub-tab.active
- * blue accent. */
-.info-sub-tabs .vim-selected,
-.news-sub-tabs .vim-selected {
-    background: rgba(68, 153, 255, 0.25) !important;
+/* Tab strips: faint row wash + neutral baseline (not table-row fill). */
+.st-tab-row[data-vim-row]:has(.vim-selected),
+.info-tabs[data-vim-row]:has(.vim-selected),
+.economics-tabs[data-vim-row]:has(.vim-selected) {
+    background: var(--tab-row-focus-bg);
+    box-shadow: inset 0 -1px 0 var(--border);
 }
-.info-sub-tabs:has(.vim-selected),
-.news-sub-tabs:has(.vim-selected) {
-    background: rgba(68, 153, 255, 0.25);
+
+.st-tab-row--blue[data-vim-row]:has(.vim-selected),
+.info-sub-tabs[data-vim-row]:has(.vim-selected),
+.news-sub-tabs[data-vim-row]:has(.vim-selected) {
+    background: var(--tab-row-focus-bg-blue);
+    box-shadow: inset 0 -1px 0 var(--border);
+}
+
+/* Tab vim focus: colour only — fill slide is on ::before (see .st-tab rules). */
+.st-tab-row .st-tab.vim-selected,
+.st-tab-row .info-tab.vim-selected,
+.info-tabs .info-tab.vim-selected,
+.info-sub-tabs .info-sub-tab.vim-selected,
+.info-sub-tabs .st-tab.vim-selected,
+.news-sub-tabs .info-sub-tab.vim-selected,
+.news-sub-tabs .st-tab.vim-selected {
+    background: transparent !important;
+    box-shadow: none !important;
+    margin: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .st-tab::before,
+    .info-tab::before,
+    .info-sub-tab::before,
+    .vim-selected,
+    .st-row-selected,
+    .st-row-selected--blue {
+        transition: none;
+    }
 }
 
 /* ── Equity Indices ── */
@@ -3126,26 +3465,19 @@ a, [tabindex] {
     flex-shrink: 0;
 }
 
+/* Economics tabs — primary nav (orange variant of the st-tab pill). */
 .economics-tabs {
     display: flex;
-    gap: 4px;
+    align-items: center;
+    gap: var(--space-2);
+    box-shadow: inset 0 -1px 0 var(--border);
 }
 
 .economics-tab {
-    background: transparent;
-    color: var(--text-secondary);
-    border: 1px solid var(--border);
-    padding: 4px 12px;
-    font-family: inherit;
-    font-size: 12px;
-    cursor: pointer;
-}
-
-.economics-tab:hover { color: var(--text-primary); }
-
-.economics-tab.active {
-    color: var(--orange);
-    border-color: var(--orange);
+    /* Geometry on the ternary grid. Visual (fill + active state) flows
+       from the shared .info-tab / .st-tab rules at the top of the file. */
+    font-size: var(--text-2);
+    padding: var(--space-1) var(--space-3);
 }
 
 .economics-hint {

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -3622,7 +3622,7 @@ window.onerror = function (msg, src, line, col, err) {
         var el = document.getElementById(containerId);
         if (!el || !symbol) return;
 
-        el.innerHTML = '<span class="cpanel-sym">' + symbol + '</span>'
+        el.innerHTML = '<span class="cpanel-sym st-link-sym">' + symbol + '</span>'
             + '<span id="cpanel-name" class="cpanel-name"></span>'
             + '<span id="cpanel-price" class="cpanel-price"></span>'
             + '<span id="cpanel-change" class="cpanel-change"></span>'

--- a/internal/server/static/vim-nav.js
+++ b/internal/server/static/vim-nav.js
@@ -112,19 +112,40 @@
         applySelection();
     }
 
-    // Row down: move to row+1, column 0. j past the last row is a no-op
-    // — by spec the page's last element is the bottom of nav.
+    // Bounds-check helper. Called at the top of every directional move so
+    // stale selection state (rows pruned out from under us by an HTML
+    // re-render) can't crash the page on the next keypress. Returns true
+    // if the cursor was already valid; otherwise resets to (0, 0).
+    function ensureCursorInBounds() {
+        if (currentRow < 0 || currentRow >= grid.length) {
+            currentRow = 0;
+            currentCol = 0;
+            return false;
+        }
+        var row = grid[currentRow];
+        if (currentCol < 0 || currentCol >= row.items.length) {
+            currentCol = 0;
+            return false;
+        }
+        return true;
+    }
+
+    // Directional moves all share the same shape:
+    //   1. rebuild grid + bounds-check (cold state lands on (0,0))
+    //   2. attempt the move (no-op at the edge)
+    //   3. apply selection
+    //
+    // The first directional keypress on a fresh page advances rather
+    // than just initialising: pressing 'l' on a freshly-loaded security
+    // page jumps from "nothing selected" to "second tab", which matches
+    // muscle memory better than "nothing → first tab → press again".
     function moveDown() {
         buildGrid();
         if (grid.length === 0) return false;
-        if (currentRow < 0) {
-            currentRow = 0;
-            currentCol = 0;
-        } else if (currentRow < grid.length - 1) {
+        ensureCursorInBounds();
+        if (currentRow < grid.length - 1) {
             currentRow++;
             currentCol = 0;
-        } else {
-            return true; // consumed but at end
         }
         applySelection();
         return true;
@@ -133,14 +154,10 @@
     function moveUp() {
         buildGrid();
         if (grid.length === 0) return false;
-        if (currentRow < 0) {
-            currentRow = 0;
-            currentCol = 0;
-        } else if (currentRow > 0) {
+        ensureCursorInBounds();
+        if (currentRow > 0) {
             currentRow--;
             currentCol = 0;
-        } else {
-            return true;
         }
         applySelection();
         return true;
@@ -149,13 +166,10 @@
     function moveRight() {
         buildGrid();
         if (grid.length === 0) return false;
-        if (currentRow < 0) {
-            currentRow = 0;
-            currentCol = 0;
-        } else {
-            var row = grid[currentRow];
-            if (currentCol < row.items.length - 1) currentCol++;
-            else return true; // at end of row — by spec h/l doesn't wrap
+        ensureCursorInBounds();
+        var row = grid[currentRow];
+        if (currentCol < row.items.length - 1) {
+            currentCol++;
         }
         applySelection();
         return true;
@@ -164,13 +178,9 @@
     function moveLeft() {
         buildGrid();
         if (grid.length === 0) return false;
-        if (currentRow < 0) {
-            currentRow = 0;
-            currentCol = 0;
-        } else if (currentCol > 0) {
+        ensureCursorInBounds();
+        if (currentCol > 0) {
             currentCol--;
-        } else {
-            return true;
         }
         applySelection();
         return true;
@@ -181,16 +191,13 @@
     function wordForward() {
         buildGrid();
         if (grid.length === 0) return false;
-        if (currentRow < 0) {
-            currentRow = 0;
+        ensureCursorInBounds();
+        var row = grid[currentRow];
+        if (currentCol < row.items.length - 1) {
+            currentCol++;
+        } else if (currentRow < grid.length - 1) {
+            currentRow++;
             currentCol = 0;
-        } else {
-            var row = grid[currentRow];
-            if (currentCol < row.items.length - 1) currentCol++;
-            else if (currentRow < grid.length - 1) {
-                currentRow++;
-                currentCol = 0;
-            } else return true;
         }
         applySelection();
         return true;
@@ -199,15 +206,13 @@
     function wordBack() {
         buildGrid();
         if (grid.length === 0) return false;
-        if (currentRow < 0) {
-            currentRow = 0;
-            currentCol = 0;
-        } else if (currentCol > 0) {
+        ensureCursorInBounds();
+        if (currentCol > 0) {
             currentCol--;
         } else if (currentRow > 0) {
             currentRow--;
             currentCol = grid[currentRow].items.length - 1;
-        } else return true;
+        }
         applySelection();
         return true;
     }

--- a/internal/server/templates/economics.html
+++ b/internal/server/templates/economics.html
@@ -3,9 +3,9 @@
 <div class="economics-layout" data-view="economics">
     <header class="page-header economics-header">
         <h2 class="view-title">Economics</h2>
-        <nav class="economics-tabs" id="economics-tabs" data-vim-row>
-            <button class="economics-tab active" data-tab="calendar" data-vim-item data-vim-action="click">Calendar</button>
-            <button class="economics-tab" data-tab="catalog" data-vim-item data-vim-action="click">Catalog</button>
+        <nav class="economics-tabs st-tab-row" id="economics-tabs" data-vim-row>
+            <button class="economics-tab st-tab active st-tab--active" data-tab="calendar" data-vim-item data-vim-action="click">Calendar</button>
+            <button class="economics-tab st-tab" data-tab="catalog" data-vim-item data-vim-action="click">Catalog</button>
         </nav>
         <span class="economics-hint" id="economics-hint">
             <kbd>h</kbd>/<kbd>l</kbd> tabs · <kbd>j</kbd>/<kbd>k</kbd> rows · <kbd>/</kbd> filter

--- a/internal/server/templates/security.html
+++ b/internal/server/templates/security.html
@@ -2,14 +2,14 @@
 {{define "content"}}
 <div id="company-panel" class="company-panel"></div>
 <span id="help-indicator" class="help-indicator hidden">? help on</span>
-<div class="info-tabs" id="info-tabs" data-vim-row>
-    <button class="info-tab active" data-tab="overview" data-vim-item><span class="tab-key">1</span> Overview</button>
-    <button class="info-tab" data-tab="financials" data-vim-item><span class="tab-key">2</span> Financials</button>
-    <button class="info-tab" data-tab="estimates" data-vim-item><span class="tab-key">3</span> Estimates</button>
-    <button class="info-tab" data-tab="news" data-vim-item><span class="tab-key">4</span> News</button>
-    <button class="info-tab" data-tab="ai" data-vim-item><span class="tab-key">5</span> AI Analysis</button>
-    <button class="info-tab" data-tab="sector" data-vim-item><span class="tab-key">6</span> Sector</button>
-    <button class="info-tab" data-tab="sec" data-vim-item><span class="tab-key">7</span> SEC</button>
+<div class="info-tabs st-tab-row" id="info-tabs" data-vim-row>
+    <button class="info-tab st-tab active st-tab--active" data-tab="overview" data-vim-item><span class="tab-key">1</span> Overview</button>
+    <button class="info-tab st-tab" data-tab="financials" data-vim-item><span class="tab-key">2</span> Financials</button>
+    <button class="info-tab st-tab" data-tab="estimates" data-vim-item><span class="tab-key">3</span> Estimates</button>
+    <button class="info-tab st-tab" data-tab="news" data-vim-item><span class="tab-key">4</span> News</button>
+    <button class="info-tab st-tab" data-tab="ai" data-vim-item><span class="tab-key">5</span> AI Analysis</button>
+    <button class="info-tab st-tab" data-tab="sector" data-vim-item><span class="tab-key">6</span> Sector</button>
+    <button class="info-tab st-tab" data-tab="sec" data-vim-item><span class="tab-key">7</span> SEC</button>
 </div>
 <div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
     <p class="empty-state">Loading...</p>

--- a/internal/server/templates/stock.html
+++ b/internal/server/templates/stock.html
@@ -2,19 +2,19 @@
 {{define "content"}}
 <div id="company-panel" class="company-panel no-spark"></div>
 <div class="page-header">
-    <div class="chart-range-bar" id="chart-range-bar">
-        <button class="chart-range-btn chart-intraday-btn" data-range="1m" data-interval="1min">1m</button>
-        <button class="chart-range-btn chart-intraday-btn" data-range="5m" data-interval="5min">5m</button>
-        <button class="chart-range-btn chart-intraday-btn" data-range="15m" data-interval="15min">15m</button>
-        <button class="chart-range-btn chart-intraday-btn" data-range="30m" data-interval="30min">30m</button>
-        <button class="chart-range-btn chart-intraday-btn" data-range="1h" data-interval="1hour">1h</button>
-        <button class="chart-range-btn chart-intraday-btn" data-range="4h" data-interval="4hour">4h</button>
+    <div class="chart-range-bar st-tab-row st-tab-row--blue" id="chart-range-bar">
+        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="1m" data-interval="1min">1m</button>
+        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="5m" data-interval="5min">5m</button>
+        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="15m" data-interval="15min">15m</button>
+        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="30m" data-interval="30min">30m</button>
+        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="1h" data-interval="1hour">1h</button>
+        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="4h" data-interval="4hour">4h</button>
         <button class="chart-auto-refresh active" id="chart-auto-refresh" title="Auto-refresh">&#8635;</button>
         <span class="chart-range-sep">|</span>
-        <button class="chart-range-btn chart-eod-btn active" data-range="1W">1w</button>
-        <button class="chart-range-btn chart-eod-btn" data-range="1M">1m</button>
-        <button class="chart-range-btn chart-eod-btn" data-range="3M">3m</button>
-        <button class="chart-range-btn chart-eod-btn" data-range="6M">6m</button>
+        <button class="chart-range-btn chart-eod-btn st-tab active st-tab--active" data-range="1W">1w</button>
+        <button class="chart-range-btn chart-eod-btn st-tab" data-range="1M">1m</button>
+        <button class="chart-range-btn chart-eod-btn st-tab" data-range="3M">3m</button>
+        <button class="chart-range-btn chart-eod-btn st-tab" data-range="6M">6m</button>
         <span class="chart-range-sep">|</span>
         <button class="chart-toggle" id="toggle-sma" data-indicator="sma" title=":sma">SMA</button>
         <button class="chart-toggle" id="toggle-ema" data-indicator="ema" title=":ema">EMA</button>

--- a/tests/bdd/features/design-tokens.feature
+++ b/tests/bdd/features/design-tokens.feature
@@ -1,0 +1,36 @@
+Feature: Design tokens and st-* primitives are in effect
+  The design language unification introduces a single set of CSS tokens and
+  reusable st-* primitive classes. These scenarios pin down that the tokens
+  resolve to real values and that the Info reference page is dual-written —
+  legacy class names stay alongside the new ones during migration, and the
+  new ones must actually take effect.
+
+  Background:
+    Given the dev server is reachable
+
+  Scenario: The accent-orange token resolves to a saturated brand colour
+    Given I am on the watchlist page
+    Then the computed value of CSS variable "--accent-orange" is "rgb(255, 154, 26)"
+    And the computed value of CSS variable "--orange" is the same as "--accent-orange"
+
+  Scenario: The Info reference page dual-writes st-tab on the active tab
+    Given I am on the security page for "AAPL"
+    Then the active tab carries the class "st-tab--active"
+    And the tab strip carries the class "st-tab-row"
+
+  Scenario: The sector peer table renders with the shared st-table primitive
+    Given I am on the security page for "AAPL"
+    When I press "6"
+    Then the peer table carries the class "st-table"
+    And the peer symbol cells carry the class "st-link-sym"
+
+  Scenario: The economics page tab strip uses the design primitive
+    Given I am on the economics page
+    Then the tab strip "#economics-tabs" carries the class "st-tab-row"
+    And the active tab in "#economics-tabs" carries the class "st-tab--active"
+
+  Scenario: The stock chart range bar uses the blue tab strip primitive
+    Given I am on the stock chart page for "AAPL"
+    Then the tab strip "#chart-range-bar" carries the class "st-tab-row"
+    And the tab strip "#chart-range-bar" carries the class "st-tab-row--blue"
+    And the active tab in "#chart-range-bar" carries the class "st-tab--active"

--- a/tests/bdd/features/vim-nav-robustness.feature
+++ b/tests/bdd/features/vim-nav-robustness.feature
@@ -1,0 +1,50 @@
+Feature: Vim navigation is robust across every directional key
+  Vim nav is the spine of this app. If a directional keypress silently
+  crashes or fails to update the selection, the user loses faith fast.
+  These scenarios walk the security tab strip + sub-tab strip with every
+  navigation key — h, l, j, k, w, b, G, gg, 1-9, Enter — and assert
+  each step lands on the right item AND that something visible was painted.
+
+  Background:
+    Given the dev server is reachable
+    And I am on the security page for "AAPL"
+
+  Scenario: h and l walk left and right across the tab strip
+    When I press "l"
+    Then the highlighted item has data-tab "financials"
+    When I press "l"
+    Then the highlighted item has data-tab "estimates"
+    When I press "h"
+    Then the highlighted item has data-tab "financials"
+
+  Scenario: w jumps forward across rows; b walks back
+    When I press "l"
+    Then the highlighted item has data-tab "financials"
+    When I press "w"
+    Then the highlighted item has data-tab "estimates"
+    When I press "b"
+    Then the highlighted item has data-tab "financials"
+
+  Scenario: gg returns to the first item, G jumps to the last
+    When I press the keys "lll"
+    Then the highlighted item has data-tab "news"
+    When I press the keys "gg"
+    Then the highlighted item has data-tab "overview"
+    When I press "G"
+    Then a row is highlighted
+
+  Scenario: Numeric jumps activate the corresponding tab
+    When I press "3"
+    Then the active tab is "Estimates"
+    When I press "1"
+    Then the active tab is "Overview"
+
+  Scenario: Enter activates the highlighted tab
+    When I press "l"
+    And I press "Enter"
+    Then the active tab is "Financials"
+
+  Scenario: A rapid keypress after an HTML rerender does not crash
+    When I press "2"
+    And I press the keys "jjjjlhlhlhwbwb"
+    Then no JavaScript error has been logged

--- a/tests/bdd/steps/given.js
+++ b/tests/bdd/steps/given.js
@@ -56,6 +56,16 @@ Given('I am on the watchlist page', async ({ page }) => {
   await page.waitForSelector('#quote-body tr', { state: 'visible' });
 });
 
+Given('I am on the economics page', async ({ page }) => {
+  await page.goto('/economics');
+  await page.waitForSelector('#economics-tabs .economics-tab.active');
+});
+
+Given('I am on the stock chart page for {string}', async ({ page }, sym) => {
+  await page.goto('/stock/' + sym);
+  await page.waitForSelector('#chart-range-bar .chart-range-btn.active');
+});
+
 Given('I am on the screener page', async ({ page }) => {
   // Capture every /api/screener request so later steps can assert on the
   // exact URL the form submits (used by the shorthand-parsing scenario).
@@ -72,6 +82,11 @@ Given('I am on the screener page', async ({ page }) => {
 });
 
 Given('I am on the security page for {string}', async ({ page }, sym) => {
+  // Capture any uncaught JS errors so robustness scenarios can assert
+  // none fired during a key-mash. Stash on the page so When/Then steps
+  // can read it.
+  page.__pageErrors = [];
+  page.on('pageerror', (err) => { page.__pageErrors.push(err.message); });
   await page.goto('/security/' + sym);
   await page.waitForSelector('#info-tabs .info-tab.active');
   // Wait for the Overview tab to finish painting — otherwise its late

--- a/tests/bdd/steps/when-then.js
+++ b/tests/bdd/steps/when-then.js
@@ -142,6 +142,89 @@ When('the page receives a background DOM update', async ({ page }) => {
   await page.waitForTimeout(200);
 });
 
+// ── Vim navigation robustness ──
+
+Then('the highlighted item has data-tab {string}', async ({ page }, tab) => {
+  // Verifies the .vim-selected element actually carries the expected
+  // data-tab. Hard-fails on missing selection (catches both the
+  // 'walked into the void' bug and the 'crashed before applySelection'
+  // bug at once).
+  const got = await page.evaluate(() => {
+    const el = document.querySelector('.vim-selected');
+    return el ? (el.dataset.tab || null) : null;
+  });
+  expect(got, 'no element is highlighted').not.toBeNull();
+  expect(got).toBe(tab);
+});
+
+Then('no JavaScript error has been logged', async ({ page }) => {
+  const errs = page.__pageErrors || [];
+  expect(errs, 'page logged JS errors during this scenario').toEqual([]);
+});
+
+// ── Design system tokens & primitives ──
+
+Then('the computed value of CSS variable {string} is {string}',
+  async ({ page }, varName, expected) => {
+    const actual = await page.evaluate((v) => {
+      // Read on documentElement (where :root lives) and resolve through
+      // a temporary element so color-mix() expands.
+      const probe = document.createElement('span');
+      probe.style.color = 'var(' + v + ')';
+      document.body.appendChild(probe);
+      const c = getComputedStyle(probe).color;
+      probe.remove();
+      return c;
+    }, varName);
+    expect(actual).toBe(expected);
+  }
+);
+
+Then('the computed value of CSS variable {string} is the same as {string}',
+  async ({ page }, a, b) => {
+    const [va, vb] = await page.evaluate(([x, y]) => {
+      const read = (name) => {
+        const probe = document.createElement('span');
+        probe.style.color = 'var(' + name + ')';
+        document.body.appendChild(probe);
+        const c = getComputedStyle(probe).color;
+        probe.remove();
+        return c;
+      };
+      return [read(x), read(y)];
+    }, [a, b]);
+    expect(va).toBe(vb);
+  }
+);
+
+Then('the active tab carries the class {string}', async ({ page }, cls) => {
+  await expect(page.locator('#info-tabs .info-tab.active')).toHaveClass(new RegExp('(^|\\s)' + cls + '(\\s|$)'));
+});
+
+Then('the tab strip carries the class {string}', async ({ page }, cls) => {
+  await expect(page.locator('#info-tabs')).toHaveClass(new RegExp('(^|\\s)' + cls + '(\\s|$)'));
+});
+
+Then('the peer table carries the class {string}', async ({ page }, cls) => {
+  await expect(page.locator('#peer-table')).toHaveClass(new RegExp('(^|\\s)' + cls + '(\\s|$)'), { timeout: 5000 });
+});
+
+Then('the peer symbol cells carry the class {string}', async ({ page }, cls) => {
+  // At least one .peer-row should host a span with the requested class.
+  await expect(page.locator('.peer-row .' + cls).first()).toBeVisible({ timeout: 5000 });
+});
+
+Then('the tab strip {string} carries the class {string}', async ({ page }, sel, cls) => {
+  await expect(page.locator(sel)).toHaveClass(new RegExp('(^|\\s)' + cls + '(\\s|$)'));
+});
+
+Then('the active tab in {string} carries the class {string}', async ({ page }, sel, cls) => {
+  // Scope to .st-tab so we don't pick up sibling buttons with their own
+  // 'active' state (auto-refresh on the chart bar, etc.).
+  await expect(page.locator(sel + ' .st-tab.active').first())
+    .toHaveClass(new RegExp('(^|\\s)' + cls + '(\\s|$)'));
+});
+
 // ── Screener UX assertions ──
 
 Then('every filter group is collapsed', async ({ page }) => {


### PR DESCRIPTION
## Summary

Phase 1 + 2 of the design-language unification (`design-language-unification.md`). Tokens land first; primitive `st-*` classes follow; four reference surfaces dual-write the new classes alongside their legacy markup.

### Token layer (`:root`)

- **Saturated brand**: `--accent-orange: #ff9a1a` (was `#ff8800`), `--accent-blue: #2db8ff` (was `#4499ff`). Legacy `--orange` / `--blue` aliased — older selectors keep working.
- **Lines / rails / surfaces** — brand line and rail tokens, opaque-ish brand surfaces (`--accent-*-surface{,-strong,-solid}`), hover-only translucency reserved.
- **Tab pill colours** — `--tab-selected-fill-{orange,blue}` (50% accent), faint `--tab-row-focus-bg*` wash for the focused strip.
- **Selection** — `--select-row-bg / --select-row-rail` in box-shadow syntax, `--pane-focus-line`.
- **Ternary spacing** — `--u: 3px`; `--space-1 … --space-15`.
- **Layout** — `--layout-split: 1fr 3fr`.
- **Emphasis thirds** — 33/66/100; **motion** 90/180/270ms; **type tiers** 10/12/13/16; **radius** 3/6.
- **Selection motion** — `--duration-select: 180ms`, shared `--ease-select` cubic-bezier.

Top brand-literal `rgba()` / hex values swept to tokens. `.vim-selected` moved from the muddy 25% wash to rail + emphasis-2 surface (§12.7).

### Primitives section

\`\`\`
/* Design system primitives (st-*) */
.st-tab-row / .st-tab / .st-tab--active (+ --blue modifier)
.st-row-selected / --blue
.st-pane-active
.st-input
.st-chip / --orange / --blue / --muted
.st-link-sym
.st-section-title
.st-table
\`\`\`

The tab primitive uses a **sliding `::before` pill** (transform: `scaleX(0)` → `scaleX(1)`) in `--tab-selected-fill-*`, with the hotkey badge transparent inside the pill. \`prefers-reduced-motion: reduce\` disables transitions.

### Dual-write across four reference surfaces

| Page | What changed |
|---|---|
| `/security/AAPL` | Info tabs + Financials/News/SEC sub-tabs + sector peer table + company panel symbol. Tabs adopt the orange pill, sub-tabs adopt the blue variant. |
| `/economics` | Calendar / Catalog tabs — orange variant of the pill. |
| `/stock/AAPL` | Chart range bar — blue pill on each \`.chart-range-btn\`. Auto-refresh (green) and SMA/EMA/MACD/RSI/News toggles deliberately keep their bespoke styles — they're filters, not selectors. |
| `/watchlist` | Tabs preserve per-list colour identity (each list has its own colour). Active state now tints with `currentColor`, and geometry (padding, radius, transition) snaps to the ternary grid. |
| `/crypto/*`, `/etf/*`, `/fund/*`, `/forex/*`, `/index/*` | Inherit via the converged `.info-tab` rules — no markup changes needed. |

Click handlers in info.js / economics.js / chart.js dual-write \`st-tab--active\` alongside legacy \`active\` so both selectors stay in sync during migration.

### vim-nav.js robustness

- **Bounds-check** the cursor at the top of every directional move via \`ensureCursorInBounds()\`. Stale \`(currentRow, currentCol)\` after an HTML rerender no longer crashes (previously \`moveRight:157\` could read \`row.items\` on undefined).
- **First directional press from cold state advances** instead of just initialising. Pressing \`l\` on a freshly-loaded \`/security/AAPL\` jumps from nothing-selected straight to Financials — matches muscle memory better than "nothing → first tab → press again".

### BDD coverage

New \`design-tokens.feature\` (4 scenarios):
- \`--accent-orange\` resolves to a saturated rgb (proves the token bump landed).
- Info tab strip + active tab carry \`st-tab-row\` / \`st-tab--active\`.
- Peer table carries \`st-table\` + \`st-link-sym\`.
- Economics + chart-range strips carry \`st-tab-row\` (and \`--blue\` for chart-range).

New \`vim-nav-robustness.feature\` (6 scenarios):
- \`h\` / \`l\` walk left and right.
- \`w\` jumps forward across rows; \`b\` walks back.
- \`gg\` returns to first, \`G\` jumps to last.
- Numeric jumps activate the right tab.
- \`Enter\` activates the highlighted tab.
- **A rapid keypress after an HTML rerender does not crash** (regression net for the moveRight bug).

**28/28 BDD ✓. Smoke ✓. Unit ✓.**

## Test plan

- [x] \`make build\` clean
- [x] \`make test\` — Go unit tests green
- [x] \`make smoke\` — Go e2e green
- [x] \`make bdd\` — 28/28 scenarios green
- [x] Manual: \`/security/AAPL\` — press h/l, see the orange pill slide across tabs. Press 2 to Financials; the Income / Balance / Cashflow sub-tab pill is blue.
- [x] Manual: \`/economics\` — Calendar / Catalog pill slides.
- [x] Manual: \`/stock/AAPL\` — click range buttons; blue pill slides. Auto-refresh stays green; SMA/EMA toggles unchanged.
- [x] Manual: \`/watchlist\` — each tab keeps its per-list colour; active gets a soft tint of *its own* colour.
- [x] Manual: any vim nav mash (\`2jjjlhlhlhwbwb\`) — no console errors.

## Follow-ups (deferred to next branch)

- Phase 3 — \`.vim-selected\` → \`.st-row-selected\` unification.
- Phase 4 — remaining pages: ideas pane chrome, screener preset pill, reader badges.
- Phase 4b — layout grids (\`--layout-split\` adoption on \`.ideas-layout\`, \`.screener-layout\`, \`.article-reader\`).
- Phase 5 — guardrails (\`docs/design-language.md\`, hex-literal grep CI).