### PR TITLE
ci: bump actions to Node 24 (release-please v5, checkout v6, setup-go v6)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,10 +14,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: '1.23'
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           # Manifest mode: release-type + package-name live in
           # release-please-config.json (alongside changelog-sections etc).


### PR DESCRIPTION
## Summary
The Node 20 deprecation warning showing up in both workflows:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: googleapis/release-please-action@v4, actions/checkout@v4, actions/setup-go@v5.

GitHub's timeline:
- **2026-06-16**: Node 24 forced by default
- **2026-09-16**: Node 20 removed entirely

All three actions in use here have Node 24 releases:
- `googleapis/release-please-action` v4 → **v5** (the only "breaking change" in v5 is the Node bump; manifest-mode inputs are unchanged)
- `actions/checkout` v4 → **v6**
- `actions/setup-go` v5 → **v6**

## Test plan
- [x] No config schema changes — v5 release-please reads the same `release-please-config.json` + `.release-please-manifest.json`
- [ ] CI run on this PR passes (Go build + tests on Node 24 runners)
- [ ] Release-please run on master after merge cleanly produces a release PR if/when there are bumpable commits