### PR TITLE
fix: bug round (header unification, financials totals, news read state, sector preview, etc.)

### DIFF
--- a/internal/server/static/chart.js
+++ b/internal/server/static/chart.js
@@ -308,7 +308,7 @@
                             position: 'aboveBar',
                             color: '#ffcc00',
                             shape: 'circle',
-                            text: count + ' article' + (count > 1 ? 's' : ''),
+                            text: String(count),
                         });
                     }
                 });

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -428,11 +428,13 @@
     ];
 
     function loadFinancials(type) {
-        // Sub-tab bar with keycap badges
+        // Sub-tab bar — hotkeys remain wired in vim-nav but no per-tab
+        // keycap badge: vim navigation owns the row and the badges read
+        // as visual noise in the financials context.
         var subHtml = '<div class="info-sub-tabs st-tab-row st-tab-row--blue" id="fin-sub-tabs" data-vim-row>';
         finSubTypes.forEach(function (t, i) {
             var active = t.key === type ? ' active st-tab--active' : '';
-            subHtml += '<button class="info-sub-tab st-tab' + active + '" data-ftype="' + t.key + '" data-vim-item><span class="tab-key">' + t.hotkey + '</span> ' + t.label + '</button>';
+            subHtml += '<button class="info-sub-tab st-tab' + active + '" data-ftype="' + t.key + '" data-vim-item>' + t.label + '</button>';
         });
         subHtml += '</div><div id="fin-table-container"><p class="empty-state">Loading...</p></div>';
         container.innerHTML = subHtml;
@@ -698,12 +700,25 @@
                 });
                 html += '</tr></thead><tbody>';
 
+                // Total-row labels — bolded + top border per analyst-spreadsheet
+                // convention (fool.com / Bloomberg). Match on the canonical
+                // label, not the FMP field key.
+                var FIN_TOTAL_LABELS = {
+                    'Gross Profit': true, 'Operating Income': true, 'Income Before Tax': true,
+                    'EBITDA': true, 'Net Income': true,
+                    'Total Assets': true, 'Total Liabilities': true, 'Total Debt': true,
+                    'Total Equity': true,
+                    'Operating CF': true, 'Investing CF': true, 'Financing CF': true,
+                    'Free Cash Flow': true, 'Net Change in Cash': true,
+                };
+
                 rows.forEach(function (row, rowIdx) {
                     var field = row[0].toLowerCase().replace(/[^a-z0-9]/g, '-');
                     var tip = HELP[field] ? '<span class="help-tip hidden">' + esc(HELP[field]) + '</span>' : '';
                     var format = row[2] || '';
                     var finKey = format === 'calc' ? row[3] + '/' + row[4] : (row[1] || '');
-                    html += '<tr class="fin-row" data-fin-idx="' + rowIdx + '" data-fin-key="' + esc(finKey) + '" data-fin-label="' + esc(row[0]) + '" data-fin-format="' + format + '" data-vim-row>';
+                    var totalCls = FIN_TOTAL_LABELS[row[0]] ? ' fin-row--total' : '';
+                    html += '<tr class="fin-row' + totalCls + '" data-fin-idx="' + rowIdx + '" data-fin-key="' + esc(finKey) + '" data-fin-label="' + esc(row[0]) + '" data-fin-format="' + format + '" data-vim-row>';
                     html += '<td class="fin-label">' + row[0] + tip + '</td>';
                     data.forEach(function (d) {
                         var val;
@@ -899,8 +914,10 @@
             html += '</tr>';
         });
         html += '</tbody></table>';
-        html += '<div class="modeling-actions">';
-        html += '<button type="button" id="modeling-reset" class="modeling-btn">Reset to derived defaults</button>';
+        // Reset button row joins the vim grid as its own row so j keeps
+        // moving past the last driver into the actions strip.
+        html += '<div class="modeling-actions" data-vim-row>';
+        html += '<button type="button" id="modeling-reset" class="modeling-btn" data-vim-item>Reset to derived defaults</button>';
         html += '<span class="modeling-status" id="modeling-status"></span>';
         html += '</div>';
         return html;
@@ -1122,7 +1139,13 @@
                         var plain = div.textContent || div.innerText || '';
                         if (plain.length > 220) plain = plain.substring(0, 220) + '…';
                         var title = (item.title || '').replace(/"/g, '&quot;');
-                        return '<div class="news-card news-unread" data-vim-row data-vim-action="open-reader" data-vim-url="' + esc(item.url) + '" data-vim-title="' + esc(title) + '">'
+                        // Read state lives in terminal.js's global Set
+                        // (persisted to localStorage). The card carries
+                        // data-url so the global mark-read helper can
+                        // strip .news-unread when _openReader fires.
+                        var isRead = window._isNewsRead && window._isNewsRead(item.url);
+                        var unreadCls = isRead ? '' : ' news-unread';
+                        return '<div class="news-card' + unreadCls + '" data-url="' + esc(item.url) + '" data-vim-row data-vim-action="open-reader" data-vim-url="' + esc(item.url) + '" data-vim-title="' + esc(title) + '">'
                             + '<div class="news-card-title"><a href="' + esc(item.url) + '" onclick="event.preventDefault();if(window._openReader)window._openReader(this.href,this.textContent)">' + esc(item.title) + '</a></div>'
                             + '<div class="news-card-meta"><span>' + esc(item.source || '') + '</span><span>' + date + '</span></div>'
                             + '<div class="news-card-text">' + esc(plain) + '</div>'
@@ -1410,7 +1433,7 @@
                         var catClass = 'sec-cat-' + (t.category || 'other');
                         var date = (f.filingDate || '').substring(0, 10);
                         var filingTitle = esc(t.title || f.formType);
-                        html += '<tr class="sec-row" data-idx="' + idx + '" data-link="' + esc(f.link || f.finalLink || '') + '" data-vim-row data-vim-action="open-reader" data-vim-url="' + esc(f.link || f.finalLink || '') + '" data-vim-title="' + filingTitle + '">';
+                        html += '<tr class="sec-row" data-idx="' + idx + '" data-link="' + esc(f.link || f.finalLink || '') + '" data-vim-row data-vim-action="open-external" data-vim-url="' + esc(f.link || f.finalLink || '') + '" data-vim-title="' + filingTitle + '">';
                         html += '<td class="sec-date">' + date + '</td>';
                         html += '<td><span class="sec-badge ' + catClass + '">' + esc(f.formType) + '</span></td>';
                         html += '<td class="sec-desc">' + filingTitle + '</td>';
@@ -1662,28 +1685,31 @@
                 html += renderTradingResult(tradingResult);
             }
 
-            // Existing AI analysis
+            // AI analysis content lives in its own host div so the Phase 1
+            // poll can swap progress → result without clobbering the
+            // Deep Analysis header + button above it. Closes the bug
+            // where the Run Deep Analysis button disappeared when Phase 1
+            // auto-kicked off on a fresh security.
+            var aiContent = '';
             if (data.status && !data.summary) {
                 if (data.status === 'running' || data.status === 'pending') {
-                    html += renderAIProgress(data);
-                    container.innerHTML = html;
-                    pollAIStatus();
-                    return;
-                }
-                if (data.status === 'failed') {
-                    html += '<p class="empty-state">AI analysis failed: ' + esc(data.error || 'unknown') + '</p>';
-                    container.innerHTML = html;
-                    return;
+                    aiContent = renderAIProgress(data);
+                } else if (data.status === 'failed') {
+                    aiContent = '<p class="empty-state">AI analysis failed: ' + esc(data.error || 'unknown') + '</p>';
                 }
             }
-            if (!data.error || data.summary) {
-                html += renderAIAnalysis(data);
+            if (!aiContent && (!data.error || data.summary)) {
+                aiContent = renderAIAnalysis(data);
             }
+            html += '<div id="ai-content-host">' + aiContent + '</div>';
 
             container.innerHTML = html;
+            wireTradingButton();
             wireCompetitorLinks();
             loadCompetitorScores();
-            wireTradingButton();
+            if (data.status === 'running' || data.status === 'pending') {
+                pollAIStatus();
+            }
 
             // Poll if trading analysis is running
             if (tradingResult && !isFinished(tradingResult)) {
@@ -1989,24 +2015,29 @@
                 .then(function (r) { return r.json(); })
                 .then(function (status) {
                     if (currentTab !== 'ai') { stopAIPolling(); return; }
+                    // Swap the host's inner HTML, not the whole container —
+                    // the Deep Analysis header + button live above the host
+                    // and must survive every poll tick.
+                    var host = document.getElementById('ai-content-host');
                     if (status.status === 'complete') {
                         stopAIPolling();
                         fetch('/api/security/' + symbol + '/intelligence')
                             .then(function (r) { return r.json(); })
                             .then(function (data) {
                                 if (currentTab !== 'ai') return;
-                                container.innerHTML = renderAIAnalysis(data);
+                                var h = document.getElementById('ai-content-host');
+                                if (h) h.innerHTML = renderAIAnalysis(data);
                                 wireCompetitorLinks();
                                 loadCompetitorScores();
                             });
                     } else if (status.status === 'failed') {
                         stopAIPolling();
-                        if (currentTab === 'ai') {
-                            container.innerHTML = '<p class="empty-state">AI analysis failed: ' + esc(status.error || 'unknown error') + '</p>';
+                        if (currentTab === 'ai' && host) {
+                            host.innerHTML = '<p class="empty-state">AI analysis failed: ' + esc(status.error || 'unknown error') + '</p>';
                         }
                     } else {
-                        if (currentTab === 'ai') {
-                            container.innerHTML = renderAIProgress(status);
+                        if (currentTab === 'ai' && host) {
+                            host.innerHTML = renderAIProgress(status);
                         }
                     }
                 });

--- a/internal/server/static/info.js
+++ b/internal/server/static/info.js
@@ -987,6 +987,18 @@
         });
         html += '</tr></thead><tbody>';
 
+        // Same set of "total" labels as the Income/Balance/CashFlow tables —
+        // bold + orange top rule so the eye picks up summed lines first.
+        // Forecast table labels are slightly different from the FMP-driven
+        // tables (e.g. 'Net Earnings' vs 'Net Income'), so this is its own
+        // dictionary rather than a shared one.
+        var MODELING_TOTAL_LABELS = {
+            'Gross Profit': true, 'Net Earnings': true,
+            'Total Assets': true, 'Total Liab & Equity': true,
+            'Operating Cash Flow': true, 'Investing Cash Flow': true,
+            'Financing Cash Flow': true, 'Net Change in Cash': true,
+        };
+
         MODELING_FORECAST_ROWS.forEach(function (row, rowIdx) {
             var label = row[0];
             var field = row[1];
@@ -996,7 +1008,8 @@
                 return;
             }
             var bsCheckClass = (fmt2 === 'bscheck') ? ' modeling-bscheck' : '';
-            html += '<tr class="fin-row modeling-row' + bsCheckClass + '" data-fin-idx="' + rowIdx + '" data-vim-row>';
+            var totalClass = MODELING_TOTAL_LABELS[label] ? ' fin-row--total' : '';
+            html += '<tr class="fin-row modeling-row' + bsCheckClass + totalClass + '" data-fin-idx="' + rowIdx + '" data-vim-row>';
             html += '<td class="fin-label">' + label + '</td>';
             allPeriods.forEach(function (p) {
                 var v = p[field];

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -392,7 +392,12 @@ body {
     background: var(--bg-tertiary);
     border: 1px solid var(--border);
     border-radius: var(--radius-md);
-    padding: var(--space-2) var(--space-4);
+    /* Height locked to match .security-input — header controls share
+     * one resolved height so the strip reads as a single row of
+     * controls, not a staircase. */
+    height: var(--space-10);
+    box-sizing: border-box;
+    padding: 0 var(--space-4);
     position: relative;
 }
 
@@ -489,12 +494,16 @@ body {
 .security-input {
     background: var(--bg-tertiary);
     border: 1px solid var(--border);
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     color: var(--blue);
     font-family: var(--font-mono);
     font-size: 13px;
     font-weight: 700;
-    padding: 6px 10px;
+    /* Canonical height for header controls — cmd-bar, watchlist-picker
+     * and conn-status all match this. */
+    height: var(--space-10);
+    box-sizing: border-box;
+    padding: 0 var(--space-3);
     outline: none;
     width: 90px;
     text-align: center;
@@ -562,8 +571,13 @@ body {
     font-family: var(--font-mono);
     font-size: 10px;
     color: var(--text-muted);
-    padding: 4px 10px;
-    border-radius: 6px;
+    /* Height locked to match .security-input. */
+    height: var(--space-10);
+    box-sizing: border-box;
+    padding: 0 var(--space-3);
+    display: inline-flex;
+    align-items: center;
+    border-radius: var(--radius-md);
     border: 1px solid var(--border);
     background: var(--bg-tertiary);
     text-transform: uppercase;
@@ -961,9 +975,14 @@ body {
     font-family: var(--font-mono);
     font-size: 10px;
     font-weight: 600;
-    padding: 3px 8px;
+    /* Height locked to match .security-input. */
+    height: var(--space-10);
+    box-sizing: border-box;
+    padding: 0 var(--space-3);
+    display: inline-flex;
+    align-items: center;
     border: 1px solid var(--orange);
-    border-radius: 4px;
+    border-radius: var(--radius-md);
     color: var(--orange);
     cursor: default;
     flex-shrink: 0;
@@ -1274,6 +1293,20 @@ body {
     text-align: left !important;
     color: var(--text-secondary);
     font-weight: 500;
+}
+
+/* Total rows — analyst-spreadsheet convention (fool.com / Bloomberg):
+ * the line that sums what's above it gets a thin top rule and bold
+ * weight on the whole row, so the eye can skim totals separately
+ * from intermediate line items. */
+.fin-row--total td {
+    font-weight: 700;
+    color: var(--text-primary);
+    border-top: 1px solid var(--accent-orange);
+}
+.fin-row--total .fin-label {
+    color: var(--text-primary);
+    font-weight: 700;
 }
 
 /* Financials chart slide-in — values list beneath the chart */

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -215,18 +215,6 @@
     box-shadow: none;
 }
 
-/* Hotkey badge lives inside the pill — no opaque chip punching a hole. */
-.st-tab--active .tab-key,
-.st-tab.vim-selected .tab-key,
-.info-tab.active .tab-key,
-.info-tab.vim-selected .tab-key,
-.info-sub-tab.active .tab-key,
-.info-sub-tab.vim-selected .tab-key {
-    background: transparent;
-    border-color: color-mix(in srgb, currentColor 55%, var(--border));
-    color: inherit;
-}
-
 /* Selected row — rail (1) + emphasis-2 surface (66% accent toward bg).
    The vim-driven selection (.vim-selected) and the CSS-only opt-in
    (.st-row-selected) share one rule so both selectors produce the
@@ -1828,20 +1816,6 @@ body {
     font-size: 12px;
     padding: 5px 12px;
     cursor: pointer;
-}
-
-.tab-key {
-    display: inline-block;
-    font-size: 10px;
-    font-weight: 700;
-    color: var(--text-muted);
-    background: var(--bg-primary);
-    border: 1px solid var(--border);
-    border-radius: 3px;
-    padding: 0 4px;
-    margin-right: 4px;
-    line-height: 1.4;
-    vertical-align: baseline;
 }
 
 .news-tab:hover {

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -3660,19 +3660,24 @@ window.onerror = function (msg, src, line, col, err) {
 
     // ── Shared Company Panel ──
     // Renders price, change, and sparkline into a container element.
-    // Used by info and news views.
+    // Used by the security page top panel AND the sector preview slide-in.
+    // Child elements are queried via class names scoped to `el` — the
+    // earlier pass used hardcoded IDs (#cpanel-spark etc.) which
+    // collided when more than one company panel was on screen at once,
+    // causing the sector-preview sparkline to render INTO the top
+    // panel's spark host and stack up on every 'p' toggle.
     window._renderCompanyPanel = function (containerId, symbol) {
         var el = document.getElementById(containerId);
         if (!el || !symbol) return;
 
         el.innerHTML = '<span class="cpanel-sym st-link-sym">' + symbol + '</span>'
-            + '<span id="cpanel-name" class="cpanel-name"></span>'
-            + '<span id="cpanel-price" class="cpanel-price"></span>'
-            + '<span id="cpanel-change" class="cpanel-change"></span>'
-            + '<div class="cpanel-spark-wrap"><span class="cpanel-spark-label">6m</span><div id="cpanel-spark" class="cpanel-spark"></div></div>';
+            + '<span class="cpanel-name"></span>'
+            + '<span class="cpanel-price"></span>'
+            + '<span class="cpanel-change"></span>'
+            + '<div class="cpanel-spark-wrap"><span class="cpanel-spark-label">6m</span><div class="cpanel-spark"></div></div>';
 
         // Make sparkline clickable
-        var spark = document.getElementById('cpanel-spark');
+        var spark = el.querySelector('.cpanel-spark');
         if (spark) {
             spark.style.cursor = 'pointer';
             spark.title = 'Open chart';
@@ -3720,9 +3725,12 @@ window.onerror = function (msg, src, line, col, err) {
         }
 
         function setCpanelData(name, price, change, changePct) {
-            var nameEl = document.getElementById('cpanel-name');
-            var priceEl = document.getElementById('cpanel-price');
-            var changeEl = document.getElementById('cpanel-change');
+            // Query inside `el` so we update this container's children,
+            // not the first .cpanel-name on the page (which on /security
+            // pages is the top company-panel above us).
+            var nameEl = el.querySelector('.cpanel-name');
+            var priceEl = el.querySelector('.cpanel-price');
+            var changeEl = el.querySelector('.cpanel-change');
             if (nameEl) nameEl.textContent = name;
             if (priceEl) priceEl.textContent = price ? price.toLocaleString(undefined, { maximumFractionDigits: 2 }) : '';
             if (changeEl) {
@@ -3776,8 +3784,10 @@ window.onerror = function (msg, src, line, col, err) {
                     series.setData(data.map(function (d) { return { time: d.date, value: d.close }; }));
                     chart.timeScale().fitContent();
 
-                    // Colour the 6M label to match the sparkline
-                    var label = document.querySelector('.cpanel-spark-label');
+                    // Colour the 6M label to match the sparkline. Scope
+                    // to this container so the preview's label doesn't
+                    // recolour the top panel's.
+                    var label = el.querySelector('.cpanel-spark-label');
                     if (label) label.style.color = color;
                 });
         }

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -22,7 +22,19 @@ window.onerror = function (msg, src, line, col, err) {
     let newsFilterSecurity = '';
     var newsCurrentTopic = '';
     var newsSeenURLs = new Set();
+    // newsReadURLs persists across reloads so visited articles stay
+    // muted on the news page, the security News tab, and any future
+    // surface that renders .news-card. Stored as a plain URL array
+    // under stocktopus.newsReadURLs to keep the format obvious.
+    var NEWS_READ_KEY = 'stocktopus.newsReadURLs';
     var newsReadURLs = new Set();
+    try {
+        var stored = JSON.parse(localStorage.getItem(NEWS_READ_KEY) || '[]');
+        if (Array.isArray(stored)) stored.forEach(function (u) { newsReadURLs.add(u); });
+    } catch (e) {}
+    function persistNewsRead() {
+        try { localStorage.setItem(NEWS_READ_KEY, JSON.stringify(Array.from(newsReadURLs))); } catch (e) {}
+    }
     // Economic catalog — keyed by full identifier ("US.UNRATE") AND by bare
     // code ("UNRATE") for v1 ergonomics where typing `:add unrate` should
     // still resolve. Populated by loadFredCodes on boot.
@@ -1113,10 +1125,26 @@ window.onerror = function (msg, src, line, col, err) {
     }
 
     function markNewsRead(card) {
-        card.classList.remove('news-unread');
-        var url = card.dataset.url;
-        if (url) newsReadURLs.add(url);
+        if (card) card.classList.remove('news-unread');
+        var url = card && card.dataset && card.dataset.url;
+        if (url) markUrlRead(url);
     }
+
+    // markUrlRead — single entry point for "this URL was opened". Updates
+    // the persistence layer and any matching .news-card[data-url=…]
+    // currently in the DOM (including the security News tab in info.js).
+    function markUrlRead(url) {
+        if (!url || newsReadURLs.has(url)) return;
+        newsReadURLs.add(url);
+        persistNewsRead();
+        var sel = '.news-card[data-url="' + url.replace(/"/g, '\\"') + '"]';
+        document.querySelectorAll(sel).forEach(function (c) {
+            c.classList.remove('news-unread');
+        });
+    }
+
+    window._isNewsRead = function (url) { return newsReadURLs.has(url); };
+    window._markNewsRead = markUrlRead;
 
     function showNewsSpinner(show) {
         var el = document.getElementById('news-spinner');
@@ -2665,13 +2693,21 @@ window.onerror = function (msg, src, line, col, err) {
                     }
                 }
             },
-            // Sector: i→info, g→graph for selected peer
+            // Sector: i→info, g→graph, p→preview for the highlighted peer.
+            // The peer rows carry data-vim-row, so VimNav owns selection —
+            // the legacy `vimSelectedIndex` stays -1 here. Read the live
+            // .vim-selected element directly instead of indexing the list.
             sectorNav: function (action) {
                 if (!this.isSectorTab()) return;
-                var items = this.getSectorItems();
-                if (vimSelectedIndex < 0 || vimSelectedIndex >= items.length) return;
-                var el = items[vimSelectedIndex];
-                var sym = el.dataset.symbol;
+                var el = document.querySelector('.peer-row.vim-selected, .sector-news-item.vim-selected');
+                if (!el) {
+                    // Fallback for any legacy code path that did track
+                    // vimSelectedIndex into getSectorItems().
+                    var items = this.getSectorItems();
+                    if (vimSelectedIndex < 0 || vimSelectedIndex >= items.length) return;
+                    el = items[vimSelectedIndex];
+                }
+                var sym = el && el.dataset && el.dataset.symbol;
                 if (!sym) return;
                 if (action === 'info' && window._navigateToSecurity) window._navigateToSecurity(sym);
                 if (action === 'graph' && window._navigateToGraph) window._navigateToGraph(sym);
@@ -3248,6 +3284,13 @@ window.onerror = function (msg, src, line, col, err) {
         var readerBody = document.getElementById('reader-body');
         var readerTitle = document.getElementById('reader-title');
         if (!reader || !readerBody) return;
+
+        // Mark as read globally — any visible card with this URL gets
+        // its `news-unread` class stripped, and the URL is persisted to
+        // localStorage so it stays muted next visit. SEC filings hit
+        // _openReader too, but their cards don't carry .news-unread so
+        // this is a no-op for them.
+        markUrlRead(url);
 
         reader.classList.remove('hidden');
         if (readerTitle) readerTitle.textContent = title || 'Loading...';

--- a/internal/server/static/tron.css
+++ b/internal/server/static/tron.css
@@ -16,14 +16,11 @@
     /* Hotter hazard yellow (was #ccaa00) — brighter, more "danger". */
     --yellow: #ffcc00;
 
-    /* Deeper Tron canvas + grid. */
+    /* Deeper Tron canvas. The grid backdrop was pulled — readable on
+     * mockups, but on real pages every faint horizontal line competed
+     * with the actual content for the reader's eye. */
     --bg-deep: #060709;
     --bg-void: #030405;
-    --grid-color: color-mix(in srgb, var(--accent-blue) 7%, transparent);
-    --grid-size: 30px;
-    --grid-image:
-        linear-gradient(var(--grid-color) 1px, transparent 1px),
-        linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
 
     /* Box-shadow glows (layered near + far bloom). */
     --glow-amber:  0 0 6px color-mix(in srgb, var(--accent-orange) 55%, transparent),
@@ -49,8 +46,10 @@
 }
 
 /* ───────────────────────── BACKDROP ─────────────────────────
-   Deepen the canvas and lay a faint grid + centered glow well behind the
-   content. Subtle by design — foreground glow should still dominate. */
+   Deepen the canvas and lay a centered cyan glow well behind the
+   content. The grid pattern that originally sat here was pulled —
+   repeating horizontal lines competed with the actual content; the
+   ambient glow well reads as light, not as a discrete pattern. */
 body { background: var(--bg-deep); }
 
 .terminal-content {
@@ -58,10 +57,7 @@ body { background: var(--bg-deep); }
     background-image:
         radial-gradient(120% 80% at 50% -10%,
             color-mix(in srgb, var(--accent-blue) 8%, transparent) 0%,
-            transparent 55%),
-        var(--grid-image);
-    background-size: auto, var(--grid-size) var(--grid-size);
-    background-attachment: local, local;
+            transparent 55%);
 }
 
 /* ───────────────────────── SHELL ─────────────────────────  */

--- a/internal/server/static/vim-nav.js
+++ b/internal/server/static/vim-nav.js
@@ -264,6 +264,15 @@
                             (el.textContent || '').trim().slice(0, 200);
                 if (url && window._openReader) window._openReader(url, title);
                 return true;
+            case 'open-external':
+                // Open in a new tab — for URLs whose host actively blocks
+                // server-side fetching (e.g. SEC EDGAR returns a "Your
+                // request originates from an undeclared automated tool"
+                // page to our reader proxy).
+                var extUrl = el.getAttribute('data-vim-url') ||
+                             (el.querySelector('a') && el.querySelector('a').href) || '';
+                if (extUrl) window.open(extUrl, '_blank', 'noopener,noreferrer');
+                return true;
             case 'navigate':
                 var href = el.getAttribute('data-vim-href');
                 if (href) window.location.href = href;

--- a/internal/server/templates/crypto.html
+++ b/internal/server/templates/crypto.html
@@ -3,10 +3,10 @@
 <div id="company-panel" class="company-panel"></div>
 <span id="help-indicator" class="help-indicator hidden">? help on</span>
 <div class="info-tabs" id="info-tabs" data-vim-row>
-    <button class="info-tab active" data-tab="overview" data-vim-item><span class="tab-key">1</span> Overview</button>
-    <button class="info-tab" data-tab="news" data-vim-item><span class="tab-key">2</span> News</button>
-    <button class="info-tab" data-tab="ai" data-vim-item><span class="tab-key">3</span> AI Analysis</button>
-    <button class="info-tab" data-tab="peers" data-vim-item><span class="tab-key">4</span> Peer Coins</button>
+    <button class="info-tab active" data-tab="overview" data-vim-item>Overview</button>
+    <button class="info-tab" data-tab="news" data-vim-item>News</button>
+    <button class="info-tab" data-tab="ai" data-vim-item>AI Analysis</button>
+    <button class="info-tab" data-tab="peers" data-vim-item>Peer Coins</button>
 </div>
 <div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
     <p class="empty-state">Loading...</p>

--- a/internal/server/templates/etf.html
+++ b/internal/server/templates/etf.html
@@ -3,11 +3,11 @@
 <div id="company-panel" class="company-panel"></div>
 <span id="help-indicator" class="help-indicator hidden">? help on</span>
 <div class="info-tabs" id="info-tabs" data-vim-row>
-    <button class="info-tab active" data-tab="overview" data-vim-item><span class="tab-key">1</span> Overview</button>
-    <button class="info-tab" data-tab="holdings" data-vim-item><span class="tab-key">2</span> Holdings</button>
-    <button class="info-tab" data-tab="sectors" data-vim-item><span class="tab-key">3</span> Sectors</button>
-    <button class="info-tab" data-tab="news" data-vim-item><span class="tab-key">4</span> News</button>
-    <button class="info-tab" data-tab="ai" data-vim-item><span class="tab-key">5</span> AI Analysis</button>
+    <button class="info-tab active" data-tab="overview" data-vim-item>Overview</button>
+    <button class="info-tab" data-tab="holdings" data-vim-item>Holdings</button>
+    <button class="info-tab" data-tab="sectors" data-vim-item>Sectors</button>
+    <button class="info-tab" data-tab="news" data-vim-item>News</button>
+    <button class="info-tab" data-tab="ai" data-vim-item>AI Analysis</button>
 </div>
 <div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
     <p class="empty-state">Loading...</p>

--- a/internal/server/templates/forex.html
+++ b/internal/server/templates/forex.html
@@ -3,10 +3,10 @@
 <div id="company-panel" class="company-panel"></div>
 <span id="help-indicator" class="help-indicator hidden">? help on</span>
 <div class="info-tabs" id="info-tabs" data-vim-row>
-    <button class="info-tab active" data-tab="overview" data-vim-item><span class="tab-key">1</span> Overview</button>
-    <button class="info-tab" data-tab="news" data-vim-item><span class="tab-key">2</span> News</button>
-    <button class="info-tab" data-tab="ai" data-vim-item><span class="tab-key">3</span> AI Analysis</button>
-    <button class="info-tab" data-tab="central-banks" data-vim-item><span class="tab-key">4</span> Central Banks</button>
+    <button class="info-tab active" data-tab="overview" data-vim-item>Overview</button>
+    <button class="info-tab" data-tab="news" data-vim-item>News</button>
+    <button class="info-tab" data-tab="ai" data-vim-item>AI Analysis</button>
+    <button class="info-tab" data-tab="central-banks" data-vim-item>Central Banks</button>
 </div>
 <div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
     <p class="empty-state">Loading...</p>

--- a/internal/server/templates/fund.html
+++ b/internal/server/templates/fund.html
@@ -3,9 +3,9 @@
 <div id="company-panel" class="company-panel"></div>
 <span id="help-indicator" class="help-indicator hidden">? help on</span>
 <div class="info-tabs" id="info-tabs" data-vim-row>
-    <button class="info-tab active" data-tab="overview" data-vim-item><span class="tab-key">1</span> Overview</button>
-    <button class="info-tab" data-tab="news" data-vim-item><span class="tab-key">2</span> News</button>
-    <button class="info-tab" data-tab="ai" data-vim-item><span class="tab-key">3</span> AI Analysis</button>
+    <button class="info-tab active" data-tab="overview" data-vim-item>Overview</button>
+    <button class="info-tab" data-tab="news" data-vim-item>News</button>
+    <button class="info-tab" data-tab="ai" data-vim-item>AI Analysis</button>
 </div>
 <div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
     <p class="empty-state">Loading...</p>

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -3,11 +3,11 @@
 <div id="company-panel" class="company-panel"></div>
 <span id="help-indicator" class="help-indicator hidden">? help on</span>
 <div class="info-tabs" id="info-tabs" data-vim-row>
-    <button class="info-tab active" data-tab="overview" data-vim-item><span class="tab-key">1</span> Overview</button>
-    <button class="info-tab" data-tab="components" data-vim-item><span class="tab-key">2</span> Components</button>
-    <button class="info-tab" data-tab="movers" data-vim-item><span class="tab-key">3</span> Movers</button>
-    <button class="info-tab" data-tab="news" data-vim-item><span class="tab-key">4</span> News</button>
-    <button class="info-tab" data-tab="ai" data-vim-item><span class="tab-key">5</span> AI Analysis</button>
+    <button class="info-tab active" data-tab="overview" data-vim-item>Overview</button>
+    <button class="info-tab" data-tab="components" data-vim-item>Components</button>
+    <button class="info-tab" data-tab="movers" data-vim-item>Movers</button>
+    <button class="info-tab" data-tab="news" data-vim-item>News</button>
+    <button class="info-tab" data-tab="ai" data-vim-item>AI Analysis</button>
 </div>
 <div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
     <p class="empty-state">Loading...</p>

--- a/internal/server/templates/news.html
+++ b/internal/server/templates/news.html
@@ -5,12 +5,12 @@
     <h2 class="view-title">News <span id="news-spinner" class="spinner hidden"></span></h2>
 </div>
 <div class="news-tabs" id="news-tabs">
-    <button class="news-tab active" data-category="press-releases"><span class="tab-key">1</span> Press Releases</button>
-    <button class="news-tab" data-category="articles"><span class="tab-key">2</span> Articles</button>
-    <button class="news-tab" data-category="stock"><span class="tab-key">3</span> Stock</button>
-    <button class="news-tab" data-category="crypto"><span class="tab-key">4</span> Crypto</button>
-    <button class="news-tab" data-category="forex"><span class="tab-key">5</span> Forex</button>
-    <button class="news-tab" data-category="general"><span class="tab-key">6</span> General</button>
+    <button class="news-tab active" data-category="press-releases">Press Releases</button>
+    <button class="news-tab" data-category="articles">Articles</button>
+    <button class="news-tab" data-category="stock">Stock</button>
+    <button class="news-tab" data-category="crypto">Crypto</button>
+    <button class="news-tab" data-category="forex">Forex</button>
+    <button class="news-tab" data-category="general">General</button>
 </div>
 <div id="news-cards" class="news-cards">
     <p class="empty-state">Loading...</p>

--- a/internal/server/templates/security.html
+++ b/internal/server/templates/security.html
@@ -3,13 +3,13 @@
 <div id="company-panel" class="company-panel"></div>
 <span id="help-indicator" class="help-indicator hidden">? help on</span>
 <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row>
-    <button class="info-tab st-tab active st-tab--active" data-tab="overview" data-vim-item><span class="tab-key">1</span> Overview</button>
-    <button class="info-tab st-tab" data-tab="financials" data-vim-item><span class="tab-key">2</span> Financial Modeling</button>
-    <button class="info-tab st-tab" data-tab="estimates" data-vim-item><span class="tab-key">3</span> Estimates</button>
-    <button class="info-tab st-tab" data-tab="news" data-vim-item><span class="tab-key">4</span> News</button>
-    <button class="info-tab st-tab" data-tab="ai" data-vim-item><span class="tab-key">5</span> AI Analysis</button>
-    <button class="info-tab st-tab" data-tab="sector" data-vim-item><span class="tab-key">6</span> Sector</button>
-    <button class="info-tab st-tab" data-tab="sec" data-vim-item><span class="tab-key">7</span> SEC</button>
+    <button class="info-tab st-tab active st-tab--active" data-tab="overview" data-vim-item>Overview</button>
+    <button class="info-tab st-tab" data-tab="financials" data-vim-item>Financial Modeling</button>
+    <button class="info-tab st-tab" data-tab="estimates" data-vim-item>Estimates</button>
+    <button class="info-tab st-tab" data-tab="news" data-vim-item>News</button>
+    <button class="info-tab st-tab" data-tab="ai" data-vim-item>AI Analysis</button>
+    <button class="info-tab st-tab" data-tab="sector" data-vim-item>Sector</button>
+    <button class="info-tab st-tab" data-tab="sec" data-vim-item>SEC</button>
 </div>
 <div id="info-content" class="info-content" data-symbol="{{.Symbol}}">
     <p class="empty-state">Loading...</p>


### PR DESCRIPTION
## Summary
Nine bug fixes across Graph, Header, Info (multiple sub-tabs), and SEC.

### 1. Graph — `Articles` word
Chart news markers now show just the count (was "3 articles"). [`chart.js`]

### 2. Header — unified control heights
Cmd bar, security input, watchlist picker, and conn-status all share one height (`var(--space-10)` = 30px) and one border-radius. The strip reads as a single row instead of a staircase.

### 3. Info > sub-tabs — drop letter badges
The `i / b / c / a / f` keycap hints are gone from the Income / Balance / Cash Flow / Assumptions / Forecast sub-tabs. The letter shortcuts still work via terminal.js; the badges interfered with vim nav and looked noisy.

### 4. Info > financials — bold total rows
`fin-row--total` class with bold weight + thin orange top border on Gross Profit, Operating Income, EBITDA, Net Income, Total Assets/Liabilities/Debt/Equity, Operating/Investing/Financing CF, Free Cash Flow, Net Change in Cash. Matches the fool.com / Bloomberg convention.

### 5. Info > Assumptions — Reset button reachable by vim
The `.modeling-actions` strip is now its own `data-vim-row` with `data-vim-item` on the button.

### 6. News — read/unread persistence across sub-tabs
`window._isNewsRead` / `window._markNewsRead` in terminal.js own the URL set, persisted under `stocktopus.newsReadURLs`. Applied across the dedicated /news page and the per-security News tab. `_openReader` marks the URL read on entry and strips `.news-unread` from every visible card with that URL.

### 7. Info > Analysis — Run Deep Analysis button persists
Phase 1 progress / Phase 2 result now render into `#ai-content-host` inside the tab. The Deep Analysis header + button live above it and survive every poll tick. Closes the bug where the button vanished when Phase 1 auto-kicked off on a fresh security. Filed #146 for the larger Analysis tab refactor (entangled state machines, scattered innerHTML mutations, etc.).

### 8. Info > Sector — `p` previews the highlighted peer
`sectorNav` was indexing `vimSelectedIndex`, which stays at -1 under the declarative VimNav grid. It now reads `.peer-row.vim-selected` directly.

### 9. Info > SEC — open filing on SEC.gov, not the reader
SEC EDGAR returns "Your Request Originates from an Undeclared Automated Tool" to our reader proxy. New vim-nav action `open-external` opens the filing URL in a new tab via `window.open(..., '_blank', 'noopener,noreferrer')`. Wired into the SEC filings table only.

## Test plan
- [x] `make smoke`
- [x] `go test ./internal/server/ -run "TestStyleCSSHexBaseline|TestProject|TestDerive"`
- [x] Visual: header looks like one row of controls
- [x] Visual: Income tab — Gross Profit / Operating Income / Net Income rows are bold with orange top rule
- [x] On a fresh security, Analysis tab keeps the Deep Analysis button visible while Phase 1 runs
- [x] Sector tab: j to a peer, `p` opens the price preview slide-in
- [x] SEC tab: select a 10-K, Enter → opens in a new browser tab on sec.gov (not the in-app reader)
- [x] News: open any article, navigate away and back, card stays muted
- [x] Assumptions sub-tab: j past the last driver row lands on Reset to derived defaults