### PR TITLE
Unify news primary nav and design previews

### DIFF
--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -221,6 +221,17 @@ Add a dedicated section in `style.css` (e.g. `/* ── Design system primitives
 
 **Maps from:** `.info-tab`, `.info-sub-tab`, `.st-tab`, `.chart-range-btn` (when dual-written).
 
+**News navigation — two contexts:**
+
+| Context | Route / shell | Category filters | Chrome |
+|---------|---------------|------------------|--------|
+| **Full-page news** | `GET /news` (`news.html`) | `.news-tabs.info-tabs` inside `.info-panel` | **Primary** orange info-panel nav — same contract as `.info-panel > .info-tabs` on security (row bleed, orange active underline, `::before` pill) |
+| **Security → News tab** | Info panel on `/` | `.info-sub-tabs.news-sub-tabs` inside `#info-content` | **Sub** nav — cyan blue band, bottom underline, upward bleed; sits under orange Overview / Financials / … primary row |
+
+On `/news`, category buttons use `.news-tab.info-tab` (dual-classed for shared primary-tab CSS). Do **not** use `.news-sub-tabs` on the full-page view — that pattern is only for the in-panel News tab on a security.
+
+Template: `internal/server/templates/news.html`. Previews: `preview-news-page.html` (full page) vs `preview-news.html` / `preview-avgo-news.html` (security sub-tabs).
+
 ### 4.2 Table row selection
 
 ```css
@@ -413,7 +424,8 @@ Use for all signed numeric columns (watchlist changes, screener Δ columns, etc.
 | **Shell** | `.terminal-header`, `.terminal-footer`, `.cmd-bar`, `.brand` | Orange brand text; cmd-bar focus = orange line; footer mode = `st-chip` semantic |
 | **Watchlist** | `.watchlist`, `.quote-table`, `.wl-tab`, `.wl-spark-cell` | `st-table`, `st-link-sym`, `st-tab` for tabs; market colors for deltas; 6M sparkline label uses `price-up`/`price-down` |
 | **Graph** | `.chart-range-bar`, `.chart-range-btn`, `.chart-toggle`, `.chart-container` | `st-tab` for range buttons; toggles: green only when “on” |
-| **Info** | `.info-panel`, `.info-tabs`, `.info-sub-tabs`, `.company-panel`, peer/SEC tables | Blue menu band on all nav strips; `st-row-selected` on tables |
+| **Info** | `.info-panel`, `.info-tabs`, `.info-sub-tabs`, `.company-panel`, peer/SEC tables | Blue menu band on sub strips; orange primary; `st-row-selected` on tables |
+| **News** | `/news`: `.info-panel`, `.news-tabs`, `.news-cards`; security News tab: `.news-sub-tabs` | Full page: category filters = primary `.info-tabs`; in-panel: cyan `.news-sub-tabs` under orange primary |
 | **Ideas** | `.ideas-layout`, `.ideas-sidebar`, `.ideas-main`, `.ideas-chart-host` | `st-pane-active`; chart series colors = token orange/blue; legend swatches match |
 | **Screener** | `.screener-layout`, `.screener-filters`, `#screener-table` | `st-input`, `st-section-title`, `st-pane-active`, `st-row-selected`, `price-up`/`price-down` on Δ columns |
 | **Economics** | `.economics-layout`, `.economics-tab` | `st-tab` / `st-tab-row` |
@@ -501,6 +513,12 @@ Use for all signed numeric columns (watchlist changes, screener Δ columns, etc.
 
 ### Economics
 - [ ] Tabs identical to Info primary tabs.
+
+### News
+- [ ] `/news`: `.info-panel` wraps `.news-tabs.info-tabs` — category tabs use **primary** orange nav (not `.news-sub-tabs`).
+- [ ] Security → News tab: orange primary row unchanged; categories in `.news-sub-tabs` with cyan sub-nav chrome.
+- [ ] Unread cards: orange left rail on `.news-card.news-unread`.
+- [ ] Previews `preview-news-page.html` vs `preview-news.html` match the two nav contexts.
 
 ---
 

--- a/docs/design-system-export/README.md
+++ b/docs/design-system-export/README.md
@@ -22,11 +22,47 @@ Source: `Stocktopus Design System (3).zip` (2026-06-21). Static preview pages + 
 
 ## View locally
 
+Static previews under `production/` all use the **Live + Tron** stack:
+
+| Stack | Link order |
+|-------|------------|
+| **Live + Tron** | 1. `../../../internal/server/static/style.css` (live base) → 2. `tron.css` (`id="tron"`, glow overlay) |
+
+`_real-style.css` remains in the kit as a frozen snapshot for diffing only — no preview links it.
+
+Previews with a **tron ON/OFF** button disable the second `<link>` for A/B comparison. Open a `preview-*.html` file directly in the browser, or use a static file server if you prefer.
+
+**Authoritative check:** run the app and verify in-browser — not a separate Python static server:
+
 ```bash
-cd docs/design-system-export/production
-python3 -m http.server 8765
-# open http://localhost:8765/preview-avgo-overview.html
+make dev
+# open http://localhost:8080/news  (full-page news)
+# open http://localhost:8080/      (security info → News tab for sub-tab layout)
 ```
+
+## Keeping previews current
+
+When you change news or info-panel templates, tab markup, or nav rules in [`style.css`](../../../internal/server/static/style.css):
+
+1. Update the matching `preview-*.html` under `production/` so classes and DOM structure mirror the live template.
+2. Keep the **live + Tron** stack for news previews: live `style.css` first, then `tron.css` (see table above). Do not snapshot CSS into the export kit unless intentionally capturing a point-in-time baseline.
+3. Verify with `make dev` at http://localhost:8080 (routes below), then spot-check the static preview if you edited one.
+
+| Preview | Live route / template | Nav pattern |
+|---------|----------------------|-------------|
+| `preview-news-page.html` | `GET /news` → `internal/server/templates/news.html` | `.info-panel` primary nav — `.news-tabs.info-tabs` (orange) |
+| `preview-news.html` | Security page → Info → News tab (`info.js`) | Orange `.info-tabs` + cyan `.news-sub-tabs` |
+| `preview-avgo-news.html` | Same as above (AVGO mock, numbered tab keys) | Orange primary + cyan `.news-sub-tabs` |
+| `preview-info.html` | Security info panel chrome | `.info-panel` primary + sub tabs |
+| `preview-overview.html` | Crypto security → Info → Overview (`crypto.html`) | `.info-panel` primary tabs |
+| `preview-avgo-overview.html` | Security → Info → Overview (AVGO) | Stat grid + chart + Key People / profile |
+| `preview-avgo-estimates.html` | Info → Estimates | Primary + table |
+| `preview-avgo-ai.html` | Info → AI Analysis | Primary + content band |
+| `preview-financials.html` | Info → Financial Modeling | Primary + fin table |
+| `preview-goog-sec.html` | Security page (GOOG) | Full info-panel composition |
+| `preview-graph.html` | `GET /{symbol}` chart → `stock.html` | `page-header` + `chart-range-bar` |
+| `preview-ideas.html` | `GET /ideas` | Two-pane + comparative chart |
+| `preview-screener.html` | `GET /screener` | Filters + results split |
 
 ## Live app vs this export
 
@@ -34,7 +70,7 @@ python3 -m http.server 8765
 |-------|------------|---------------------|
 | Tron layer | Separate `tron.css` | Merged at end of `style.css` |
 | Info nav | Orange numbered primary tabs; sub-tabs blue band | **Blue menu band** on primary + sub (`.info-panel`) |
-| Overview | Stat grid + 1:3 columns; no price chart in AVGO mock | Chart panel + same columns (`info.js`) |
+| Overview | Stat grid + chart + 1:3 columns (AVGO mock) | Chart panel + same columns (`info.js`) |
 | Spec doc | `INTEGRATION.md` + previews | `docs/design-language.md` |
 
 Structural items called out in `INTEGRATION.md` but **not** in CSS alone: `.st-tabfolder`, stat YoY comparison rows, contextual footer help map.

--- a/docs/design-system-export/production/_real-style.css
+++ b/docs/design-system-export/production/_real-style.css
@@ -2460,19 +2460,10 @@ body {
     text-align: left !important;
 }
 
-.idx-spark {
-    width: 80px;
-    height: 24px;
-}
-
 .idx-spark-selected {
     outline: 1px solid var(--orange);
     outline-offset: 1px;
     border-radius: 3px;
-}
-
-.idx-spark a[href*="tradingview"] {
-    display: none !important;
 }
 
 .idx-price {

--- a/docs/design-system-export/production/preview-avgo-ai.html
+++ b/docs/design-system-export/production/preview-avgo-ai.html
@@ -5,7 +5,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="_real-style.css">
+<!-- Live base — keep DOM/classes in sync with security.html + info.js AI tab -->
+<link rel="stylesheet" href="../../../internal/server/static/style.css">
 <link rel="stylesheet" href="tron.css" id="tron">
 <style>
   body{font-family:'Fira Code',var(--font-mono)}
@@ -36,12 +37,22 @@
   .ai-top > .ai-section{flex:1;min-width:0;margin:0}
   .ai-top > .ai-scores{flex:0 0 250px;display:flex;flex-direction:column;gap:9px;margin:0}
   .ai-top > .ai-scores .ai-score{flex:1;display:flex;flex-direction:column;justify-content:center}
+  .trading-header .ai-section-title{margin:0}
+  .ai-score-fill--90{width:90%}
+  .ai-score-fill--35{width:35%}
+  .trading-btn--compact{padding:1px 8px;font-size:10px}
 </style></head>
 <body>
 <button id="t" onclick="var x=document.getElementById('tron');x.disabled=!x.disabled;this.textContent=x.disabled?'tron OFF':'tron ON'">tron ON</button>
 
 <header class="terminal-header">
-  <span class="brand">STOCKTOPUS</span>
+  <span class="brand" title="Stocktopus">
+    <svg class="brand-octopus" viewBox="0 0 40 24" role="img" aria-label="Stocktopus" fill="currentColor">
+      <path d="M5 16.5 C5 8.8 11 2.5 20 2.5 C29 2.5 35 8.8 35 16.5 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 Z"/>
+      <circle cx="15" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+      <circle cx="25" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+    </svg>
+  </span>
   <div class="cmd-bar"><span class="cmd-prompt">&gt;</span><input class="cmd-input" placeholder="enter command..." spellcheck="false"></div>
   <div class="security-selector"><input class="security-input" value="LEE" spellcheck="false"></div>
   <span class="watchlist-picker">Default</span>
@@ -50,7 +61,7 @@
 
 <div class="terminal-body">
   <main class="terminal-content" data-view="security">
-    <div class="company-panel">
+    <div id="company-panel" class="company-panel">
       <span class="cpanel-sym">AVGO</span>
       <span class="cpanel-name">Broadcom Inc.</span>
       <span class="cpanel-price">411.35</span>
@@ -62,7 +73,8 @@
       </svg>
     </div>
 
-    <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row>
+    <div class="info-panel">
+    <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row data-vim-role="tabs">
       <button class="info-tab st-tab" data-tab="overview"><span class="tab-key">1</span> Overview</button>
       <button class="info-tab st-tab" data-tab="financials"><span class="tab-key">2</span> Financial Modeling</button>
       <button class="info-tab st-tab" data-tab="estimates"><span class="tab-key">3</span> Estimates</button>
@@ -72,9 +84,9 @@
       <button class="info-tab st-tab" data-tab="sec"><span class="tab-key">7</span> SEC</button>
     </div>
 
-    <div id="info-content" class="info-content">
+    <div id="info-content" class="info-content" data-symbol="AVGO">
       <div class="trading-header" data-vim-row>
-        <span class="ai-section-title" style="margin:0">Deep Analysis — Multi-Agent Pipeline</span>
+        <span class="ai-section-title">Deep Analysis — Multi-Agent Pipeline</span>
         <div class="trading-actions">
           <button class="trading-btn" id="trading-analyze-btn">Run Deep Analysis</button>
           <span class="trading-cost">Est. $0.035</span>
@@ -92,17 +104,17 @@
             <div class="ai-score">
               <div class="ai-score-label">Sentiment</div>
               <div class="ai-score-value price-up">0.8</div>
-              <div class="ai-score-bar"><div class="ai-score-fill" style="width:90%"></div></div>
+              <div class="ai-score-bar"><div class="ai-score-fill ai-score-fill--90"></div></div>
             </div>
             <div class="ai-score">
               <div class="ai-score-label">Risk</div>
               <div class="ai-score-value">35.0</div>
-              <div class="ai-score-bar"><div class="ai-score-fill" style="width:35%"></div></div>
+              <div class="ai-score-bar"><div class="ai-score-fill ai-score-fill--35"></div></div>
             </div>
             <div class="ai-score">
               <div class="ai-score-label">Confidence</div>
               <div class="ai-score-value">90.0</div>
-              <div class="ai-score-bar"><div class="ai-score-fill" style="width:90%"></div></div>
+              <div class="ai-score-bar"><div class="ai-score-fill ai-score-fill--90"></div></div>
             </div>
           </div>
         </div>
@@ -138,11 +150,12 @@
             </div>
             <div class="ai-competitor-card" data-symbol="CRDO">
               <span class="ai-competitor-sym">CRDO</span>
-              <span class="ai-competitor-scores"><button class="trading-btn" style="padding:1px 8px;font-size:10px">analyze</button></span>
+              <span class="ai-competitor-scores"><button class="trading-btn trading-btn--compact">analyze</button></span>
             </div>
           </div>
         </div>
       </div>
+    </div>
     </div>
   </main>
 </div>

--- a/docs/design-system-export/production/preview-avgo-estimates.html
+++ b/docs/design-system-export/production/preview-avgo-estimates.html
@@ -5,7 +5,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="_real-style.css">
+<!-- Live base — keep DOM/classes in sync with security.html + info.js Estimates tab -->
+<link rel="stylesheet" href="../../../internal/server/static/style.css">
 <link rel="stylesheet" href="tron.css" id="tron">
 <style>
   body{font-family:'Fira Code',var(--font-mono)}
@@ -27,7 +28,13 @@
 <button id="t" onclick="var x=document.getElementById('tron');x.disabled=!x.disabled;this.textContent=x.disabled?'tron OFF':'tron ON'">tron ON</button>
 
 <header class="terminal-header">
-  <span class="brand">STOCKTOPUS</span>
+  <span class="brand" title="Stocktopus">
+    <svg class="brand-octopus" viewBox="0 0 40 24" role="img" aria-label="Stocktopus" fill="currentColor">
+      <path d="M5 16.5 C5 8.8 11 2.5 20 2.5 C29 2.5 35 8.8 35 16.5 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 Z"/>
+      <circle cx="15" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+      <circle cx="25" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+    </svg>
+  </span>
   <div class="cmd-bar"><span class="cmd-prompt">&gt;</span><input class="cmd-input" placeholder="enter command..." spellcheck="false"></div>
   <div class="security-selector"><input class="security-input" value="LEE" spellcheck="false"></div>
   <span class="watchlist-picker">Default</span>
@@ -36,7 +43,7 @@
 
 <div class="terminal-body">
   <main class="terminal-content" data-view="security">
-    <div class="company-panel">
+    <div id="company-panel" class="company-panel">
       <span class="cpanel-sym">AVGO</span>
       <span class="cpanel-name">Broadcom Inc.</span>
       <span class="cpanel-price">411.35</span>
@@ -48,7 +55,8 @@
       </svg>
     </div>
 
-    <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row>
+    <div class="info-panel">
+    <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row data-vim-role="tabs">
       <button class="info-tab st-tab" data-tab="overview"><span class="tab-key">1</span> Overview</button>
       <button class="info-tab st-tab" data-tab="financials"><span class="tab-key">2</span> Financial Modeling</button>
       <button class="info-tab st-tab active st-tab--active" data-tab="estimates"><span class="tab-key">3</span> Estimates</button>
@@ -58,7 +66,7 @@
       <button class="info-tab st-tab" data-tab="sec"><span class="tab-key">7</span> SEC</button>
     </div>
 
-    <div id="info-content" class="info-content">
+    <div id="info-content" class="info-content" data-symbol="AVGO">
       <table class="fin-table">
         <thead><tr><th>Year</th><th class="num">Revenue Est</th><th class="num">EPS Est</th><th class="num">EBITDA Est</th><th class="num">Net Income Est</th></tr></thead>
         <tbody>
@@ -69,6 +77,7 @@
           <tr class="fin-row"><td class="fin-label">2030</td><td class="num">139.00B <span class="est-range">105.13B–152.64B</span></td><td class="num">35.00 <span class="est-range">23.91–39.47</span></td><td class="num">74.85B</td><td class="num">169.86B</td></tr>
         </tbody>
       </table>
+    </div>
     </div>
   </main>
 </div>

--- a/docs/design-system-export/production/preview-avgo-news.html
+++ b/docs/design-system-export/production/preview-avgo-news.html
@@ -5,18 +5,26 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="_real-style.css">
+<!-- Live base — keep DOM/classes in sync with security.html + info.js News tab -->
+<link rel="stylesheet" href="../../../internal/server/static/style.css">
+<!-- Tron glow overlay (toggle with button) -->
 <link rel="stylesheet" href="tron.css" id="tron">
 <style>
-  body{font-family:'Fira Code',var(--font-mono)}
-  #t{position:fixed;top:6px;right:10px;z-index:9999;font:11px 'Fira Code',monospace;background:var(--bg-tertiary);color:var(--accent-orange);border:1px solid var(--accent-orange);border-radius:5px;padding:4px 9px;cursor:pointer}
-  .demo-spark{display:inline-block;vertical-align:middle;margin-left:8px}
+  body { font-family: 'Fira Code', var(--font-mono); }
+  #t { position: fixed; top: 6px; right: 10px; z-index: 9999; font: 11px 'Fira Code', monospace; background: var(--bg-tertiary); color: var(--accent-orange); border: 1px solid var(--accent-orange); border-radius: 5px; padding: 4px 9px; cursor: pointer; }
+  .demo-spark { display: inline-block; vertical-align: middle; margin-left: 8px; }
 </style></head>
 <body>
 <button id="t" onclick="var x=document.getElementById('tron');x.disabled=!x.disabled;this.textContent=x.disabled?'tron OFF':'tron ON'">tron ON</button>
 
 <header class="terminal-header">
-  <span class="brand">STOCKTOPUS</span>
+  <span class="brand" title="Stocktopus">
+    <svg class="brand-octopus" viewBox="0 0 40 24" role="img" aria-label="Stocktopus" fill="currentColor">
+      <path d="M5 16.5 C5 8.8 11 2.5 20 2.5 C29 2.5 35 8.8 35 16.5 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 Z"/>
+      <circle cx="15" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+      <circle cx="25" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+    </svg>
+  </span>
   <div class="cmd-bar"><span class="cmd-prompt">&gt;</span><input class="cmd-input" placeholder="enter command..." spellcheck="false"></div>
   <div class="security-selector"><input class="security-input" value="LEE" spellcheck="false"></div>
   <span class="watchlist-picker">Default</span>
@@ -25,7 +33,7 @@
 
 <div class="terminal-body">
   <main class="terminal-content" data-view="security">
-    <div class="company-panel" style="padding: 0px 0px 0px 17px">
+    <div id="company-panel" class="company-panel">
       <span class="cpanel-sym">AVGO</span>
       <span class="cpanel-name">Broadcom Inc.</span>
       <span class="cpanel-price">411.35</span>
@@ -37,7 +45,8 @@
       </svg>
     </div>
 
-    <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row>
+    <div class="info-panel">
+    <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row data-vim-role="tabs">
       <button class="info-tab st-tab" data-tab="overview"><span class="tab-key">1</span> Overview</button>
       <button class="info-tab st-tab" data-tab="financials"><span class="tab-key">2</span> Financial Modeling</button>
       <button class="info-tab st-tab" data-tab="estimates"><span class="tab-key">3</span> Estimates</button>
@@ -47,14 +56,14 @@
       <button class="info-tab st-tab" data-tab="sec"><span class="tab-key">7</span> SEC</button>
     </div>
 
-    <div id="info-content" class="info-content" style="margin: 0px 7px 0px 9px">
+    <div id="info-content" class="info-content" data-symbol="AVGO">
       <div class="info-sub-tabs news-sub-tabs st-tab-row st-tab-row--blue" id="news-sub-tabs" data-vim-row>
-        <button class="info-sub-tab st-tab active" data-cat="press">Press Releases</button>
-        <button class="info-sub-tab st-tab" data-cat="articles">Articles</button>
-        <button class="info-sub-tab st-tab" data-cat="stock">Stock</button>
-        <button class="info-sub-tab st-tab" data-cat="crypto">Crypto</button>
-        <button class="info-sub-tab st-tab" data-cat="forex">Forex</button>
-        <button class="info-sub-tab st-tab" data-cat="general">General</button>
+        <button class="info-sub-tab st-tab active st-tab--active" data-cat="press-releases" data-vim-item>Press Releases</button>
+        <button class="info-sub-tab st-tab" data-cat="articles" data-vim-item>Articles</button>
+        <button class="info-sub-tab st-tab" data-cat="stock" data-vim-item>Stock</button>
+        <button class="info-sub-tab st-tab" data-cat="crypto" data-vim-item>Crypto</button>
+        <button class="info-sub-tab st-tab" data-cat="forex" data-vim-item>Forex</button>
+        <button class="info-sub-tab st-tab" data-cat="general" data-vim-item>General</button>
       </div>
       <div class="news-cards" id="info-news-cards">
         <div class="news-card">
@@ -62,7 +71,7 @@
           <div class="news-card-meta"><span>PRNewsWire</span><span>Jun 17, 2026</span></div>
           <div class="news-card-text">PALO ALTO, Calif., June 17, 2026 /PRNewswire/ — Broadcom Inc. (NASDAQ: AVGO) ("Broadcom") today announced the expiration and results of its previously announced cash tender offers (collectively, the "Offers") to purchas…</div>
         </div>
-        <div class="news-card news-unread" style="padding: 12px 15px 12px 16px; height: 115px; width: 1547px">
+        <div class="news-card news-unread">
           <div class="news-card-title"><a>Broadcom Inc. Announces Pricing Terms of Offers to Purchase for Cash Certain of its Outstanding Debt Securities</a></div>
           <div class="news-card-meta"><span>PRNewsWire</span><span>Jun 17, 2026</span></div>
           <div class="news-card-text">PALO ALTO, Calif., June 17, 2026 /PRNewswire/ — Broadcom Inc. (NASDAQ: AVGO) ("Broadcom") today announced the pricing terms of its previously announced cash tender offers (collectively, the "Offers") to purchase the out…</div>
@@ -88,6 +97,7 @@
           <div class="news-card-text">The Redesign Group today announced it has achieved Pinnacle Partner status, the highest tier in the Broadcom Advantage Partner Program, recognising its expertise across the VMware Cloud Foundation portfolio.</div>
         </div>
       </div>
+    </div>
     </div>
   </main>
 </div>

--- a/docs/design-system-export/production/preview-avgo-overview.html
+++ b/docs/design-system-export/production/preview-avgo-overview.html
@@ -5,7 +5,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="_real-style.css">
+<!-- Live base — keep DOM/classes in sync with security.html + info.js Overview tab -->
+<link rel="stylesheet" href="../../../internal/server/static/style.css">
 <link rel="stylesheet" href="tron.css" id="tron">
 <style>
   body{font-family:'Fira Code',var(--font-mono)}
@@ -29,7 +30,13 @@
 <button id="t" onclick="var x=document.getElementById('tron');x.disabled=!x.disabled;this.textContent=x.disabled?'tron OFF':'tron ON'">tron ON</button>
 
 <header class="terminal-header">
-  <span class="brand">STOCKTOPUS</span>
+  <span class="brand" title="Stocktopus">
+    <svg class="brand-octopus" viewBox="0 0 40 24" role="img" aria-label="Stocktopus" fill="currentColor">
+      <path d="M5 16.5 C5 8.8 11 2.5 20 2.5 C29 2.5 35 8.8 35 16.5 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 Z"/>
+      <circle cx="15" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+      <circle cx="25" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+    </svg>
+  </span>
   <div class="cmd-bar"><span class="cmd-prompt">&gt;</span><input class="cmd-input" placeholder="enter command..." spellcheck="false"></div>
   <div class="security-selector"><input class="security-input" value="LEE" spellcheck="false"></div>
   <span class="watchlist-picker">Default</span>
@@ -38,7 +45,7 @@
 
 <div class="terminal-body">
   <main class="terminal-content" data-view="security">
-    <div class="company-panel">
+    <div id="company-panel" class="company-panel">
       <span class="cpanel-sym">AVGO</span>
       <span class="cpanel-name">Broadcom Inc.</span>
       <span class="cpanel-price">411.35</span>
@@ -50,7 +57,8 @@
       </svg>
     </div>
 
-    <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row>
+    <div class="info-panel">
+    <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row data-vim-role="tabs">
       <button class="info-tab st-tab active st-tab--active" data-tab="overview"><span class="tab-key">1</span> Overview</button>
       <button class="info-tab st-tab" data-tab="financials"><span class="tab-key">2</span> Financial Modeling</button>
       <button class="info-tab st-tab" data-tab="estimates"><span class="tab-key">3</span> Estimates</button>
@@ -60,7 +68,7 @@
       <button class="info-tab st-tab" data-tab="sec"><span class="tab-key">7</span> SEC</button>
     </div>
 
-    <div id="info-content" class="info-content">
+    <div id="info-content" class="info-content" data-symbol="AVGO">
       <div class="info-overview">
         <div class="info-grid info-grid-dense">
           <div class="info-stat"><span class="info-stat-label">Market Cap</span><span class="info-stat-value">1.96T</span></div>
@@ -81,7 +89,9 @@
           <div class="info-stat"><span class="info-stat-label">P/B</span><span class="info-stat-value">22.27</span></div>
         </div>
 
-        <div class="info-overview-top">
+        <div class="info-overview-body">
+          <div id="info-overview-chart" class="info-overview-chart">[ 6m price chart ]</div>
+          <div class="info-overview-top">
           <div class="info-overview-left">
             <div class="info-people-header">Key People <span class="info-people-meta">25 on file · <a class="info-people-more">timeline →</a></span></div>
             <ul class="info-people-list">
@@ -108,8 +118,10 @@
             <p class="info-description">Broadcom Inc. is a prominent global technology enterprise focused on the innovation, development, and supply of advanced semiconductor solutions and critical infrastructure software. The company's headquarters are situated in San Jose, California, and it maintains a significant team of 19,000 full-time staff.</p>
             <p class="info-description">Its operations are segmented into four primary divisions: Wired Infrastructure, Wireless Communications, Enterprise Storage, and Industrial &amp; Other. Broadcom's diverse product range is integrated into numerous end-user technologies, including enterprise and data center networking, residential internet solutions, digital television receivers, telecommunications apparatus, mobile phones, data center servers and storage architectures, industrial automation, alternative and power generation systems, and electronic display technologies.</p>
           </div>
+          </div>
         </div>
       </div>
+    </div>
     </div>
   </main>
 </div>

--- a/docs/design-system-export/production/preview-financials.html
+++ b/docs/design-system-export/production/preview-financials.html
@@ -5,7 +5,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="_real-style.css">
+<!-- Live base — keep DOM/classes in sync with security.html + info.js Financials tab -->
+<link rel="stylesheet" href="../../../internal/server/static/style.css">
 <link rel="stylesheet" href="tron.css" id="tron">
 <style>
   body{font-family:'Fira Code',var(--font-mono)}
@@ -21,7 +22,13 @@
 <button id="t" onclick="var x=document.getElementById('tron');x.disabled=!x.disabled;this.textContent=x.disabled?'tron OFF':'tron ON'">tron ON</button>
 
 <header class="terminal-header">
-  <span class="brand">STOCKTOPUS</span>
+  <span class="brand" title="Stocktopus">
+    <svg class="brand-octopus" viewBox="0 0 40 24" role="img" aria-label="Stocktopus" fill="currentColor">
+      <path d="M5 16.5 C5 8.8 11 2.5 20 2.5 C29 2.5 35 8.8 35 16.5 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 Z"/>
+      <circle cx="15" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+      <circle cx="25" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+    </svg>
+  </span>
   <div class="cmd-bar"><span class="cmd-prompt">&gt;</span><input class="cmd-input" placeholder="enter command..." spellcheck="false"></div>
   <div class="security-selector"><input class="security-input" value="LEE" spellcheck="false"></div>
   <span class="watchlist-picker">Default</span>
@@ -30,7 +37,7 @@
 
 <div class="terminal-body">
   <main class="terminal-content" data-view="security">
-    <div class="company-panel">
+    <div id="company-panel" class="company-panel">
       <span class="cpanel-sym">LEE</span>
       <span class="cpanel-name">Lee Enterprises, Incorporated</span>
       <span class="cpanel-price">9.28</span>
@@ -42,9 +49,10 @@
       </svg>
     </div>
 
-    <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row style="gap: 22px">
-      <button class="info-tab st-tab" data-tab="overview" style="height: 32px; line-height: 3.55"><span class="tab-key">1</span> Overview</button>
-      <button class="info-tab st-tab active st-tab--active" data-tab="financials" style="padding: 1px 6px 0px; height: 29px"><span class="tab-key">2</span> Financial Modeling</button>
+    <div class="info-panel">
+    <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row data-vim-role="tabs">
+      <button class="info-tab st-tab" data-tab="overview"><span class="tab-key">1</span> Overview</button>
+      <button class="info-tab st-tab active st-tab--active" data-tab="financials"><span class="tab-key">2</span> Financial Modeling</button>
       <button class="info-tab st-tab" data-tab="estimates"><span class="tab-key">3</span> Estimates</button>
       <button class="info-tab st-tab" data-tab="news"><span class="tab-key">4</span> News</button>
       <button class="info-tab st-tab" data-tab="ai"><span class="tab-key">5</span> AI Analysis</button>
@@ -52,11 +60,11 @@
       <button class="info-tab st-tab" data-tab="sec"><span class="tab-key">7</span> SEC</button>
     </div>
 
-    <div id="info-content" class="info-content">
+    <div id="info-content" class="info-content" data-symbol="LEE">
       <div class="info-sub-tabs st-tab-row st-tab-row--blue" id="fin-sub-tabs" data-vim-row>
         <button class="info-sub-tab st-tab" data-ftype="income">Income</button>
         <button class="info-sub-tab st-tab" data-ftype="balance">Balance Sheet</button>
-        <button class="info-sub-tab st-tab active" data-ftype="cashflow">Cash Flow</button>
+        <button class="info-sub-tab st-tab active st-tab--active" data-ftype="cashflow">Cash Flow</button>
         <button class="info-sub-tab st-tab" data-ftype="assumptions">Assumptions</button>
         <button class="info-sub-tab st-tab" data-ftype="forecast">Forecast</button>
       </div>
@@ -83,6 +91,7 @@
           </tbody>
         </table>
       </div>
+    </div>
     </div>
   </main>
 </div>

--- a/docs/design-system-export/production/preview-goog-sec.html
+++ b/docs/design-system-export/production/preview-goog-sec.html
@@ -5,7 +5,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="_real-style.css">
+<!-- Live base — keep DOM/classes in sync with security.html + info.js SEC tab -->
+<link rel="stylesheet" href="../../../internal/server/static/style.css">
 <link rel="stylesheet" href="tron.css" id="tron">
 <style>
   body{font-family:'Fira Code',var(--font-mono)}
@@ -27,7 +28,13 @@
 <button id="t" onclick="var x=document.getElementById('tron');x.disabled=!x.disabled;this.textContent=x.disabled?'tron OFF':'tron ON'">tron ON</button>
 
 <header class="terminal-header">
-  <span class="brand">STOCKTOPUS</span>
+  <span class="brand" title="Stocktopus">
+    <svg class="brand-octopus" viewBox="0 0 40 24" role="img" aria-label="Stocktopus" fill="currentColor">
+      <path d="M5 16.5 C5 8.8 11 2.5 20 2.5 C29 2.5 35 8.8 35 16.5 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 Z"/>
+      <circle cx="15" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+      <circle cx="25" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+    </svg>
+  </span>
   <div class="cmd-bar"><span class="cmd-prompt">&gt;</span><input class="cmd-input" placeholder="enter command..." spellcheck="false"></div>
   <div class="security-selector"><input class="security-input" value="LEE" spellcheck="false"></div>
   <span class="watchlist-picker">Default</span>
@@ -35,8 +42,8 @@
 </header>
 
 <div class="terminal-body">
-  <main class="terminal-content" data-view="info">
-    <div class="company-panel">
+  <main class="terminal-content" data-view="security">
+    <div id="company-panel" class="company-panel">
       <span class="cpanel-sym">GOOG</span>
       <span class="cpanel-name">Alphabet Inc.</span>
       <span class="cpanel-price">367.46</span>
@@ -48,7 +55,8 @@
       </svg>
     </div>
 
-    <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row>
+    <div class="info-panel">
+    <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row data-vim-role="tabs">
       <button class="info-tab st-tab" data-tab="overview"><span class="tab-key">1</span> Overview</button>
       <button class="info-tab st-tab" data-tab="financials"><span class="tab-key">2</span> Financial Modeling</button>
       <button class="info-tab st-tab" data-tab="estimates"><span class="tab-key">3</span> Estimates</button>
@@ -58,7 +66,7 @@
       <button class="info-tab st-tab active st-tab--active" data-tab="sec"><span class="tab-key">7</span> SEC</button>
     </div>
 
-    <div id="info-content" class="info-content">
+    <div id="info-content" class="info-content" data-symbol="GOOG">
       <div class="sec-view">
         <div class="info-sub-tabs st-tab-row st-tab-row--blue" id="sec-filters" data-vim-row>
           <button class="info-sub-tab st-tab active st-tab--active" data-cat="all" data-view="filings">All</button>
@@ -87,6 +95,7 @@
           </tbody>
         </table>
       </div>
+    </div>
     </div>
   </main>
 </div>

--- a/docs/design-system-export/production/preview-graph.html
+++ b/docs/design-system-export/production/preview-graph.html
@@ -1,19 +1,29 @@
 <!doctype html>
 <html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Stocktopus — Chart (Tron preview)</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="_real-style.css">
+<!-- Live base — keep DOM/classes in sync with internal/server/templates/stock.html -->
+<link rel="stylesheet" href="../../../internal/server/static/style.css">
 <link rel="stylesheet" href="tron.css" id="tron">
 <style>
   body{font-family:'Fira Code',var(--font-mono)}
   #t{position:fixed;top:6px;right:10px;z-index:9999;font:11px 'Fira Code',monospace;background:var(--bg-tertiary);color:var(--accent-orange);border:1px solid var(--accent-orange);border-radius:5px;padding:4px 9px;cursor:pointer}
+  .chart-placeholder{display:flex;align-items:center;justify-content:center;color:var(--text-muted);min-height:360px}
 </style></head>
 <body>
 <button id="t" onclick="var x=document.getElementById('tron');x.disabled=!x.disabled;this.textContent=x.disabled?'tron OFF':'tron ON'">tron ON</button>
 <header class="terminal-header">
-  <span class="brand">STOCKTOPUS</span>
-  <div class="cmd-bar"><span class="cmd-prompt">&gt;</span><input class="cmd-input" placeholder="enter command..." value="" spellcheck="false"></div>
+  <span class="brand" title="Stocktopus">
+    <svg class="brand-octopus" viewBox="0 0 40 24" role="img" aria-label="Stocktopus" fill="currentColor">
+      <path d="M5 16.5 C5 8.8 11 2.5 20 2.5 C29 2.5 35 8.8 35 16.5 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 Z"/>
+      <circle cx="15" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+      <circle cx="25" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+    </svg>
+  </span>
+  <div class="cmd-bar"><span class="cmd-prompt">&gt;</span><input class="cmd-input" placeholder="enter command..." spellcheck="false"></div>
   <div class="security-selector"><input class="security-input" value="KR" spellcheck="false"></div>
   <span class="watchlist-picker">Default</span>
   <div class="conn-status connected">CONNECTED</div>
@@ -25,36 +35,47 @@
       <span class="cpanel-name">The Kroger Co.</span>
       <span class="cpanel-price">56.61</span>
       <span class="cpanel-change price-down">-5.21 (-8.43%)</span>
-      <span class="cpanel-spark-wrap"><span class="cpanel-spark-label price-down">6m</span></span>
     </div>
-    <div class="chart-container-wrap">
+    <div class="page-header">
       <div class="chart-range-bar st-tab-row st-tab-row--blue" id="chart-range-bar">
-        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="1m">1m</button>
-        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="5m">5m</button>
-        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="15m">15m</button>
-        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="30m">30m</button>
-        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="1h">1h</button>
-        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="4h">4h</button>
+        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="1m" data-interval="1min">1m</button>
+        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="5m" data-interval="5min">5m</button>
+        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="15m" data-interval="15min">15m</button>
+        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="30m" data-interval="30min">30m</button>
+        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="1h" data-interval="1hour">1h</button>
+        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="4h" data-interval="4hour">4h</button>
+        <button class="chart-range-btn chart-intraday-btn st-tab" data-range="2d" data-interval="5min">2d</button>
+        <button class="chart-auto-refresh active" id="chart-auto-refresh" title="Auto-refresh">&#8635;</button>
         <span class="chart-range-sep">|</span>
         <button class="chart-range-btn chart-eod-btn st-tab" data-range="1W">1w</button>
         <button class="chart-range-btn chart-eod-btn st-tab" data-range="1M">1m</button>
         <button class="chart-range-btn chart-eod-btn st-tab" data-range="3M">3m</button>
         <button class="chart-range-btn chart-eod-btn st-tab active st-tab--active" data-range="6M">6m</button>
+        <button class="chart-range-btn chart-eod-btn st-tab" data-range="1Y">1y</button>
+        <button class="chart-range-btn chart-eod-btn st-tab" data-range="5Y">5y</button>
+        <button class="chart-range-btn chart-eod-btn st-tab" data-range="10Y">10y</button>
+        <button class="chart-range-btn chart-eod-btn st-tab" data-range="MAX">max</button>
         <span class="chart-range-sep">|</span>
-        <button class="chart-toggle" data-indicator="sma">SMA</button>
-        <button class="chart-toggle" data-indicator="ema">EMA</button>
-        <button class="chart-toggle" data-indicator="macd">MACD</button>
-        <button class="chart-toggle" data-indicator="rsi">RSI</button>
-        <button class="chart-toggle" data-indicator="news">News</button>
+        <button class="chart-toggle" id="toggle-sma" data-indicator="sma" title=":sma">SMA</button>
+        <button class="chart-toggle" id="toggle-ema" data-indicator="ema" title=":ema">EMA</button>
+        <button class="chart-toggle" id="toggle-macd" data-indicator="macd" title=":macd">MACD</button>
+        <button class="chart-toggle" id="toggle-rsi" data-indicator="rsi" title=":rsi">RSI</button>
+        <button class="chart-toggle" id="toggle-news" data-indicator="news" title=":sn">News</button>
       </div>
-      <div class="chart-container" style="height:360px;display:flex;align-items:center;justify-content:center;color:var(--text-muted)">[ candlestick chart ]</div>
+    </div>
+    <div id="chart-container" class="chart-container" data-symbol="KR">
+      <div class="chart-placeholder">[ candlestick chart ]</div>
     </div>
   </main>
 </div>
 <footer class="terminal-footer">
   <span class="footer-mode normal">NORMAL</span>
-  <span class="footer-view">graph</span>
-  <span class="footer-help">/ cmd &middot; s security &middot; hjkl nav &middot; : chart cmd</span>
-  <div class="footer-clocks"><span class="tz-block"><span class="tz-label">ET</span>09:41</span></div>
+  <span class="footer-view">GRAPH</span>
+  <span class="footer-help">/ cmd · s security · hjkl nav · : chart cmd</span>
+  <div class="footer-clocks">
+    <span class="tz-block"><span class="tz-label">ET</span>09:41</span>
+    <span class="tz-block"><span class="tz-label">UTC</span>13:41</span>
+    <span class="tz-block"><span class="tz-label">JST</span>22:41</span>
+  </div>
 </footer>
 </body></html>

--- a/docs/design-system-export/production/preview-ideas.html
+++ b/docs/design-system-export/production/preview-ideas.html
@@ -5,7 +5,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="_real-style.css">
+<!-- Live base — keep DOM/classes in sync with internal/server/templates/ideas.html -->
+<link rel="stylesheet" href="../../../internal/server/static/style.css">
 <link rel="stylesheet" href="tron.css" id="tron">
 <style>
   body{font-family:'Fira Code',var(--font-mono)}
@@ -23,7 +24,13 @@
 <button id="t" onclick="var x=document.getElementById('tron');x.disabled=!x.disabled;this.textContent=x.disabled?'tron OFF':'tron ON'">tron ON</button>
 
 <header class="terminal-header">
-  <span class="brand">STOCKTOPUS</span>
+  <span class="brand" title="Stocktopus">
+    <svg class="brand-octopus" viewBox="0 0 40 24" role="img" aria-label="Stocktopus" fill="currentColor">
+      <path d="M5 16.5 C5 8.8 11 2.5 20 2.5 C29 2.5 35 8.8 35 16.5 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 Z"/>
+      <circle cx="15" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+      <circle cx="25" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+    </svg>
+  </span>
   <div class="cmd-bar"><span class="cmd-prompt">&gt;</span><input class="cmd-input" placeholder="enter command..." spellcheck="false"></div>
   <div class="security-selector"><input class="security-input" value="DJTWW" spellcheck="false"></div>
   <span class="watchlist-picker">Default</span>
@@ -31,15 +38,14 @@
 </header>
 
 <div class="terminal-body">
-  <main class="terminal-content" data-view="ideas" style="padding: 4px 9px 9px">
-    <div class="ideas-layout">
-      <!-- ───────── SKETCHES SIDEBAR ───────── -->
-      <aside class="ideas-sidebar" id="ideas-sidebar">
-        <div class="ideas-sidebar-header">
+  <main class="terminal-content" data-view="ideas">
+    <div class="ideas-layout st-split">
+      <aside class="ideas-sidebar st-pane st-pane--nav" id="ideas-sidebar">
+        <div class="ideas-sidebar-header st-pane-header">
           <span>Sketches</span>
           <span class="ideas-sidebar-meta">3 saved</span>
         </div>
-        <ul class="ideas-list" id="ideas-list">
+        <ul class="ideas-list st-nav-list" id="ideas-list">
           <li class="ideas-list-item">
             <span class="ideas-list-name">Default</span>
             <span class="ideas-list-meta">scratchpad</span>
@@ -62,15 +68,14 @@
         </div>
       </aside>
 
-      <!-- ───────── MAIN ───────── -->
-      <section class="ideas-main" id="ideas-main">
+      <section class="ideas-main st-pane st-pane--content" id="ideas-main">
         <div class="ideas-header">
           <h2 class="ideas-title">Daves Magical Space Charts</h2>
           <span class="ideas-meta">3 metrics</span>
           <span class="ideas-help-toggle" title="Press ? to toggle">?</span>
         </div>
 
-        <div id="ideas-chart-host" class="ideas-chart-host" style="position:relative;height:340px">
+        <div id="ideas-chart-host" class="ideas-chart-host">
           <canvas id="chart"></canvas>
         </div>
 

--- a/docs/design-system-export/production/preview-info.html
+++ b/docs/design-system-export/production/preview-info.html
@@ -3,30 +3,29 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Stocktopus — Tron overlay preview (real style.css)</title>
+  <title>Stocktopus — Security Info (Tron preview)</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <!-- the REAL production stylesheet -->
-  <link rel="stylesheet" href="../internal/server/static/style.css">
-  <!-- the additive Tron overlay (toggle with the button) -->
+  <!-- Live base — keep DOM/classes in sync with internal/server/templates/security.html -->
+  <link rel="stylesheet" href="../../../internal/server/static/style.css">
   <link rel="stylesheet" href="tron.css" id="tron">
   <style>
     body { font-family: 'Fira Code', var(--font-mono); }
-    #toggle {
-      position: fixed; top: 8px; right: 12px; z-index: 9999;
-      font-family: 'Fira Code', monospace; font-size: 11px;
-      background: var(--bg-tertiary); color: var(--accent-orange);
-      border: 1px solid var(--accent-orange); border-radius: 4px;
-      padding: 5px 10px; cursor: pointer;
-    }
+    #t { position: fixed; top: 6px; right: 10px; z-index: 9999; font: 11px 'Fira Code', monospace; background: var(--bg-tertiary); color: var(--accent-orange); border: 1px solid var(--accent-orange); border-radius: 5px; padding: 4px 9px; cursor: pointer; }
   </style>
 </head>
 <body>
-  <button id="toggle" onclick="var t=document.getElementById('tron');t.disabled=!t.disabled;this.textContent=t.disabled?'tron: OFF':'tron: ON';">tron: ON</button>
+  <button id="t" onclick="var x=document.getElementById('tron');x.disabled=!x.disabled;this.textContent=x.disabled?'tron OFF':'tron ON'">tron ON</button>
 
   <header class="terminal-header">
-    <span class="brand">STOCKTOPUS</span>
+    <span class="brand" title="Stocktopus">
+      <svg class="brand-octopus" viewBox="0 0 40 24" role="img" aria-label="Stocktopus" fill="currentColor">
+        <path d="M5 16.5 C5 8.8 11 2.5 20 2.5 C29 2.5 35 8.8 35 16.5 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 Z"/>
+        <circle cx="15" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+        <circle cx="25" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+      </svg>
+    </span>
     <div class="cmd-bar">
       <span class="cmd-prompt">&gt;</span>
       <input class="cmd-input" type="text" placeholder="enter command..." value="info NVDA" spellcheck="false">
@@ -40,24 +39,25 @@
 
   <div class="terminal-body">
     <main class="terminal-content" data-view="security">
-      <div class="company-panel">
+      <div id="company-panel" class="company-panel">
         <span class="cpanel-sym">NVDA</span>
         <span class="cpanel-name">NVIDIA Corp.</span>
-        <span class="cpanel-price">$121.08</span>
+        <span class="cpanel-price">121.08</span>
         <span class="cpanel-change price-up">+3.61 (+3.07%)</span>
       </div>
 
-      <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row>
-        <button class="info-tab st-tab active st-tab--active" data-tab="overview">Overview</button>
-        <button class="info-tab st-tab" data-tab="financials">Financial Modeling</button>
-        <button class="info-tab st-tab" data-tab="estimates">Estimates</button>
-        <button class="info-tab st-tab" data-tab="news">News</button>
-        <button class="info-tab st-tab" data-tab="ai">AI Analysis</button>
-        <button class="info-tab st-tab" data-tab="sector">Sector</button>
-        <button class="info-tab st-tab" data-tab="sec">SEC</button>
+      <div class="info-panel">
+      <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row data-vim-role="tabs">
+        <button class="info-tab st-tab active st-tab--active" data-tab="overview" data-vim-item>Overview</button>
+        <button class="info-tab st-tab" data-tab="financials" data-vim-item>Financial Modeling</button>
+        <button class="info-tab st-tab" data-tab="estimates" data-vim-item>Estimates</button>
+        <button class="info-tab st-tab" data-tab="news" data-vim-item>News</button>
+        <button class="info-tab st-tab" data-tab="ai" data-vim-item>AI Analysis</button>
+        <button class="info-tab st-tab" data-tab="sector" data-vim-item>Sector</button>
+        <button class="info-tab st-tab" data-tab="sec" data-vim-item>SEC</button>
       </div>
 
-      <div class="info-content">
+      <div id="info-content" class="info-content" data-symbol="NVDA">
         <div class="info-grid">
           <div class="info-stat"><span class="info-stat-label">Mkt Cap</span><span class="info-stat-value">2.98T</span></div>
           <div class="info-stat"><span class="info-stat-label">P/E</span><span class="info-stat-value">54.7</span></div>
@@ -65,7 +65,7 @@
           <div class="info-stat"><span class="info-stat-label">Volume</span><span class="info-stat-value">288M</span></div>
         </div>
 
-        <div style="margin:18px 0 8px;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.5px;color:var(--accent-orange)">Technology — Peers</div>
+        <div class="sector-header"><span class="sector-name">Technology</span><span class="sector-industry">Peers</span></div>
         <table class="quote-table">
           <thead><tr><th>Security</th><th>Company</th><th>Price</th><th>Δ% 1d</th><th>Δ% 6m</th><th>Mkt Cap</th></tr></thead>
           <tbody>
@@ -88,6 +88,7 @@
           </tbody>
         </table>
       </div>
+      </div>
     </main>
   </div>
 
@@ -96,9 +97,9 @@
     <span class="footer-view">SECURITY</span>
     <span class="footer-help">/ cmd · s security · hjkl nav · : chart cmd</span>
     <div class="footer-clocks">
-      <span class="tz-block"><span class="tz-label">ET</span>09:41:08</span>
-      <span class="tz-block"><span class="tz-label">UTC</span>13:41:08</span>
-      <span class="tz-block"><span class="tz-label">JST</span>22:41:08</span>
+      <span class="tz-block"><span class="tz-label">ET</span>09:41</span>
+      <span class="tz-block"><span class="tz-label">UTC</span>13:41</span>
+      <span class="tz-block"><span class="tz-label">JST</span>22:41</span>
     </div>
   </footer>
 </body>

--- a/docs/design-system-export/production/preview-news-page.html
+++ b/docs/design-system-export/production/preview-news-page.html
@@ -5,17 +5,25 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="_real-style.css">
+<!-- Live base — keep DOM/classes in sync with internal/server/templates/news.html -->
+<link rel="stylesheet" href="../../../internal/server/static/style.css">
+<!-- Tron glow overlay (toggle with button) -->
 <link rel="stylesheet" href="tron.css" id="tron">
 <style>
-  body{font-family:'Fira Code',var(--font-mono)}
-  #t{position:fixed;top:6px;right:10px;z-index:9999;font:11px 'Fira Code',monospace;background:var(--bg-tertiary);color:var(--accent-orange);border:1px solid var(--accent-orange);border-radius:5px;padding:4px 9px;cursor:pointer}
+  body { font-family: 'Fira Code', var(--font-mono); }
+  #t { position: fixed; top: 6px; right: 10px; z-index: 9999; font: 11px 'Fira Code', monospace; background: var(--bg-tertiary); color: var(--accent-orange); border: 1px solid var(--accent-orange); border-radius: 5px; padding: 4px 9px; cursor: pointer; }
 </style></head>
 <body>
 <button id="t" onclick="var x=document.getElementById('tron');x.disabled=!x.disabled;this.textContent=x.disabled?'tron OFF':'tron ON'">tron ON</button>
 
 <header class="terminal-header">
-  <span class="brand">STOCKTOPUS</span>
+  <span class="brand" title="Stocktopus">
+    <svg class="brand-octopus" viewBox="0 0 40 24" role="img" aria-label="Stocktopus" fill="currentColor">
+      <path d="M5 16.5 C5 8.8 11 2.5 20 2.5 C29 2.5 35 8.8 35 16.5 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 Z"/>
+      <circle cx="15" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+      <circle cx="25" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+    </svg>
+  </span>
   <div class="cmd-bar"><span class="cmd-prompt">&gt;</span><input class="cmd-input" placeholder="enter command..." spellcheck="false"></div>
   <div class="security-selector"><input class="security-input" value="AAPL" spellcheck="false"></div>
   <span class="watchlist-picker">Default</span>
@@ -23,44 +31,44 @@
 </header>
 
 <div class="terminal-body">
-  <main class="terminal-content" data-view="security">
-    <div class="company-panel">
+  <main class="terminal-content" data-view="news">
+    <div id="company-panel" class="company-panel">
       <span class="cpanel-sym">AAPL</span>
       <span class="cpanel-name">Apple Inc.</span>
       <span class="cpanel-price">298.01</span>
       <span class="cpanel-change price-up">+2.06 (0.70%)</span>
     </div>
-    <div class="page-header">
-      <h2 class="view-title">News</h2>
-    </div>
-    <div class="news-tabs" style="border-style: none; padding: 0px; margin: 0px 0px 8px">
-      <button class="news-tab active" style="padding: 5px 15px 5px 16px">Press Releases</button>
-      <button class="news-tab">Articles</button>
-      <button class="news-tab">Stock</button>
-      <button class="news-tab dimmed">Crypto</button>
-      <button class="news-tab dimmed">Forex</button>
-      <button class="news-tab">General</button>
-    </div>
-    <div class="news-cards">
-      <div class="news-card news-unread">
-        <div class="news-card-title"><a>Xiao-I Corporation Provides Update on First-Instance Rulings in Patent Litigation Against Apple; Company Intends to Appeal</a></div>
-        <div class="news-card-meta"><span class="news-symbol">AAPL</span> PRNewsWire · Jun 19, 2026, 06:00 PM</div>
-        <div class="news-card-text">SHANGHAI, June 19, 2026 /PRNewswire/ — Xiao-I Corporation (NASDAQ: AIXI) ("Xiao-I" or the "Company"), a leading developer of AI solutions, provided a material update on the patent-related litigation…</div>
+    <div class="info-panel">
+      <div class="news-tabs info-tabs st-tab-row" id="news-tabs" data-vim-row data-vim-role="tabs">
+        <button class="news-tab info-tab st-tab active st-tab--active" data-category="press-releases" data-vim-item>Press Releases</button>
+        <button class="news-tab info-tab st-tab" data-category="articles" data-vim-item>Articles</button>
+        <button class="news-tab info-tab st-tab" data-category="stock" data-vim-item>Stock</button>
+        <button class="news-tab info-tab st-tab" data-category="crypto" data-vim-item>Crypto</button>
+        <button class="news-tab info-tab st-tab" data-category="forex" data-vim-item>Forex</button>
+        <button class="news-tab info-tab st-tab" data-category="general" data-vim-item>General</button>
+        <span id="news-spinner" class="spinner hidden"></span>
       </div>
-      <div class="news-card news-unread">
-        <div class="news-card-title"><a>Addigy Expands Identity for Apple Fleets: IdP-Native Login, FileVault Single Sign-In, and Multi-Tenant Support — Included at No Extra Cost</a></div>
-        <div class="news-card-meta"><span class="news-symbol">AAPL</span> Business Wire · Jun 17, 2026, 10:00 AM</div>
-        <div class="news-card-text">MIAMI—(BUSINESS WIRE)— #Addigy—Addigy Identity, included at no additional cost in every Addigy Apple MDM plan, protects the real device attack surface: the person authenticated.</div>
-      </div>
-      <div class="news-card">
-        <div class="news-card-title"><a>Pennsylvania Expansion Continues: Apple Blossom Joins Legend Senior Living</a></div>
-        <div class="news-card-meta"><span class="news-symbol">AAPL</span> GlobeNewsWire · Jun 16, 2026, 02:23 PM</div>
-        <div class="news-card-text">Legend Senior Living expands in Pennsylvania with the addition of Apple Blossom Senior Living in Moon Township, bringing its portfolio to 78 communities.</div>
-      </div>
-      <div class="news-card news-unread">
-        <div class="news-card-title"><a>MIKROE develops Spatial Anchor R1 &amp; S1 for Apple Vision Pro</a></div>
-        <div class="news-card-meta"><span class="news-symbol">AAPL</span> Business Wire · Jun 9, 2026, 10:58 AM</div>
-        <div class="news-card-text">BELGRADE, Serbia—(BUSINESS WIRE)—MIKROE, the embedded solutions company, today announced two spatial accessory tracking modules that mount to objects for Apple Vision Pro.</div>
+      <div id="news-cards" class="news-cards info-content" data-vim-scroll>
+        <div class="news-card news-unread">
+          <div class="news-card-title"><a>Xiao-I Corporation Provides Update on First-Instance Rulings in Patent Litigation Against Apple; Company Intends to Appeal</a></div>
+          <div class="news-card-meta"><span class="news-symbol">AAPL</span> PRNewsWire · Jun 19, 2026, 06:00 PM</div>
+          <div class="news-card-text">SHANGHAI, June 19, 2026 /PRNewswire/ — Xiao-I Corporation (NASDAQ: AIXI) ("Xiao-I" or the "Company"), a leading developer of AI solutions, provided a material update on the patent-related litigation…</div>
+        </div>
+        <div class="news-card news-unread">
+          <div class="news-card-title"><a>Addigy Expands Identity for Apple Fleets: IdP-Native Login, FileVault Single Sign-In, and Multi-Tenant Support — Included at No Extra Cost</a></div>
+          <div class="news-card-meta"><span class="news-symbol">AAPL</span> Business Wire · Jun 17, 2026, 10:00 AM</div>
+          <div class="news-card-text">MIAMI—(BUSINESS WIRE)— #Addigy—Addigy Identity, included at no additional cost in every Addigy Apple MDM plan, protects the real device attack surface: the person authenticated.</div>
+        </div>
+        <div class="news-card">
+          <div class="news-card-title"><a>Pennsylvania Expansion Continues: Apple Blossom Joins Legend Senior Living</a></div>
+          <div class="news-card-meta"><span class="news-symbol">AAPL</span> GlobeNewsWire · Jun 16, 2026, 02:23 PM</div>
+          <div class="news-card-text">Legend Senior Living expands in Pennsylvania with the addition of Apple Blossom Senior Living in Moon Township, bringing its portfolio to 78 communities.</div>
+        </div>
+        <div class="news-card news-unread">
+          <div class="news-card-title"><a>MIKROE develops Spatial Anchor R1 &amp; S1 for Apple Vision Pro</a></div>
+          <div class="news-card-meta"><span class="news-symbol">AAPL</span> Business Wire · Jun 9, 2026, 10:58 AM</div>
+          <div class="news-card-text">BELGRADE, Serbia—(BUSINESS WIRE)—MIKROE, the embedded solutions company, today announced two spatial accessory tracking modules that mount to objects for Apple Vision Pro.</div>
+        </div>
       </div>
     </div>
   </main>

--- a/docs/design-system-export/production/preview-news.html
+++ b/docs/design-system-export/production/preview-news.html
@@ -1,18 +1,29 @@
 <!doctype html>
 <html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Stocktopus — DJT — News tab (Tron preview)</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="_real-style.css">
+<!-- Live base — keep DOM/classes in sync with security.html + info.js News tab -->
+<link rel="stylesheet" href="../../../internal/server/static/style.css">
+<!-- Tron glow overlay (toggle with button) -->
 <link rel="stylesheet" href="tron.css" id="tron">
 <style>
-  body{font-family:'Fira Code',var(--font-mono)}
-  #t{position:fixed;top:6px;right:10px;z-index:9999;font:11px 'Fira Code',monospace;background:var(--bg-tertiary);color:var(--accent-orange);border:1px solid var(--accent-orange);border-radius:5px;padding:4px 9px;cursor:pointer}
+  body { font-family: 'Fira Code', var(--font-mono); }
+  #t { position: fixed; top: 6px; right: 10px; z-index: 9999; font: 11px 'Fira Code', monospace; background: var(--bg-tertiary); color: var(--accent-orange); border: 1px solid var(--accent-orange); border-radius: 5px; padding: 4px 9px; cursor: pointer; }
 </style></head>
 <body>
 <button id="t" onclick="var x=document.getElementById('tron');x.disabled=!x.disabled;this.textContent=x.disabled?'tron OFF':'tron ON'">tron ON</button>
+
 <header class="terminal-header">
-  <span class="brand">STOCKTOPUS</span>
+  <span class="brand" title="Stocktopus">
+    <svg class="brand-octopus" viewBox="0 0 40 24" role="img" aria-label="Stocktopus" fill="currentColor">
+      <path d="M5 16.5 C5 8.8 11 2.5 20 2.5 C29 2.5 35 8.8 35 16.5 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 Z"/>
+      <circle cx="15" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+      <circle cx="25" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+    </svg>
+  </span>
   <div class="cmd-bar"><span class="cmd-prompt">&gt;</span><input class="cmd-input" placeholder="enter command..." spellcheck="false"></div>
   <div class="security-selector"><input class="security-input" value="DJT" spellcheck="false"></div>
   <span class="watchlist-picker">Default</span>
@@ -20,40 +31,42 @@
 </header>
 <div class="terminal-body">
   <main class="terminal-content" data-view="security">
-    <div class="company-panel" style="padding: 0px 0px 0px 11px">
+    <div id="company-panel" class="company-panel">
       <span class="cpanel-sym">DJT</span>
       <span class="cpanel-name">Trump Media &amp; Technology Group Corp.</span>
       <span class="cpanel-price">8.49</span>
       <span class="cpanel-change price-up">+0.39 (+4.81%)</span>
     </div>
-    <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row style="margin: 9px 8px 9px 5px">
-      <button class="info-tab st-tab active st-tab--active" data-tab="overview">Overview</button>
-      <button class="info-tab st-tab" data-tab="financials">Financial Modeling</button>
-      <button class="info-tab st-tab" data-tab="estimates">Estimates</button>
-      <button class="info-tab st-tab" data-tab="news">News</button>
-      <button class="info-tab st-tab" data-tab="ai">AI Analysis</button>
-      <button class="info-tab st-tab" data-tab="sector">Sector</button>
-      <button class="info-tab st-tab" data-tab="sec">SEC</button>
-    </div>
-    <div id="info-content" class="info-content">
-      <div class="info-sub-tabs news-sub-tabs st-tab-row st-tab-row--blue" id="news-sub-tabs" data-vim-row style="margin: 0px 0px -2px; align-items: center">
-        <button class="info-sub-tab st-tab" data-cat="press">Press Releases</button>
-        <button class="info-sub-tab st-tab" data-cat="articles">Articles</button>
-        <button class="info-sub-tab st-tab" data-cat="stock">Stock</button>
-        <button class="info-sub-tab st-tab" data-cat="crypto">Crypto</button>
-        <button class="info-sub-tab st-tab" data-cat="forex">Forex</button>
-        <button class="info-sub-tab st-tab active" data-cat="general">General</button>
+    <div class="info-panel">
+      <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row data-vim-role="tabs">
+        <button class="info-tab st-tab" data-tab="overview" data-vim-item>Overview</button>
+        <button class="info-tab st-tab" data-tab="financials" data-vim-item>Financial Modeling</button>
+        <button class="info-tab st-tab" data-tab="estimates" data-vim-item>Estimates</button>
+        <button class="info-tab st-tab active st-tab--active" data-tab="news" data-vim-item>News</button>
+        <button class="info-tab st-tab" data-tab="ai" data-vim-item>AI Analysis</button>
+        <button class="info-tab st-tab" data-tab="sector" data-vim-item>Sector</button>
+        <button class="info-tab st-tab" data-tab="sec" data-vim-item>SEC</button>
       </div>
-      <div style="margin-top:12px">
-        <div class="news-item">
-          <div style="font-weight:700;color:var(--text-primary)">Natural Gas, WTI Oil, Brent Oil Forecasts — Oil Moves Higher</div>
-          <div style="font-size:10px;color:var(--text-muted);margin:4px 0">FXEmpire · Jun 19, 2026</div>
-          <div style="color:var(--text-secondary)">Iran wants Israel to stop its military operation against Hezbollah in Lebanon.</div>
+      <div id="info-content" class="info-content" data-symbol="DJT">
+        <div class="info-sub-tabs news-sub-tabs st-tab-row st-tab-row--blue" id="news-sub-tabs" data-vim-row>
+          <button class="info-sub-tab st-tab" data-cat="press-releases" data-vim-item>Press Releases</button>
+          <button class="info-sub-tab st-tab" data-cat="articles" data-vim-item>Articles</button>
+          <button class="info-sub-tab st-tab" data-cat="stock" data-vim-item>Stock</button>
+          <button class="info-sub-tab st-tab" data-cat="crypto" data-vim-item>Crypto</button>
+          <button class="info-sub-tab st-tab" data-cat="forex" data-vim-item>Forex</button>
+          <button class="info-sub-tab st-tab active st-tab--active" data-cat="general" data-vim-item>General</button>
         </div>
-        <div class="news-item">
-          <div style="font-weight:700;color:var(--text-primary)">The Bond Market Is Too Hawkish</div>
-          <div style="font-size:10px;color:var(--text-muted);margin:4px 0">Seeking Alpha · Jun 19, 2026</div>
-          <div style="color:var(--text-secondary)">Developed-market central banks went hawkish in unison.</div>
+        <div class="news-cards" id="info-news-cards">
+          <div class="news-card news-unread">
+            <div class="news-card-title"><a>Natural Gas, WTI Oil, Brent Oil Forecasts — Oil Moves Higher</a></div>
+            <div class="news-card-meta"><span>FXEmpire</span><span>Jun 19, 2026</span></div>
+            <div class="news-card-text">Iran wants Israel to stop its military operation against Hezbollah in Lebanon.</div>
+          </div>
+          <div class="news-card">
+            <div class="news-card-title"><a>The Bond Market Is Too Hawkish</a></div>
+            <div class="news-card-meta"><span>Seeking Alpha</span><span>Jun 19, 2026</span></div>
+            <div class="news-card-text">Developed-market central banks went hawkish in unison.</div>
+          </div>
         </div>
       </div>
     </div>
@@ -63,6 +76,10 @@
   <span class="footer-mode normal">NORMAL</span>
   <span class="footer-view">INFO</span>
   <span class="footer-help">/ cmd · s security · hjkl nav · : chart cmd</span>
-  <div class="footer-clocks"><span class="tz-block"><span class="tz-label">ET</span>20:56</span></div>
+  <div class="footer-clocks">
+    <span class="tz-block"><span class="tz-label">ET</span>20:56</span>
+    <span class="tz-block"><span class="tz-label">UTC</span>00:56</span>
+    <span class="tz-block"><span class="tz-label">JST</span>09:56</span>
+  </div>
 </footer>
 </body></html>

--- a/docs/design-system-export/production/preview-overview.html
+++ b/docs/design-system-export/production/preview-overview.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Stocktopus — Crypto Overview (Tron preview)</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="_real-style.css">
+<!-- Live base — keep DOM/classes in sync with internal/server/templates/crypto.html -->
+<link rel="stylesheet" href="../../../internal/server/static/style.css">
 <link rel="stylesheet" href="tron.css" id="tron">
 <style>
   body{font-family:'Fira Code',var(--font-mono)}
@@ -12,7 +15,13 @@
 <body>
 <button id="t" onclick="var x=document.getElementById('tron');x.disabled=!x.disabled;this.textContent=x.disabled?'tron OFF':'tron ON'">tron ON</button>
 <header class="terminal-header">
-  <span class="brand">STOCKTOPUS</span>
+  <span class="brand" title="Stocktopus">
+    <svg class="brand-octopus" viewBox="0 0 40 24" role="img" aria-label="Stocktopus" fill="currentColor">
+      <path d="M5 16.5 C5 8.8 11 2.5 20 2.5 C29 2.5 35 8.8 35 16.5 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 Z"/>
+      <circle cx="15" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+      <circle cx="25" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+    </svg>
+  </span>
   <div class="cmd-bar"><span class="cmd-prompt">&gt;</span><input class="cmd-input" placeholder="enter command..." value="" spellcheck="false"></div>
   <div class="security-selector"><input class="security-input" value="KR" spellcheck="false"></div>
   <span class="watchlist-picker">Default</span>
@@ -21,13 +30,14 @@
 <div class="terminal-body">
   <main class="terminal-content" data-view="crypto">
     <div id="company-panel" class="company-panel"></div>
-    <div class="info-tabs" id="info-tabs" data-vim-row>
-      <button class="info-tab active" data-tab="overview">Overview</button>
-      <button class="info-tab" data-tab="news">News</button>
-      <button class="info-tab" data-tab="ai">AI Analysis</button>
-      <button class="info-tab" data-tab="peers">Peer Coins</button>
+    <div class="info-panel">
+    <div class="info-tabs st-tab-row" id="info-tabs" data-vim-row data-vim-role="tabs">
+      <button class="info-tab st-tab active st-tab--active" data-tab="overview" data-vim-item>Overview</button>
+      <button class="info-tab st-tab" data-tab="news" data-vim-item>News</button>
+      <button class="info-tab st-tab" data-tab="ai" data-vim-item>AI Analysis</button>
+      <button class="info-tab st-tab" data-tab="peers" data-vim-item>Peer Coins</button>
     </div>
-    <div id="info-content" class="info-content">
+    <div id="info-content" class="info-content" data-symbol="KR">
       <div class="crypto-header">
         <span class="crypto-name">The Kroger Co.</span>
         <span class="crypto-exchange">NYSE</span>
@@ -46,14 +56,15 @@
         <div class="crypto-stat"><span class="crypto-stat-label">50-Day Avg</span><span class="crypto-stat-value">$65.7394</span></div>
         <div class="crypto-stat"><span class="crypto-stat-label">200-Day Avg</span><span class="crypto-stat-value">$66.4658</span></div>
       </div>
-      <div class="crypto-chart" style="height:230px;display:flex;align-items:center;justify-content:center;color:var(--text-muted)">[ price chart ]</div>
+      <div class="crypto-chart">[ price chart ]</div>
       <div class="crypto-desc">The Kroger Co. functions as a significant retail entity throughout the United States, encompassing a varied collection of store formats. Its operations include integrated food and drug stores, which stock a broad range of products from natural and organic sections to pharmacies, general merchandise, pet centers, fresh seafood, and organic produce. Established in 1883, the company is headquartered in Cincinnati, Ohio.</div>
+    </div>
     </div>
   </main>
 </div>
 <footer class="terminal-footer">
   <span class="footer-mode normal">NORMAL</span>
-  <span class="footer-view">crypto</span>
+  <span class="footer-view">CRYPTO</span>
   <span class="footer-help">/ cmd &middot; s security &middot; hjkl nav &middot; : chart cmd</span>
   <div class="footer-clocks"><span class="tz-block"><span class="tz-label">ET</span>09:41</span></div>
 </footer>

--- a/docs/design-system-export/production/preview-screener.html
+++ b/docs/design-system-export/production/preview-screener.html
@@ -5,7 +5,8 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="_real-style.css">
+<!-- Live base — keep DOM/classes in sync with internal/server/templates/screener.html -->
+<link rel="stylesheet" href="../../../internal/server/static/style.css">
 <link rel="stylesheet" href="tron.css" id="tron">
 <style>
   body{font-family:'Fira Code',var(--font-mono)}
@@ -22,7 +23,13 @@
 <button id="t" onclick="var x=document.getElementById('tron');x.disabled=!x.disabled;this.textContent=x.disabled?'tron OFF':'tron ON'">tron ON</button>
 
 <header class="terminal-header">
-  <span class="brand">STOCKTOPUS</span>
+  <span class="brand" title="Stocktopus">
+    <svg class="brand-octopus" viewBox="0 0 40 24" role="img" aria-label="Stocktopus" fill="currentColor">
+      <path d="M5 16.5 C5 8.8 11 2.5 20 2.5 C29 2.5 35 8.8 35 16.5 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 Z"/>
+      <circle cx="15" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+      <circle cx="25" cy="12.5" r="2" fill="var(--bg-secondary)"/>
+    </svg>
+  </span>
   <div class="cmd-bar"><span class="cmd-prompt">&gt;</span><input class="cmd-input" placeholder="enter command..." spellcheck="false"></div>
   <div class="security-selector"><input class="security-input" value="DJTWW" spellcheck="false"></div>
   <span class="watchlist-picker">Default</span>
@@ -31,9 +38,9 @@
 
 <div class="terminal-body">
   <main class="terminal-content" data-view="screener">
-    <div class="screener-layout">
-      <aside class="screener-filters">
-        <div class="screener-filters-header">Filters</div>
+    <div class="screener-layout st-split">
+      <aside class="screener-filters st-pane st-pane--nav">
+        <div class="screener-filters-header st-pane-header">Filters</div>
         <form class="screener-form">
           <details class="screener-group" open>
             <summary>Fundamentals</summary>
@@ -59,13 +66,13 @@
         </form>
       </aside>
 
-      <section class="screener-results">
-        <div class="screener-results-header">
+      <section class="screener-results st-pane st-pane--content">
+        <div class="screener-results-header st-pane-header">
           <h2>Results</h2>
           <span class="screener-results-meta">10 matches · sorted Δ prev %</span>
         </div>
         <div class="screener-table-wrap">
-          <table class="screener-table">
+          <table class="screener-table" id="screener-table">
             <thead>
               <tr>
                 <th>Security</th><th>Company</th><th>Sector</th>

--- a/docs/design-system-export/production/tron.css
+++ b/docs/design-system-export/production/tron.css
@@ -495,20 +495,15 @@ body { background: var(--bg-deep); }
 .ideas-list-name { color: var(--text-primary); }
 
 /* ───────────────────────── NEWS PAGE (full /news view) ─────────────────────────
-   The /news view uses .news-tab / .news-card classes the overlay didn't reach,
-   so it fell back to raw base style. Bring it into the system. */
-
-/* Tab strip — amber active with glow (consistent with info tabs). */
-.news-tab.active {
-    color: var(--accent-orange) !important;
-    border-color: var(--accent-orange) !important;
-    box-shadow: var(--glow-amber);
-    text-shadow: var(--text-glow-amber);
-    border-radius: var(--control-radius) !important;
-}
-.news-tab { border-radius: var(--control-radius) !important; white-space: nowrap; }
+   Primary category tabs use .info-panel > .info-tabs (orange primary nav —
+   same chrome as security info). Card polish below; tab strip rules live in
+   style.css. */
 
 /* Cards become rounded panel boxes with a consistent gap; cyan hover glow. */
+.info-panel > .info-content.news-cards {
+    padding-inline: var(--panel-gap);
+    box-sizing: border-box;
+}
 .news-cards { gap: var(--panel-gap) !important; padding-top: 2px; }
 .news-card {
     background: var(--panel-bg) !important;

--- a/docs/index.html
+++ b/docs/index.html
@@ -92,7 +92,7 @@
   <div class="grid">
     <a class="card" href="design-system-export/production/preview-avgo-overview.html"><div class="name">AVGO · Overview</div><div class="desc">Stat grid + Key People / company profile, 1:3 columns.</div></a>
     <a class="card" href="design-system-export/production/preview-avgo-estimates.html"><div class="name">AVGO · Estimates</div><div class="desc">Analyst estimates with YoY comparison rows.</div></a>
-    <a class="card" href="design-system-export/production/preview-avgo-news.html"><div class="name">AVGO · News</div><div class="desc">Per-security news tab.</div></a>
+    <a class="card" href="design-system-export/production/preview-avgo-news.html"><div class="name">AVGO · News</div><div class="desc">Security info News tab — orange primary nav + cyan category sub-tabs.</div></a>
     <a class="card" href="design-system-export/production/preview-avgo-ai.html"><div class="name">AVGO · AI Analysis</div><div class="desc">AI analysis tab layout.</div></a>
     <a class="card" href="design-system-export/production/preview-financials.html"><div class="name">Financials</div><div class="desc">Financial statements table + totals.</div></a>
     <a class="card" href="design-system-export/production/preview-goog-sec.html"><div class="name">GOOG · Security page</div><div class="desc">Full security page composition.</div></a>
@@ -109,8 +109,8 @@
   <div class="grid">
     <a class="card" href="design-system-export/production/preview-info.html"><div class="name">Info panel</div><div class="desc">Tabbed info panel (blue menu band).</div></a>
     <a class="card" href="design-system-export/production/preview-overview.html"><div class="name">Overview</div><div class="desc">Generic overview composition.</div></a>
-    <a class="card" href="design-system-export/production/preview-news.html"><div class="name">News (panel)</div><div class="desc">News inside the info panel.</div></a>
-    <a class="card" href="design-system-export/production/preview-news-page.html"><div class="name">News (full page)</div><div class="desc">Standalone /news view.</div></a>
+    <a class="card" href="design-system-export/production/preview-news.html"><div class="name">News (panel)</div><div class="desc">Info panel News tab — category filters as cyan `.news-sub-tabs` under orange primary.</div></a>
+    <a class="card" href="design-system-export/production/preview-news-page.html"><div class="name">News (full page)</div><div class="desc">`/news` route — category filters as `.info-panel` primary nav (orange), live `style.css`.</div></a>
   </div>
 
   <footer>

--- a/internal/server/static/indices.js
+++ b/internal/server/static/indices.js
@@ -53,6 +53,32 @@
 
     function esc(s) { return (s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;'); }
 
+    function buildIndexSparkClusterHtml(symbol) {
+        var specs = window.MINI_SPARK_SPECS || [];
+        var hosts = specs.map(function (s) {
+            return '<div class="wl-spark" data-range="' + s.key + '"></div>';
+        }).join('');
+        return '<div class="wl-sparks" data-spark-sym="' + esc(symbol) + '">' + hosts + '</div>';
+    }
+
+    function hydrateIndexSparks(symbol) {
+        var cluster = document.querySelector('.wl-sparks[data-spark-sym="' + symbol + '"]');
+        if (!cluster) return;
+        var specs = window.MINI_SPARK_SPECS || [];
+        function run() {
+            if (!window.LightweightCharts || !window._loadMiniSpark) {
+                setTimeout(run, 200);
+                return;
+            }
+            specs.forEach(function (spec) {
+                var host = cluster.querySelector('.wl-spark[data-range="' + spec.key + '"]');
+                if (!host) return;
+                window._loadMiniSpark(host, null, symbol, spec);
+            });
+        }
+        run();
+    }
+
     // Load indices
     fetch('/api/indices')
         .then(function (r) { return r.json(); })
@@ -71,7 +97,7 @@
 
             // Render table shell
             var html = '<table class="fin-table indices-table" id="indices-table"><thead><tr>';
-            html += '<th>Index</th><th>2D</th><th>Price</th><th>Change</th><th>% Change</th><th>Local Time</th>';
+            html += '<th>Index</th><th>Trend</th><th>Price</th><th>Change</th><th>% Change</th><th>Local Time</th>';
             html += '</tr></thead><tbody>';
             indices.forEach(function (idx) {
                 var local = getLocalTime(idx.exchange);
@@ -80,7 +106,7 @@
                 var safeId = idx.symbol.replace('^', '');
                 html += '<tr class="idx-row" data-symbol="' + esc(idx.symbol) + '" data-exchange="' + esc(idx.exchange) + '">'
                     + '<td class="idx-name"><span class="idx-sym">' + esc(idx.symbol) + '</span> <span class="idx-label">' + esc(idx.name) + '</span></td>'
-                    + '<td><div class="idx-spark" data-spark-sym="' + esc(idx.symbol) + '"></div></td>'
+                    + '<td class="wl-spark-cell">' + buildIndexSparkClusterHtml(idx.symbol) + '</td>'
                     + '<td class="idx-price" id="price-' + safeId + '">—</td>'
                     + '<td class="idx-change" id="change-' + safeId + '">—</td>'
                     + '<td class="idx-pct" id="pct-' + safeId + '">—</td>'
@@ -93,8 +119,8 @@
             // Fetch quotes for each index
             indices.forEach(function (idx) { fetchIndexQuote(idx.symbol); });
 
-            // Load sparklines
-            loadIndexSparklines(indices);
+            // Load spark cluster (2d / 6M / 1y via MINI_SPARK_SPECS)
+            indices.forEach(function (idx) { hydrateIndexSparks(idx.symbol); });
 
             // Update local times every minute
             setInterval(function () { updateLocalTimes(indices); }, 60000);
@@ -128,43 +154,6 @@
                 if (pctEl) { pctEl.textContent = (q.changePercentage >= 0 ? '+' : '') + q.changePercentage.toFixed(2) + '%'; pctEl.className = 'idx-pct ' + chgClass; }
             })
             .catch(function () {});
-    }
-
-    function loadIndexSparklines(indices) {
-        function tryRender() {
-            if (!window.LightweightCharts) { setTimeout(tryRender, 200); return; }
-            var from = new Date(); from.setDate(from.getDate() - 5);
-            var fromStr = from.toISOString().slice(0, 10);
-            var toStr = new Date().toISOString().slice(0, 10);
-
-            document.querySelectorAll('.idx-spark').forEach(function (el) {
-                var sym = el.dataset.sparkSym;
-                if (!sym) return;
-                fetch('/api/chart/eod/' + encodeURIComponent(sym) + '?from=' + fromStr + '&to=' + toStr)
-                    .then(function (r) { return r.json(); })
-                    .then(function (data) {
-                        if (!data || data.length < 2) return;
-                        var first = data[0].close, last = data[data.length - 1].close;
-                        var color = last >= first ? '#00cc66' : '#ff4444';
-                        var chart = LightweightCharts.createChart(el, {
-                            width: 80, height: 24,
-                            layout: { background: { color: 'transparent' }, textColor: 'transparent', attributionLogo: false },
-                            grid: { vertLines: { visible: false }, horzLines: { visible: false } },
-                            rightPriceScale: { visible: false }, timeScale: { visible: false },
-                            handleScroll: false, handleScale: false,
-                            crosshair: { vertLine: { visible: false }, horzLine: { visible: false } },
-                        });
-                        var series = chart.addSeries(LightweightCharts.AreaSeries, {
-                            lineColor: color, topColor: color.replace(')', ',0.15)').replace('rgb', 'rgba'),
-                            bottomColor: 'transparent', lineWidth: 1,
-                            priceLineVisible: false, lastValueVisible: false,
-                        });
-                        series.setData(data.map(function (d) { return { time: d.date, value: d.close }; }));
-                        chart.timeScale().fitContent();
-                    }).catch(function () {});
-            });
-        }
-        tryRender();
     }
 
     function updateLocalTimes(indices) {

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -2169,47 +2169,28 @@ body {
 /* ── News View ── */
 
 .news-tabs {
-    display: flex;
-    gap: 4px;
-    margin-bottom: 16px;
-    border-bottom: 1px solid var(--border);
-    padding-bottom: 8px;
+    /* Primary nav chrome flows from .info-panel > .info-tabs (shared with security info). */
+    flex: 1;
+    min-width: 0;
 }
 
-.news-tab {
-    background: transparent;
-    border: 1px solid transparent;
-    border-radius: 4px;
-    color: var(--text-secondary);
-    font-family: var(--font-mono);
-    font-size: 12px;
-    padding: 5px 12px;
-    cursor: pointer;
-}
-
-.news-tab:hover {
-    color: var(--text-primary);
-    background: var(--bg-tertiary);
-}
-
-.news-tab.active {
-    color: var(--orange);
-    border-color: var(--orange);
-    background: var(--bg-tertiary);
+.news-tabs .spinner {
+    margin-left: auto;
+    align-self: center;
+    margin-right: var(--space-3);
 }
 
 .news-tab.dimmed {
     color: var(--text-muted);
     opacity: 0.4;
     cursor: default;
+    pointer-events: none;
 }
 
 .news-cards {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    max-height: calc(100vh - 180px);
-    overflow-y: auto;
 }
 
 .news-card {
@@ -2753,8 +2734,8 @@ body {
 }
 
 /* Tab strips: faint row wash + neutral baseline (not table-row fill). */
-.st-tab-row[data-vim-row]:has(.vim-selected),
-.info-tabs[data-vim-row]:has(.vim-selected):not(#info-tabs),
+.st-tab-row:not(.info-tabs)[data-vim-row]:has(.vim-selected),
+.info-tabs[data-vim-row]:has(.vim-selected):not(#info-tabs):not(#news-tabs),
 .economics-tabs[data-vim-row]:has(.vim-selected) {
     background: var(--tab-row-focus-bg);
     box-shadow: inset 0 -1px 0 var(--border);
@@ -2768,9 +2749,9 @@ body {
 
 /* Tab vim focus: colour only — fill slide is on ::before (see .st-tab rules).
    Primary + sub info-panel nav keep Tron tab chrome below. */
-.st-tab-row .st-tab.vim-selected,
-.st-tab-row .info-tab.vim-selected,
-.info-tabs:not(#info-tabs) .info-tab.vim-selected,
+.st-tab-row:not(.info-tabs) .st-tab.vim-selected,
+.st-tab-row:not(.info-tabs) .info-tab.vim-selected,
+.info-tabs:not(#info-tabs):not(#news-tabs) .info-tab.vim-selected,
 .news-sub-tabs .info-sub-tab.vim-selected,
 .news-sub-tabs .st-tab.vim-selected {
     background: transparent !important;
@@ -2827,19 +2808,10 @@ body {
     text-align: left !important;
 }
 
-.idx-spark {
-    width: 80px;
-    height: 24px;
-}
-
 .idx-spark-selected {
     outline: 1px solid var(--orange);
     outline-offset: 1px;
     border-radius: 3px;
-}
-
-.idx-spark a[href*="tradingview"] {
-    display: none !important;
 }
 
 .idx-price {
@@ -4830,10 +4802,10 @@ body { background: var(--bg-deep); }
    just brighter amber/cyan text with a short underline tick beneath it. */
 
 /* 1 — kill the full-row baseline on generic st-tab strips (not info-panel nav). */
-.st-tab-row:not(.info-sub-tabs):not(.news-sub-tabs), .chart-range-bar,
+.st-tab-row:not(.info-sub-tabs):not(.news-sub-tabs):not(.info-tabs), .chart-range-bar,
 .economics-tabs,
-.st-tab-row:not(.info-sub-tabs):not(.news-sub-tabs).tab-row-focused,
-.st-tab-row:not(.info-sub-tabs):not(.news-sub-tabs)[data-vim-row]:has(.vim-selected),
+.st-tab-row:not(.info-sub-tabs):not(.news-sub-tabs):not(.info-tabs).tab-row-focused,
+.st-tab-row:not(.info-sub-tabs):not(.news-sub-tabs):not(.info-tabs)[data-vim-row]:has(.vim-selected),
 .economics-tabs[data-vim-row]:has(.vim-selected) {
     box-shadow: none !important;
     border-bottom: none !important;
@@ -4897,7 +4869,9 @@ body { background: var(--bg-deep); }
 /* Row-focus wash bleeds into content padding — bright at top, opaque black below. */
 .info-panel > .info-tabs.tab-row-focused::after,
 .info-panel > .info-tabs[data-vim-row]:has(.vim-selected)::after,
-.info-panel > .info-tabs:has(.info-tab.active)::after {
+.info-panel > .info-tabs:has(.info-tab.active)::after,
+.info-panel > .info-tabs:has(.news-tab.active)::after,
+.info-panel > .info-tabs:has(.st-tab--active)::after {
     content: '';
     position: absolute;
     left: 0;
@@ -4975,6 +4949,7 @@ body { background: var(--bg-deep); }
 }
 
 .info-panel > .info-tabs .info-tab,
+.info-panel > .info-tabs .news-tab,
 .info-sub-tabs .info-sub-tab,
 .news-sub-tabs .info-sub-tab {
     display: inline-flex;
@@ -4992,11 +4967,15 @@ body { background: var(--bg-deep); }
 }
 
 .info-panel > .info-tabs .info-tab::before,
+.info-panel > .info-tabs .news-tab::before,
 .info-sub-tabs .info-sub-tab::before,
 .news-sub-tabs .info-sub-tab::before { display: none !important; }
 
 .info-panel > .info-tabs .info-tab.active,
-.info-panel > .info-tabs .info-tab.vim-selected {
+.info-panel > .info-tabs .info-tab.vim-selected,
+.info-panel > .info-tabs .news-tab.active,
+.info-panel > .info-tabs .news-tab.vim-selected,
+.info-panel > .info-tabs .st-tab--active {
     background: color-mix(in srgb, var(--accent-orange) 45%, var(--panel-bg-soft)) !important;
     color: var(--accent-orange);
     text-shadow: var(--text-glow-amber);
@@ -5009,7 +4988,10 @@ body { background: var(--bg-deep); }
 
 /* Active primary tab notches through the panel top edge when present. */
 .info-panel > .info-tabs .info-tab.active::after,
-.info-panel > .info-tabs .info-tab.vim-selected::after {
+.info-panel > .info-tabs .info-tab.vim-selected::after,
+.info-panel > .info-tabs .news-tab.active::after,
+.info-panel > .info-tabs .news-tab.vim-selected::after,
+.info-panel > .info-tabs .st-tab--active::after {
     content: '';
     position: absolute;
     left: 0;
@@ -5056,7 +5038,9 @@ body { background: var(--bg-deep); }
 .info-sub-tab.active, .info-sub-tab.vim-selected,
 .st-tab-row--blue .st-tab--active { text-shadow: var(--text-glow-cyan); }
 .info-panel > .info-tabs .info-tab.active,
-.info-panel > .info-tabs .info-tab.vim-selected { text-shadow: var(--text-glow-amber); }
+.info-panel > .info-tabs .info-tab.vim-selected,
+.info-panel > .info-tabs .news-tab.active,
+.info-panel > .info-tabs .news-tab.vim-selected { text-shadow: var(--text-glow-amber); }
 
 /* Scroll host for tab body — sub-tab strips scroll with content; panel chrome clips corners. */
 .info-panel > .info-content {
@@ -5487,20 +5471,13 @@ table tbody tr.st-row-selected > td:first-child {
    (.st-nav-list > li.active / .vim-selected). Do not redefine per page. */
 
 /* ───────────────────────── NEWS PAGE (full /news view) ─────────────────────────
-   The /news view uses .news-tab / .news-card classes the overlay didn't reach,
-   so it fell back to raw base style. Bring it into the system. */
-
-/* Tab strip — amber active with glow (consistent with info tabs). */
-.news-tab.active {
-    color: var(--accent-orange) !important;
-    border-color: var(--accent-orange) !important;
-    box-shadow: var(--glow-amber);
-    text-shadow: var(--text-glow-amber);
-    border-radius: var(--control-radius) !important;
-}
-.news-tab { border-radius: var(--control-radius) !important; white-space: nowrap; }
+   Tab strip uses the shared .info-panel > .info-tabs primary nav. Card polish below. */
 
 /* Cards become rounded panel boxes with a consistent gap; cyan hover glow. */
+.info-panel > .info-content.news-cards {
+    padding-inline: var(--panel-gap);
+    box-sizing: border-box;
+}
 .news-cards { gap: var(--panel-gap) !important; padding-top: 2px; }
 .news-card {
     background: var(--panel-bg) !important;

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -1146,8 +1146,10 @@ window.onerror = function (msg, src, line, col, err) {
         tabs.querySelectorAll('.news-tab').forEach(function (tab) {
             tab.onclick = function () {
                 if (tab.classList.contains('dimmed')) return;
-                tabs.querySelectorAll('.news-tab').forEach(function (t) { t.classList.remove('active'); });
-                tab.classList.add('active');
+                tabs.querySelectorAll('.news-tab').forEach(function (t) {
+                    t.classList.remove('active', 'st-tab--active');
+                });
+                tab.classList.add('active', 'st-tab--active');
                 fetchNews(tab.dataset.category);
             };
         });
@@ -2940,7 +2942,7 @@ window.onerror = function (msg, src, line, col, err) {
                     el.classList.remove('idx-spark-selected');
                 });
                 if (this._colFocus === 'spark' && vimSelectedIndex >= 0 && items[vimSelectedIndex]) {
-                    var sparkCell = items[vimSelectedIndex].querySelector('.idx-spark');
+                    var sparkCell = items[vimSelectedIndex].querySelector('.wl-sparks');
                     if (sparkCell) sparkCell.classList.add('idx-spark-selected');
                 }
             },

--- a/internal/server/templates/news.html
+++ b/internal/server/templates/news.html
@@ -1,16 +1,18 @@
 {{template "layout" .}}
 {{define "content"}}
 <div id="company-panel" class="company-panel"></div>
-<div class="news-tabs st-tab-row" id="news-tabs" data-vim-region data-vim-axis="x" data-vim-role="tabs">
-    <button class="news-tab st-tab active" data-category="press-releases" data-vim-item>Press Releases</button>
-    <button class="news-tab st-tab" data-category="articles" data-vim-item>Articles</button>
-    <button class="news-tab st-tab" data-category="stock" data-vim-item>Stock</button>
-    <button class="news-tab st-tab" data-category="crypto" data-vim-item>Crypto</button>
-    <button class="news-tab st-tab" data-category="forex" data-vim-item>Forex</button>
-    <button class="news-tab st-tab" data-category="general" data-vim-item>General</button>
+<div class="info-panel">
+<div class="news-tabs info-tabs st-tab-row" id="news-tabs" data-vim-row data-vim-role="tabs">
+    <button class="news-tab info-tab st-tab active st-tab--active" data-category="press-releases" data-vim-item>Press Releases</button>
+    <button class="news-tab info-tab st-tab" data-category="articles" data-vim-item>Articles</button>
+    <button class="news-tab info-tab st-tab" data-category="stock" data-vim-item>Stock</button>
+    <button class="news-tab info-tab st-tab" data-category="crypto" data-vim-item>Crypto</button>
+    <button class="news-tab info-tab st-tab" data-category="forex" data-vim-item>Forex</button>
+    <button class="news-tab info-tab st-tab" data-category="general" data-vim-item>General</button>
     <span id="news-spinner" class="spinner hidden"></span>
 </div>
-<div id="news-cards" class="news-cards" data-vim-scroll>
+<div id="news-cards" class="news-cards info-content" data-vim-scroll>
     <p class="empty-state">Loading...</p>
+</div>
 </div>
 {{end}}


### PR DESCRIPTION
## Summary
- Align `/news` primary navigation with the security info panel (orange tabs, `.info-panel` wrapper) for consistent chrome across views.
- Migrate all 13 design-system export previews to live `style.css` plus `tron.css`, with docs/README/design-language updates.
- Indices table sparklines use 2D/6M/1Y clusters matching the watchlist pattern.

## Test plan
- [ ] Open `/news` and confirm primary nav matches a security info-panel (orange tabs, layout).
- [ ] Spot-check design previews under `docs/design-system-export/production/` in a browser.
- [ ] Open indices view and verify three-interval sparklines render and update.
- [ ] `make test` / `go build ./...` pass locally.

