### PR TITLE
Add favicon and feature-branch workflow rule

### DIFF
--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -1,0 +1,10 @@
+---
+description: Git branching workflow — never commit directly to master
+alwaysApply: true
+---
+
+All code on this project must land via a **feature branch**, never committed directly to `master`.
+
+- Create a branch before making commits (e.g. `feature/…`, `fix/…`)
+- Open a PR to merge into `master`; do not push commits straight to `master`
+- When starting new work, branch from an up-to-date `master`

--- a/docs/design-language.md
+++ b/docs/design-language.md
@@ -421,7 +421,7 @@ Use for all signed numeric columns (watchlist changes, screener Δ columns, etc.
 
 | Region | DOM / class anchors | Primitives to apply |
 |--------|---------------------|---------------------|
-| **Shell** | `.terminal-header`, `.terminal-footer`, `.cmd-bar`, `.brand` | Orange brand text; cmd-bar focus = orange line; footer mode = `st-chip` semantic |
+| **Shell** | `.terminal-header`, `.terminal-footer`, `.cmd-bar`, `.brand`, `favicon.svg` | Orange brand octopus (header + favicon); cmd-bar focus = orange line; footer mode = `st-chip` semantic |
 | **Watchlist** | `.watchlist`, `.quote-table`, `.wl-tab`, `.wl-spark-cell` | `st-table`, `st-link-sym`, `st-tab` for tabs; market colors for deltas; 6M sparkline label uses `price-up`/`price-down` |
 | **Graph** | `.chart-range-bar`, `.chart-range-btn`, `.chart-toggle`, `.chart-container` | `st-tab` for range buttons; toggles: green only when “on” |
 | **Info** | `.info-panel`, `.info-tabs`, `.info-sub-tabs`, `.company-panel`, peer/SEC tables | Blue menu band on sub strips; orange primary; `st-row-selected` on tables |
@@ -480,6 +480,7 @@ Use for all signed numeric columns (watchlist changes, screener Δ columns, etc.
 
 ### Shell
 - [ ] Brand orange is saturated, readable on `#0a0a0a`.
+- [ ] Header `.brand-octopus` and `internal/server/static/favicon.svg` share the same octopus mark (`viewBox` 40×24 body path; favicon uses square 40×32 canvas with `--accent-orange` / `--bg-secondary` fills).
 - [ ] Cmd bar focus uses orange line token.
 - [ ] Footer `NORMAL` / view label uses chip/surface tokens.
 
@@ -740,6 +741,7 @@ Optional: `.st-tab--active` inset bar `0 -3px 0` (ternary stroke) instead of `-2
 
 | Path | Role |
 |------|------|
+| `internal/server/static/favicon.svg` | Browser tab icon — same octopus mark as `.brand-octopus` in `layout.html` (`--accent-orange` body, `--bg-secondary` eyes on `--bg-primary` canvas). Linked from `layout.html` `<head>`. |
 | **`docs/design-system-export/`** | Visual reference kit from design export zip — HTML previews, `tron.css`, `_real-style.css`, `INTEGRATION.md`, `tweaks-panel.jsx`. Open previews locally to compare Tron on/off. |
 | **`docs/design-language.md`** | Written spec (this file) — tokens, primitives, rollout, ternary system. |
 | `watchlist-reader-ui-handoff.md` | Feature/UI content changes (when present in repo). |

--- a/docs/design-system-export/README.md
+++ b/docs/design-system-export/README.md
@@ -9,6 +9,7 @@ Source: `Stocktopus Design System (3).zip` (2026-06-21). Static preview pages + 
 | `INTEGRATION.md` | How to ship `tron.css` (Option A: second `<link>`; Option B: merge into `style.css`) |
 | `_real-style.css` | Snapshot of app `style.css` at export time (~99k) |
 | `tron.css` | Tron glow / panel overlay (now merged into live `internal/server/static/style.css`) |
+| `favicon.svg` | Lives in live app at `internal/server/static/favicon.svg` — octopus brand mark for browser tabs (see `layout.html`) |
 | `tweaks-panel.jsx` | React tweaks UI for Overview density / focus / stat highlight experiments |
 | `preview-*.html` | Full-page mocks (open in browser; toggle **tron ON/OFF** where provided) |
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Stocktopus — Design System</title>
+<link rel="icon" href="../internal/server/static/favicon.svg" type="image/svg+xml">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/internal/server/static/favicon.svg
+++ b/internal/server/static/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 32" role="img" aria-label="Stocktopus">
+  <rect width="40" height="32" fill="#0a0a0a"/>
+  <g transform="translate(0 4)" fill="#ff9a1a">
+    <path d="M5 16.5 C5 8.8 11 2.5 20 2.5 C29 2.5 35 8.8 35 16.5 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 a1.875 5 0 0 0 -3.75 0 Z"/>
+    <circle cx="15" cy="12.5" r="2" fill="#111111"/>
+    <circle cx="25" cy="12.5" r="2" fill="#111111"/>
+  </g>
+</svg>

--- a/internal/server/templates/layout.html
+++ b/internal/server/templates/layout.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Stocktopus — {{.Title}}</title>
+    <link rel="icon" href="/static/favicon.svg?v={{.AssetVersion}}" type="image/svg+xml">
     <link rel="stylesheet" href="/static/style.css?v={{.AssetVersion}}">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Add `favicon.svg` and wire it into the app layout and design docs
- Add Cursor rule requiring feature branches and PRs to `master` (no direct commits)

## Test plan
- [ ] Run `make dev` and confirm favicon appears in browser tab
- [ ] Verify `docs/index.html` shows favicon on GitHub Pages preview
- [ ] Confirm `.cursor/rules/git-workflow.mdc` is picked up by Cursor


Made with [Cursor](https://cursor.com)