### PR TITLE
feat(engine): optimal-entry backtest engine + endpoint

### DIFF
--- a/internal/engine/backtest/backtest.go
+++ b/internal/engine/backtest/backtest.go
@@ -1,0 +1,178 @@
+// Package backtest evaluates, on historical price bars, where the optimal
+// entry was inside a selected window — the engine behind the ideas-board
+// "agent-led optimal entry" analysis.
+//
+// The core question: for a symbol over a selected window, which entry bar
+// gave the best risk-adjusted return over a holding horizon H? Because the
+// answer is sensitive to exit timing and costs, each candidate entry is
+// scored over a Monte-Carlo cloud of jittered exits (around H) on the real
+// forward path, yielding an outcome distribution (mean / std / Sharpe /
+// win-rate) rather than a brittle point estimate.
+//
+// v1 keeps the cost function to risk-adjusted return (Sharpe-like) and the
+// Monte-Carlo to exit-timing jitter over the actual historical path. Later
+// passes can bootstrap forward returns and add drawdown / target-stop exit
+// rules — the EntryEval distribution and Assumptions knobs are the seam.
+package backtest
+
+import (
+	"errors"
+	"math"
+	"math/rand"
+
+	"stocktopus/internal/model"
+)
+
+// Assumptions are the (deliberately explicit) inputs the "optimal entry" is
+// optimal *with respect to*. Surfacing them is the point — the agent narrates
+// over them and the user can perturb them.
+type Assumptions struct {
+	Horizon     int     `json:"horizon"`     // target holding period, in bars
+	ExitJitter  int     `json:"exitJitter"`  // MC exits land within ±this many bars of Horizon
+	Sims        int     `json:"sims"`        // Monte-Carlo simulations per candidate entry
+	SlippageBps float64 `json:"slippageBps"` // round-trip slippage + cost, basis points
+	PerBarRF    float64 `json:"perBarRf"`    // risk-free return per bar (Sharpe numerator)
+	Seed        int64   `json:"seed"`        // RNG seed for reproducibility
+}
+
+// DefaultAssumptions is a reasonable daily-bars starting point.
+func DefaultAssumptions() Assumptions {
+	return Assumptions{Horizon: 10, ExitJitter: 3, Sims: 500, SlippageBps: 10, PerBarRF: 0, Seed: 1}
+}
+
+// EntryEval is the scored outcome distribution for entering at one bar.
+type EntryEval struct {
+	Index      int     `json:"index"`
+	Date       string  `json:"date"`
+	EntryPrice float64 `json:"entryPrice"`
+	MeanReturn float64 `json:"meanReturn"` // mean net return across sims
+	StdReturn  float64 `json:"stdReturn"`
+	Sharpe     float64 `json:"sharpe"`
+	PWin       float64 `json:"pWin"` // P(net return > 0)
+	Score      float64 `json:"score"`
+}
+
+// Result is the full analysis: the winning entry plus every candidate's
+// distribution (so the board can plot the score curve across the window).
+type Result struct {
+	Optimal     EntryEval   `json:"optimal"`
+	Candidates  []EntryEval `json:"candidates"`
+	Assumptions Assumptions `json:"assumptions"`
+}
+
+// FindOptimalEntry scores every candidate entry in bars[0..windowEnd] and
+// returns the highest-scoring one. bars must include a forward outcome window
+// past windowEnd (that's where the holding-period returns come from).
+func FindOptimalEntry(bars []model.OHLCV, windowEnd int, a Assumptions) (Result, error) {
+	if len(bars) < 2 {
+		return Result{}, errors.New("backtest: need at least 2 bars")
+	}
+	if windowEnd < 0 {
+		windowEnd = 0
+	}
+	if windowEnd > len(bars)-2 {
+		windowEnd = len(bars) - 2 // every entry needs ≥1 forward bar
+	}
+	if a.Sims <= 0 {
+		a.Sims = 1
+	}
+	if a.Horizon < 1 {
+		a.Horizon = 1
+	}
+	rng := rand.New(rand.NewSource(a.Seed))
+
+	cands := make([]EntryEval, 0, windowEnd+1)
+	for i := 0; i <= windowEnd; i++ {
+		if e, ok := evaluateEntry(bars, i, a, rng); ok {
+			cands = append(cands, e)
+		}
+	}
+	if len(cands) == 0 {
+		return Result{}, errors.New("backtest: no scorable entries in window")
+	}
+	best := cands[0]
+	for _, c := range cands[1:] {
+		if c.Score > best.Score {
+			best = c
+		}
+	}
+	return Result{Optimal: best, Candidates: cands, Assumptions: a}, nil
+}
+
+// evaluateEntry simulates entering at bar i and exiting near i+Horizon, with
+// exit timing jittered ±ExitJitter bars, on the real forward path.
+func evaluateEntry(bars []model.OHLCV, i int, a Assumptions, rng *rand.Rand) (EntryEval, bool) {
+	entry := bars[i].Close
+	if entry <= 0 || i+1 >= len(bars) {
+		return EntryEval{}, false
+	}
+	slip := a.SlippageBps / 10000.0
+	rets := make([]float64, 0, a.Sims)
+	for s := 0; s < a.Sims; s++ {
+		jitter := 0
+		if a.ExitJitter > 0 {
+			jitter = rng.Intn(2*a.ExitJitter+1) - a.ExitJitter
+		}
+		exitIdx := i + a.Horizon + jitter
+		if exitIdx <= i {
+			exitIdx = i + 1
+		}
+		if exitIdx >= len(bars) {
+			exitIdx = len(bars) - 1
+		}
+		exit := bars[exitIdx].Close
+		rets = append(rets, (exit/entry-1.0)-slip) // round-trip net return
+	}
+	m := mean(rets)
+	sd := std(rets, m)
+	sharpe := 0.0
+	if sd > 0 {
+		sharpe = (m - a.PerBarRF*float64(a.Horizon)) / sd
+	} else if m > 0 {
+		// Zero-variance positive outcome (e.g. no exit jitter): reward it so a
+		// deterministic winner still scores above a deterministic loser.
+		sharpe = m
+	}
+	return EntryEval{
+		Index: i, Date: bars[i].Date, EntryPrice: entry,
+		MeanReturn: m, StdReturn: sd, Sharpe: sharpe,
+		PWin:  frac(rets, func(r float64) bool { return r > 0 }),
+		Score: sharpe,
+	}, true
+}
+
+func mean(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	var s float64
+	for _, x := range xs {
+		s += x
+	}
+	return s / float64(len(xs))
+}
+
+func std(xs []float64, m float64) float64 {
+	if len(xs) < 2 {
+		return 0
+	}
+	var ss float64
+	for _, x := range xs {
+		d := x - m
+		ss += d * d
+	}
+	return math.Sqrt(ss / float64(len(xs)-1))
+}
+
+func frac(xs []float64, pred func(float64) bool) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	n := 0
+	for _, x := range xs {
+		if pred(x) {
+			n++
+		}
+	}
+	return float64(n) / float64(len(xs))
+}

--- a/internal/engine/backtest/backtest_test.go
+++ b/internal/engine/backtest/backtest_test.go
@@ -1,0 +1,114 @@
+package backtest
+
+import (
+	"fmt"
+	"testing"
+
+	"stocktopus/internal/model"
+)
+
+// closes builds daily bars from a close-price series (OHLC flat = close).
+func closes(prices ...float64) []model.OHLCV {
+	out := make([]model.OHLCV, len(prices))
+	for i, p := range prices {
+		out[i] = model.OHLCV{
+			Date:   fmt.Sprintf("2026-03-%02d", i+1),
+			Open:   p, High: p, Low: p, Close: p,
+			Volume: 1_000_000,
+		}
+	}
+	return out
+}
+
+// A V-then-pop: price bottoms at index 2 (94), pops to ~109, then drifts down.
+// Over a 3-bar horizon the bottom is the unambiguous best entry.
+var vThenPop = closes(100, 97, 94, 104, 108, 109, 108, 107, 106, 105)
+
+func TestFindOptimalEntry_PicksTheBottom(t *testing.T) {
+	a := Assumptions{Horizon: 3, ExitJitter: 0, Sims: 1, SlippageBps: 0, Seed: 1}
+	res, err := FindOptimalEntry(vThenPop, 4, a) // candidates 0..4
+	if err != nil {
+		t.Fatalf("FindOptimalEntry: %v", err)
+	}
+	if res.Optimal.Index != 2 {
+		t.Fatalf("optimal entry = index %d (price %.0f); want index 2 (the 94 bottom). candidates: %+v",
+			res.Optimal.Index, res.Optimal.EntryPrice, res.Candidates)
+	}
+	if res.Optimal.MeanReturn <= 0 {
+		t.Fatalf("bottom entry should be profitable over horizon; got %.4f", res.Optimal.MeanReturn)
+	}
+	if len(res.Candidates) != 5 {
+		t.Fatalf("want 5 candidates (indices 0..4); got %d", len(res.Candidates))
+	}
+}
+
+func TestFindOptimalEntry_Deterministic(t *testing.T) {
+	a := Assumptions{Horizon: 3, ExitJitter: 2, Sims: 300, SlippageBps: 5, Seed: 42}
+	r1, err := FindOptimalEntry(vThenPop, 4, a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2, err := FindOptimalEntry(vThenPop, 4, a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r1.Optimal != r2.Optimal {
+		t.Fatalf("same seed must reproduce: %+v vs %+v", r1.Optimal, r2.Optimal)
+	}
+}
+
+func TestEvaluateEntry_MCStats(t *testing.T) {
+	// Deterministic (no jitter): std must be 0 and pWin a hard 0/1.
+	a0 := Assumptions{Horizon: 3, ExitJitter: 0, Sims: 50, Seed: 1}
+	res, err := FindOptimalEntry(vThenPop, 4, a0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Optimal.StdReturn > 1e-9 {
+		t.Fatalf("no jitter ⇒ std ~0; got %g", res.Optimal.StdReturn)
+	}
+	if res.Optimal.PWin != 1 {
+		t.Fatalf("profitable deterministic entry ⇒ pWin 1; got %.2f", res.Optimal.PWin)
+	}
+
+	// With jitter over a varying forward path the bottom entry stays a winner
+	// but now carries dispersion.
+	aj := Assumptions{Horizon: 3, ExitJitter: 2, Sims: 500, Seed: 7}
+	rj, err := FindOptimalEntry(vThenPop, 4, aj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rj.Optimal.StdReturn <= 0 {
+		t.Fatalf("jitter over a varying path ⇒ std > 0; got %.6f", rj.Optimal.StdReturn)
+	}
+	if rj.Optimal.PWin <= 0 || rj.Optimal.PWin > 1 {
+		t.Fatalf("pWin must be in (0,1]; got %.2f", rj.Optimal.PWin)
+	}
+}
+
+func TestSlippage_LowersReturn(t *testing.T) {
+	base := Assumptions{Horizon: 3, ExitJitter: 0, Sims: 1, SlippageBps: 0, Seed: 1}
+	withCost := base
+	withCost.SlippageBps = 100 // 1%
+
+	r0, _ := FindOptimalEntry(vThenPop, 4, base)
+	r1, _ := FindOptimalEntry(vThenPop, 4, withCost)
+	// Same optimal bar, return lowered by exactly the slippage fraction.
+	if r0.Optimal.Index != r1.Optimal.Index {
+		t.Fatalf("slippage shouldn't change the winner here: %d vs %d", r0.Optimal.Index, r1.Optimal.Index)
+	}
+	got := r0.Optimal.MeanReturn - r1.Optimal.MeanReturn
+	if diff := got - 0.01; diff < -1e-9 || diff > 1e-9 {
+		t.Fatalf("100bps slippage should lower return by 0.01; lowered by %.6f", got)
+	}
+}
+
+func TestFindOptimalEntry_Errors(t *testing.T) {
+	if _, err := FindOptimalEntry(closes(100), 0, DefaultAssumptions()); err == nil {
+		t.Fatal("want error for <2 bars")
+	}
+	// windowEnd past the data is clamped, not an error.
+	if _, err := FindOptimalEntry(vThenPop, 999, DefaultAssumptions()); err != nil {
+		t.Fatalf("windowEnd should clamp, not error: %v", err)
+	}
+}

--- a/internal/engine/backtest/portfolio.go
+++ b/internal/engine/backtest/portfolio.go
@@ -1,0 +1,136 @@
+package backtest
+
+import "stocktopus/internal/model"
+
+// portfolio.go — the "$10k, decide at every candle, make the most profit"
+// simulation. This is both the validation harness (does a policy beat
+// buy-&-hold? how close to the hindsight ceiling?) and the shape of the
+// agent's product output (a per-candle decision trace with rationale).
+//
+// Long-only, fractional positions. A Policy sees only bars[0..i] — NO
+// lookahead — so a simulated result is what a trader could actually have
+// achieved in real time. The hindsight ceiling (HindsightOptimalEquity) is
+// computed separately and DOES peek; it's the upper bound, not a policy.
+
+// Decision is one bar's action in a simulation trace.
+type Decision struct {
+	Index    int     `json:"index"`
+	Date     string  `json:"date"`
+	Price    float64 `json:"price"`
+	Target   float64 `json:"target"`   // post-decision fraction of equity in the stock (0..1)
+	Traded   float64 `json:"traded"`   // signed shares traded this bar (+buy / -sell)
+	Cash     float64 `json:"cash"`     // cash after the trade
+	Shares   float64 `json:"shares"`   // shares held after the trade
+	Equity   float64 `json:"equity"`   // mark-to-market equity at this bar's close
+}
+
+// SimResult is the outcome of walking a policy across the bars.
+type SimResult struct {
+	StartCash   float64    `json:"startCash"`
+	EndEquity   float64    `json:"endEquity"`
+	TotalReturn float64    `json:"totalReturn"` // EndEquity/StartCash - 1
+	Trace       []Decision `json:"trace"`
+}
+
+// Policy decides the target fraction of equity to hold in the stock at bar i,
+// using ONLY bars[0..i]. Returns a value in [0,1] (long-only).
+type Policy interface {
+	Target(bars []model.OHLCV, i int, equity float64) float64
+}
+
+// PolicyFunc adapts a function to a Policy.
+type PolicyFunc func(bars []model.OHLCV, i int, equity float64) float64
+
+func (f PolicyFunc) Target(bars []model.OHLCV, i int, equity float64) float64 {
+	return f(bars, i, equity)
+}
+
+// Simulate walks the policy across every bar, rebalancing to its target
+// fraction (paying slippage on traded notional), and returns the trace +
+// ending equity.
+func Simulate(bars []model.OHLCV, p Policy, startCash, slippageBps float64) SimResult {
+	slip := slippageBps / 10000.0
+	cash := startCash
+	shares := 0.0
+	trace := make([]Decision, 0, len(bars))
+
+	for i := range bars {
+		px := bars[i].Close
+		if px <= 0 {
+			continue
+		}
+		equity := cash + shares*px
+		target := clamp01(p.Target(bars, i, equity))
+		desired := target * equity / px
+		traded := desired - shares
+		cost := abs(traded) * px * slip
+		cash -= traded*px + cost
+		shares = desired
+		equity = cash + shares*px // re-mark after costs
+		trace = append(trace, Decision{
+			Index: i, Date: bars[i].Date, Price: px,
+			Target: target, Traded: traded, Cash: cash, Shares: shares, Equity: equity,
+		})
+	}
+
+	end := startCash
+	if n := len(trace); n > 0 {
+		end = trace[n-1].Equity
+	}
+	return SimResult{StartCash: startCash, EndEquity: end, TotalReturn: end/startCash - 1, Trace: trace}
+}
+
+// BuyHold buys fully at the first bar and holds.
+func BuyHold() Policy { return PolicyFunc(func(_ []model.OHLCV, _ int, _ float64) float64 { return 1 }) }
+
+// AllCash never invests (baseline floor).
+func AllCash() Policy { return PolicyFunc(func(_ []model.OHLCV, _ int, _ float64) float64 { return 0 }) }
+
+// MomentumPolicy is fully invested while the close is above its trailing
+// SMA(n) and flat otherwise — a simple, lookahead-free trend filter used to
+// demonstrate that a policy can dodge drawdowns and beat buy-&-hold.
+func MomentumPolicy(n int) Policy {
+	return PolicyFunc(func(bars []model.OHLCV, i int, _ float64) float64 {
+		if i < n {
+			return 0
+		}
+		var sum float64
+		for k := i - n + 1; k <= i; k++ {
+			sum += bars[k].Close
+		}
+		if bars[i].Close > sum/float64(n) {
+			return 1
+		}
+		return 0
+	})
+}
+
+// HindsightOptimalEquity is the upper bound for long-only, all-in/all-out
+// trading with perfect foresight: capture every up-day, sit out every
+// down-day. equity ×= close[i]/close[i-1] for each up move.
+func HindsightOptimalEquity(bars []model.OHLCV, startCash float64) float64 {
+	eq := startCash
+	for i := 1; i < len(bars); i++ {
+		if bars[i-1].Close > 0 && bars[i].Close > bars[i-1].Close {
+			eq *= bars[i].Close / bars[i-1].Close
+		}
+	}
+	return eq
+}
+
+func clamp01(x float64) float64 {
+	if x < 0 {
+		return 0
+	}
+	if x > 1 {
+		return 1
+	}
+	return x
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/internal/engine/backtest/portfolio_test.go
+++ b/internal/engine/backtest/portfolio_test.go
@@ -1,0 +1,80 @@
+package backtest
+
+import "testing"
+
+const start = 10_000.0
+
+func approx(a, b, tol float64) bool { return a-b < tol && b-a < tol }
+
+// Buy-&-hold ending equity is exactly start × priceRatio (no slippage).
+func TestBuyHold_EndingEquityExact(t *testing.T) {
+	bars := closes(100, 120, 160, 200) // 2× over the window
+	r := Simulate(bars, BuyHold(), start, 0)
+	if !approx(r.EndEquity, 20_000, 1e-6) {
+		t.Fatalf("buy-hold on a 2× series should end at $20k; got $%.2f", r.EndEquity)
+	}
+	if !approx(r.TotalReturn, 1.0, 1e-9) {
+		t.Fatalf("total return should be +100%%; got %.4f", r.TotalReturn)
+	}
+	if len(r.Trace) != len(bars) {
+		t.Fatalf("trace should have one decision per bar; got %d", len(r.Trace))
+	}
+}
+
+func TestAllCash_PreservesCapital(t *testing.T) {
+	r := Simulate(closes(100, 50, 200), AllCash(), start, 50)
+	if !approx(r.EndEquity, start, 1e-6) {
+		t.Fatalf("all-cash must preserve $%.0f; got $%.2f", start, r.EndEquity)
+	}
+}
+
+// The crux: a lookahead-free momentum policy must beat buy-&-hold on a series
+// that runs up then craters — it exits into cash and dodges the drawdown.
+func TestMomentum_BeatsBuyHold_OnCrash(t *testing.T) {
+	// Up-run, then a sustained crash that ends well below the start.
+	bars := closes(100, 105, 115, 130, 150, 150, 120, 95, 75, 70)
+
+	bh := Simulate(bars, BuyHold(), start, 0)
+	mo := Simulate(bars, MomentumPolicy(3), start, 0)
+
+	if bh.EndEquity >= start {
+		t.Fatalf("setup invalid: buy-hold should LOSE here (100→70); got $%.2f", bh.EndEquity)
+	}
+	if mo.EndEquity <= bh.EndEquity {
+		t.Fatalf("momentum should beat buy-hold by dodging the crash; momentum $%.2f vs buy-hold $%.2f",
+			mo.EndEquity, bh.EndEquity)
+	}
+}
+
+// The hindsight ceiling must dominate every realizable policy on the same path.
+func TestHindsight_IsCeiling(t *testing.T) {
+	bars := closes(100, 105, 115, 130, 150, 150, 120, 95, 75, 70)
+	ceiling := HindsightOptimalEquity(bars, start)
+
+	for _, p := range []struct {
+		name string
+		pol  Policy
+	}{
+		{"buyhold", BuyHold()},
+		{"momentum", MomentumPolicy(3)},
+		{"allcash", AllCash()},
+	} {
+		got := Simulate(bars, p.pol, start, 0).EndEquity
+		if got > ceiling+1e-6 {
+			t.Fatalf("%s ($%.2f) exceeded the hindsight ceiling ($%.2f) — impossible",
+				p.name, got, ceiling)
+		}
+	}
+	if ceiling <= start {
+		t.Fatalf("series has up-moves; hindsight ceiling should exceed start; got $%.2f", ceiling)
+	}
+}
+
+func TestSimulate_Deterministic(t *testing.T) {
+	bars := closes(100, 105, 115, 130, 150, 150, 120, 95, 75, 70)
+	a := Simulate(bars, MomentumPolicy(3), start, 10)
+	b := Simulate(bars, MomentumPolicy(3), start, 10)
+	if a.EndEquity != b.EndEquity || len(a.Trace) != len(b.Trace) {
+		t.Fatalf("Simulate must be deterministic")
+	}
+}

--- a/internal/server/backtest.go
+++ b/internal/server/backtest.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"stocktopus/internal/engine/backtest"
+)
+
+// backtestResponse is the optimal-entry analysis the ideas board pins as a
+// "way-to-trade" card. Deterministic (no LLM): the engine over real OHLCV.
+type backtestResponse struct {
+	Symbol     string               `json:"symbol"`
+	From       string               `json:"from"`
+	To         string               `json:"to"`
+	Horizon    int                  `json:"horizon"`
+	Bars       int                  `json:"bars"`
+	StartCash  float64              `json:"startCash"`
+	Optimal    backtest.EntryEval   `json:"optimal"`     // best historical entry (hindsight)
+	Candidates []backtest.EntryEval `json:"candidates"`  // score curve across the window
+	Policy     backtest.SimResult   `json:"policy"`      // the $10k lookahead-free walk + decision trace
+	BuyHold    float64              `json:"buyHoldEquity"`
+	Hindsight  float64              `json:"hindsightEquity"`
+}
+
+// GET /api/backtest/optimal-entry/{symbol}?from=&to=&horizon=
+// from/to bound the *selected window*; we fetch through to the latest bar so the
+// holding-horizon outcomes (the bars past `to`) are available to score entries.
+func (s *Server) handleBacktestOptimalEntry(w http.ResponseWriter, r *http.Request) {
+	symbol := r.PathValue("symbol")
+	from := r.URL.Query().Get("from")
+	to := r.URL.Query().Get("to")
+	horizon := 10
+	if h := r.URL.Query().Get("horizon"); h != "" {
+		if n, err := strconv.Atoi(h); err == nil && n > 0 {
+			horizon = n
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	writeErr := func(code int, msg string) {
+		w.WriteHeader(code)
+		json.NewEncoder(w).Encode(map[string]string{"error": msg})
+	}
+
+	bars, err := s.news.GetHistoricalEOD(r.Context(), symbol, from, "")
+	if err != nil {
+		s.logger.Error("backtest eod failed", "symbol", symbol, "error", err)
+		writeErr(http.StatusBadGateway, err.Error())
+		return
+	}
+	if len(bars) < 2 {
+		writeErr(http.StatusUnprocessableEntity, "not enough price history for "+symbol)
+		return
+	}
+
+	// windowEnd = last bar at or before `to` (the selection end); bars after it
+	// are the forward outcome window. Empty `to` → use all but the last bar.
+	windowEnd := len(bars) - 2
+	if to != "" {
+		windowEnd = 0
+		for i, b := range bars {
+			if b.Date <= to {
+				windowEnd = i
+			} else {
+				break
+			}
+		}
+		if windowEnd > len(bars)-2 {
+			windowEnd = len(bars) - 2
+		}
+	}
+
+	a := backtest.DefaultAssumptions()
+	a.Horizon = horizon
+	res, err := backtest.FindOptimalEntry(bars, windowEnd, a)
+	if err != nil {
+		writeErr(http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+
+	// The $10k walk + baselines run over the selected window (lookahead-free).
+	const startCash = 10_000.0
+	window := bars[:windowEnd+1]
+	policy := backtest.Simulate(window, backtest.MomentumPolicy(5), startCash, a.SlippageBps)
+	buyHold := backtest.Simulate(window, backtest.BuyHold(), startCash, 0).EndEquity
+	hindsight := backtest.HindsightOptimalEquity(window, startCash)
+
+	cands := res.Candidates
+	if len(cands) > 400 { // cap payload on long windows
+		cands = cands[len(cands)-400:]
+	}
+
+	json.NewEncoder(w).Encode(backtestResponse{
+		Symbol: symbol, From: from, To: to, Horizon: horizon, Bars: len(bars),
+		StartCash: startCash, Optimal: res.Optimal, Candidates: cands,
+		Policy: policy, BuyHold: buyHold, Hindsight: hindsight,
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -147,6 +147,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/article", s.handleArticle)
 	mux.HandleFunc("GET /api/article/entities", s.handleArticleEntities)
 	mux.HandleFunc("GET /api/chart/intraday/{interval}/{symbol}", s.handleChartIntraday)
+	mux.HandleFunc("GET /api/backtest/optimal-entry/{symbol}", s.handleBacktestOptimalEntry)
 	mux.HandleFunc("GET /api/security/{symbol}/profile", s.handleSecurityProfile)
 	mux.HandleFunc("GET /api/security/{symbol}/quote", s.handleSecurityQuote)
 	mux.HandleFunc("GET /api/security/{symbol}/etf-holdings", s.handleETFHoldings)


### PR DESCRIPTION
**M1 of the ideas-board epic.** Deterministic — no LLM.

- `internal/engine/backtest`: Monte-Carlo cost-function `FindOptimalEntry` (scores each candidate entry over jittered exits on the real forward path) + a **$10k portfolio simulation** (`Simulate` with BuyHold/Momentum policies, `HindsightOptimalEquity` ceiling). Pure, **10 unit tests** (optimal-entry on a known shape, MC stats, slippage, buy-hold exactness, hindsight-is-ceiling, momentum-beats-buyhold-on-a-crash, determinism).
- `GET /api/backtest/optimal-entry/{symbol}?from&to&horizon`: fetches OHLCV via the news client, runs the engine, returns the way-to-trade result — optimal entry, the $10k policy walk + per-candle decision trace, vs buy-&-hold and the hindsight ceiling. Smoke-tested on real AAPL data.

`make test` + `go build` clean. Merge order doesn't matter, but the board PR's analyze loop needs this endpoint.