### PR TITLE
feat(ideas): React Flow ideas-board island (M2 scaffold)

### DIFF
--- a/internal/server/static/board.html
+++ b/internal/server/static/board.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Stocktopus — Ideas Board</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&display=swap" rel="stylesheet">
+<!-- the real app stylesheet (Tron overlay merged in) — board inherits its tokens + glows -->
+<link rel="stylesheet" href="/static/style.css?v=board">
+<link rel="stylesheet" href="https://esm.sh/@xyflow/react@12/dist/style.css">
+<script type="importmap">
+{
+  "imports": {
+    "react": "https://esm.sh/react@18.3.1",
+    "react-dom": "https://esm.sh/react-dom@18.3.1",
+    "react-dom/client": "https://esm.sh/react-dom@18.3.1/client",
+    "@xyflow/react": "https://esm.sh/@xyflow/react@12?deps=react@18.3.1,react-dom@18.3.1",
+    "lightweight-charts": "https://esm.sh/lightweight-charts@4.1.3",
+    "htm": "https://esm.sh/htm@3.1.1"
+  }
+}
+</script>
+<style>
+  /* board-local: tokens fall back to the app's Tron vars from style.css */
+  html,body,#root{height:100%;margin:0;overflow:hidden}
+  body{font-family:'Fira Code','SF Mono',Consolas,monospace;font-size:12px;
+    background:
+      radial-gradient(1200px 560px at 80% -8%, rgba(45,184,255,.10), transparent 60%),
+      radial-gradient(900px 480px at -6% 110%, rgba(255,154,26,.07), transparent 60%),
+      var(--bg-primary,#06070a) !important;}
+  .react-flow{background:transparent}
+  .react-flow__background{opacity:.45}
+  .react-flow__controls{filter:invert(.9) hue-rotate(180deg) brightness(.95)}
+  .react-flow__minimap{opacity:.9}
+
+  .hud{position:fixed;top:14px;left:18px;z-index:20;pointer-events:none}
+  .hud .t{font-size:16px;font-weight:700;color:#fff;letter-spacing:1px;text-shadow:var(--text-glow-cyan,0 0 8px rgba(45,184,255,.6))}
+  .hud .t .b{color:var(--accent-blue,#2db8ff)}
+  .hud .h{color:var(--text-muted,#6b7888);margin-top:3px}
+
+  .node{background:linear-gradient(160deg,var(--panel-bg,#131922),#0f1318);border:1px solid var(--panel-border,#1b232d);
+    border-radius:12px;box-shadow:0 12px 34px rgba(0,0,0,.5);overflow:hidden}
+  .node.chart{border-left:2px solid var(--accent-blue,#2db8ff);box-shadow:0 12px 34px rgba(0,0,0,.5),var(--glow-cyan,0 0 14px rgba(45,184,255,.2))}
+  .node.comp{border-left:2px solid var(--accent-orange,#ff9a1a);box-shadow:0 12px 34px rgba(0,0,0,.5),var(--glow-amber,0 0 14px rgba(255,154,26,.2))}
+  .node.wl{width:180px;border-left:2px solid var(--accent-blue,#2db8ff)}
+  .node.note{width:230px;border-left:2px solid var(--accent-orange,#ff9a1a)}
+  .node-hdr{padding:8px 12px;font-size:11px;text-transform:uppercase;letter-spacing:1.5px;color:var(--text-muted,#6b7888);
+    border-bottom:1px solid var(--panel-border,#1b232d);display:flex;justify-content:space-between}
+  .node.chart .node-hdr{color:var(--accent-blue,#2db8ff);text-shadow:var(--text-glow-cyan,0 0 8px rgba(45,184,255,.5))}
+  .node.comp .node-hdr{color:var(--accent-orange,#ff9a1a);text-shadow:var(--text-glow-amber,0 0 8px rgba(255,154,26,.5))}
+  .chart-box{width:520px;height:300px}
+  .note-body{padding:12px 14px;color:var(--text-primary,#cdd7e1);line-height:1.6}
+  .legend{display:flex;gap:14px;padding:7px 12px;border-top:1px solid var(--panel-border,#1b232d);font-size:11px;flex-wrap:wrap}
+  .wl-body{padding:4px 0}
+  .wl-row{padding:6px 12px;color:var(--text-primary,#cdd7e1);border-bottom:1px solid #141a21;cursor:pointer}
+  .wl-row:hover{background:rgba(45,184,255,.08);color:#fff}
+  .analyze-btn{color:var(--accent-orange,#ff9a1a);cursor:pointer;text-shadow:var(--text-glow-amber,0 0 8px rgba(255,154,26,.5));padding:0 4px;border:1px solid transparent;border-radius:4px}
+  .analyze-btn:hover{border-color:var(--accent-orange,#ff9a1a);background:rgba(255,154,26,.1)}
+  .node.wtt{width:280px;border-left:2px solid var(--accent-orange,#ff9a1a);box-shadow:0 12px 34px rgba(0,0,0,.5),var(--glow-amber,0 0 14px rgba(255,154,26,.2))}
+  .node.wtt .node-hdr{color:var(--accent-orange,#ff9a1a);text-shadow:var(--text-glow-amber,0 0 8px rgba(255,154,26,.5))}
+  .wtt-body{padding:12px 14px}
+  .wtt-big{font-size:22px;color:#fff;text-shadow:0 0 8px rgba(0,204,102,.5)}
+  .wtt-big .up{color:#7dffb0;font-size:15px} .wtt-big .dn{color:#ff8a8a;font-size:15px}
+  .wtt-sub{color:var(--text-muted,#6b7888);margin:2px 0 10px;font-size:11px}
+  .wtt-stat{display:flex;justify-content:space-between;padding:5px 0;border-top:1px solid #141a21;font-size:11.5px}
+  .wtt-stat .b{color:var(--accent-blue,#2db8ff);text-shadow:var(--text-glow-cyan,0 0 6px rgba(45,184,255,.5))}
+  .wtt-row.err{color:#ff8a8a}
+  .react-flow__handle{width:9px;height:9px;background:var(--accent-blue,#2db8ff);border:1px solid #061018;box-shadow:0 0 8px rgba(45,184,255,.7)}
+  .react-flow__edge-path{stroke-width:1.6px}
+  .react-flow__edge-text{fill:var(--accent-blue,#2db8ff);font-size:9px;text-transform:uppercase;letter-spacing:1px}
+</style>
+</head>
+<body>
+<div class="hud"><div class="t">STOCK<span class="b">TOPUS</span> · IDEAS BOARD</div><div class="h">drag canvas to pan · scroll to zoom · drag a handle → to wire · drag nodes to compose</div></div>
+<div id="root"></div>
+<script type="module" src="/static/board.js"></script>
+</body>
+</html>

--- a/internal/server/static/board.js
+++ b/internal/server/static/board.js
@@ -1,0 +1,193 @@
+// Ideas Board — React Flow island (M2 scaffold).
+// No build step yet: React + React Flow + lightweight-charts load as ESM from a
+// CDN via the import map in board.html. Served by the app, so /api is same-origin.
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import { createRoot } from 'react-dom/client';
+import {
+  ReactFlow, Background, Controls, MiniMap, Handle, Position,
+  useNodesState, useEdgesState, addEdge, useReactFlow,
+} from '@xyflow/react';
+import { createChart } from 'lightweight-charts';
+import htm from 'htm';
+
+const html = htm.bind(React.createElement);
+const ymd = (d) => d.toISOString().slice(0, 10);
+const yearsAgo = (n) => { const d = new Date(); d.setFullYear(d.getFullYear() - n); return d; };
+const usd = (v) => '$' + Math.round(v).toLocaleString();
+
+const baseChartOpts = {
+  layout: { background: { color: 'transparent' }, textColor: '#7f8c9b', fontFamily: "'Fira Code',monospace", fontSize: 10, attributionLogo: false },
+  grid: { vertLines: { color: '#101720' }, horzLines: { color: '#101720' } },
+  rightPriceScale: { borderColor: '#1b232d' },
+  timeScale: { borderColor: '#1b232d', fixLeftEdge: true, fixRightEdge: true },
+  handleScroll: false, handleScale: false,
+};
+
+function rebasePct(rows, valueKey, fromStr) {
+  const out = []; let base = null;
+  for (const r of rows) {
+    const date = (r.date || '').slice(0, 10);
+    if (!date || date < fromStr) continue;
+    const v = Number(r[valueKey]); if (!isFinite(v)) continue;
+    if (base === null) { if (v === 0) continue; base = v; }
+    out.push({ time: date, value: ((v - base) / Math.abs(base)) * 100 });
+  }
+  return out;
+}
+
+// ── Price chart node — with an "analyze" trigger that fires the backtest ──
+function ChartNode({ id, data }) {
+  const ref = useRef(null);
+  const rf = useReactFlow();
+  useEffect(() => {
+    if (!ref.current) return;
+    const chart = createChart(ref.current, { ...baseChartOpts, width: 520, height: 300 });
+    const s = chart.addCandlestickSeries({ upColor: '#0c8', downColor: '#e55', wickUpColor: '#0c8', wickDownColor: '#e55', borderVisible: false });
+    fetch(`/api/chart/eod/${encodeURIComponent(data.symbol)}?from=${ymd(yearsAgo(1))}&to=${ymd(new Date())}`)
+      .then((r) => (r.ok ? r.json() : [])).then((rows) => {
+        if (Array.isArray(rows) && rows.length) {
+          s.setData(rows.map((b) => ({ time: b.date, open: b.open, high: b.high, low: b.low, close: b.close })));
+          chart.timeScale().fitContent();
+        }
+      }).catch(() => {});
+    return () => { try { chart.remove(); } catch (e) {} };
+  }, [data.symbol]);
+
+  // fire the deterministic backtest over the visible (1Y) window, pin a card
+  const analyze = useCallback(async (e) => {
+    e.stopPropagation();
+    const from = ymd(yearsAgo(1)), to = ymd(new Date());
+    const src = rf.getNode(id);
+    const cardId = id + '-wtt';
+    const pos = { x: (src?.position.x || 0) + 600, y: (src?.position.y || 0) };
+    rf.setNodes((ns) => ns.filter((n) => n.id !== cardId).concat(
+      { id: cardId, type: 'waytotrade', position: pos, data: { loading: true, symbol: data.symbol } }));
+    rf.setEdges((es) => es.filter((x) => x.id !== 'e-' + cardId).concat(
+      { id: 'e-' + cardId, source: id, target: cardId, animated: true, label: 'analyze',
+        style: { stroke: '#ff9a1a', strokeWidth: 1.8, filter: 'drop-shadow(0 0 4px rgba(255,154,26,.7))' } }));
+    try {
+      const r = await fetch(`/api/backtest/optimal-entry/${encodeURIComponent(data.symbol)}?from=${from}&to=${to}&horizon=10`);
+      const res = await r.json();
+      rf.setNodes((ns) => ns.map((n) => (n.id === cardId ? { ...n, data: { ...res, loading: false } } : n)));
+    } catch (err) {
+      rf.setNodes((ns) => ns.map((n) => (n.id === cardId ? { ...n, data: { error: String(err) } } : n)));
+    }
+  }, [id, data.symbol, rf]);
+
+  return html`<div class="node chart">
+    <div class="node-hdr"><span>${data.symbol} · 1Y</span>
+      <span class="analyze-btn" title="backtest optimal entry over this window" onClick=${analyze}>⌖ analyze</span></div>
+    <div ref=${ref} class="chart-box"></div>
+    <${Handle} type="target" position=${Position.Left} />
+    <${Handle} type="source" position=${Position.Right} />
+  </div>`;
+}
+
+// ── The live "way-to-trade" card — real backtest result ──
+function WayToTradeNode({ data }) {
+  let body;
+  if (data.error) body = html`<div class="wtt-row err">error: ${data.error}</div>`;
+  else if (data.loading) body = html`<div class="wtt-big">analysing…</div>`;
+  else {
+    const end = data.policy?.endEquity ?? data.startCash;
+    const ret = (end / data.startCash - 1) * 100;
+    const opt = data.optimal || {};
+    body = html`<div>
+      <div class="wtt-big">${usd(end)} <span class=${ret >= 0 ? 'up' : 'dn'}>${(ret >= 0 ? '+' : '') + ret.toFixed(1)}%</span></div>
+      <div class="wtt-sub">$10k policy walk over the window</div>
+      <div class="wtt-stat"><span>optimal entry</span><span class="b">${opt.date} @ $${(opt.entryPrice || 0).toFixed(2)}</span></div>
+      <div class="wtt-stat"><span>vs buy &amp; hold</span><span>${usd((data.buyHoldEquity || 0))}</span></div>
+      <div class="wtt-stat"><span>hindsight ceiling</span><span>${usd((data.hindsightEquity || 0))} (${Math.round(end / (data.hindsightEquity || end) * 100)}%)</span></div>
+      <div class="wtt-stat"><span>decisions</span><span>${(data.policy?.trace || []).length}</span></div>
+    </div>`;
+  }
+  return html`<div class="node wtt">
+    <div class="node-hdr"><span>way to trade${data.symbol ? ' · ' + data.symbol : ''}</span><span>⠿</span></div>
+    <div class="wtt-body">${body}</div>
+    <${Handle} type="target" position=${Position.Left} />
+  </div>`;
+}
+
+function ComparisonNode({ data }) {
+  const ref = useRef(null);
+  useEffect(() => {
+    if (!ref.current) return;
+    const fromStr = ymd(yearsAgo(data.years || 3));
+    const chart = createChart(ref.current, { ...baseChartOpts, width: 560, height: 320 });
+    data.series.forEach((sp) => {
+      const url = sp.kind === 'economic'
+        ? `/api/historical/economic/${encodeURIComponent(sp.id)}`
+        : `/api/chart/eod/${encodeURIComponent(sp.id)}?from=${fromStr}&to=${ymd(new Date())}`;
+      const line = chart.addLineSeries({ color: sp.color, lineWidth: 2, priceLineVisible: false,
+        priceFormat: { type: 'custom', formatter: (v) => (v >= 0 ? '+' : '') + v.toFixed(0) + '%', minMove: 0.1 } });
+      fetch(url).then((r) => (r.ok ? r.json() : [])).then((rows) => {
+        if (!Array.isArray(rows) || !rows.length) return;
+        line.setData(rebasePct(rows, sp.kind === 'economic' ? 'value' : 'close', fromStr));
+        chart.timeScale().fitContent();
+      }).catch(() => {});
+    });
+    return () => { try { chart.remove(); } catch (e) {} };
+  }, []);
+  return html`<div class="node comp">
+    <div class="node-hdr"><span>comparison · rebased % · ${data.years || 3}Y</span><span>⠿</span></div>
+    <div ref=${ref} class="chart-box" style=${{ width: '560px', height: '320px' }}></div>
+    <div class="legend">${data.series.map((s) => html`<span key=${s.id} style=${{ color: s.color }}>● ${s.label}</span>`)}</div>
+    <${Handle} type="target" position=${Position.Left} />
+  </div>`;
+}
+
+function WatchlistNode({ data }) {
+  return html`<div class="node wl">
+    <div class="node-hdr"><span>watchlist · ${data.name}</span><span>⠿</span></div>
+    <div class="wl-body">${data.symbols.map((s) => html`<div class="wl-row" key=${s}>${s}</div>`)}</div>
+    <${Handle} type="source" position=${Position.Right} />
+  </div>`;
+}
+
+function NoteNode({ data }) {
+  return html`<div class="node note">
+    <div class="node-hdr"><span>note</span><span>⠿</span></div>
+    <div class="note-body">${data.text}</div>
+    <${Handle} type="target" position=${Position.Left} />
+  </div>`;
+}
+
+const nodeTypes = { chart: ChartNode, waytotrade: WayToTradeNode, comparison: ComparisonNode, watchlist: WatchlistNode, note: NoteNode };
+
+const initialNodes = [
+  { id: 'wl', type: 'watchlist', position: { x: 16, y: 120 }, data: { name: 'Mega-cap', symbols: ['AAPL', 'MSFT', 'NVDA'] } },
+  { id: 'c1', type: 'chart', position: { x: 320, y: 64 }, data: { symbol: 'AAPL' } },
+  { id: 'cmp', type: 'comparison', position: { x: 320, y: 432 }, data: { years: 5, series: [
+        { label: '10Y Treasury (DGS10)', color: '#2db8ff', kind: 'economic', id: 'US.DGS10' },
+        { label: 'Unemployment (UNRATE)', color: '#ff9a1a', kind: 'economic', id: 'US.UNRATE' },
+        { label: 'AAPL', color: '#00cc66', kind: 'price', id: 'AAPL' } ] } },
+  { id: 'n1', type: 'note', position: { x: 1500, y: 96 }, data: { text: '⌖ analyze on a chart fires the $10k backtest → pins a live way-to-trade card. The watchlist drives the chart; a screen feeds the watchlist.' } },
+];
+const initialEdges = [
+  { id: 'e-wl-c1', source: 'wl', target: 'c1', label: 'drives', animated: true,
+    style: { stroke: '#2db8ff', strokeWidth: 1.8, filter: 'drop-shadow(0 0 4px rgba(45,184,255,.7))' } },
+];
+
+function Board() {
+  const [nodes, , onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+  const onConnect = useCallback((p) => setEdges((es) => addEdge({ ...p, animated: true, style: { stroke: '#2db8ff', strokeWidth: 1.8 } }, es)), [setEdges]);
+  const [moving, setMoving] = useState(false);
+  const hideT = useRef(null);
+  const onMoveStart = useCallback(() => { clearTimeout(hideT.current); setMoving(true); }, []);
+  const onMoveEnd = useCallback(() => { hideT.current = setTimeout(() => setMoving(false), 900); }, []);
+  return html`<${ReactFlow}
+      nodes=${nodes} edges=${edges}
+      onNodesChange=${onNodesChange} onEdgesChange=${onEdgesChange} onConnect=${onConnect}
+      nodeTypes=${nodeTypes}
+      fitView snapToGrid snapGrid=${[16, 16]} minZoom=${0.2} maxZoom=${4}
+      onMoveStart=${onMoveStart} onMoveEnd=${onMoveEnd}
+      proOptions=${{ hideAttribution: true }}
+      defaultEdgeOptions=${{ animated: true, style: { stroke: '#2db8ff', strokeWidth: 1.6 } }}>
+    <${Background} color="#1b232d" gap=${26} />
+    <${Controls} showInteractive=${false} />
+    ${moving ? html`<${MiniMap} pannable zoomable nodeColor=${() => '#2db8ff'} maskColor="rgba(6,7,10,.7)" />` : null}
+  <//>`;
+}
+
+createRoot(document.getElementById('root')).render(html`<${Board} />`);


### PR DESCRIPTION
**M2 of the ideas-board epic** — the Miro-style canvas, served at `/static/board.html`.

- React + **React Flow (xyflow)** + lightweight-charts via **ESM CDN (no build step yet)**; served by the app so `/api` is same-origin (real data). Inherits the app's Tron `style.css`.
- Custom nodes: **price chart** (driver-parameterized), **comparison** (rebased economic + price overlay — 10Y Treasury vs unemployment vs a stock), **watchlist** (drives a chart via a 'drives' edge), **note**, and a live **way-to-trade card**.
- **⌖ analyze** on a chart calls `/api/backtest/optimal-entry` and pins the card. Pan/zoom, snap-to-grid, transient minimap, connectable handles.

⚠️ **Depends on the optimal-entry endpoint** (PR #feat/optimal-entry-engine) for the analyze loop — the board renders fine without it; only the analyze button needs it. Scaffold/prototype: ESM-CDN + no-build is a deliberate first step; production bundling is a later hardening.