### PR TITLE
feat(ideas): vim navigation + visual-mode region select (#158)

### DIFF
--- a/internal/server/static/board.html
+++ b/internal/server/static/board.html
@@ -55,6 +55,11 @@
   .wl-body{padding:4px 0}
   .wl-row{padding:6px 12px;color:var(--text-primary,#cdd7e1);border-bottom:1px solid #141a21;cursor:pointer}
   .wl-row:hover{background:rgba(45,184,255,.08);color:#fff}
+  /* vim HUD + selected-node ring */
+  .vimhud{position:fixed;top:14px;right:18px;z-index:40;background:rgba(6,7,10,.8);border:1px solid var(--panel-border,#1b232d);
+    border-radius:8px;padding:6px 12px;font-size:12px;color:var(--text-muted,#6b7888);pointer-events:none}
+  .vimhud .vmode{font-weight:700;letter-spacing:1.5px;margin-right:8px}
+  .react-flow__node.selected .node{outline:2px solid var(--accent-blue,#2db8ff);outline-offset:2px;box-shadow:0 0 0 1px rgba(45,184,255,.4),0 0 22px rgba(45,184,255,.35)!important}
   .analyze-btn{color:var(--accent-orange,#ff9a1a);cursor:pointer;text-shadow:var(--text-glow-amber,0 0 8px rgba(255,154,26,.5));padding:0 4px;border:1px solid transparent;border-radius:4px}
   .analyze-btn:hover{border-color:var(--accent-orange,#ff9a1a);background:rgba(255,154,26,.1)}
   .node.wtt{width:280px;border-left:2px solid var(--accent-orange,#ff9a1a);box-shadow:0 12px 34px rgba(0,0,0,.5),var(--glow-amber,0 0 14px rgba(255,154,26,.2))}

--- a/internal/server/static/board.js
+++ b/internal/server/static/board.js
@@ -1,10 +1,16 @@
-// Ideas Board — React Flow island (M2 scaffold).
-// No build step yet: React + React Flow + lightweight-charts load as ESM from a
-// CDN via the import map in board.html. Served by the app, so /api is same-origin.
+// Ideas Board — React Flow island (M2 + M3 vim navigation).
+// ESM via CDN (import map in board.html); served by the app so /api is same-origin.
+//
+// Vim nav (issue #158): a board→chart→visual state machine.
+//   board mode  : h/j/k/l move the selection between nodes; Enter focuses a chart.
+//   chart mode  : a candle cursor — h/l ±1, H/L ±5, {count}l/{count}h ±count.
+//   visual mode : v anchors; h/l extends a candle range (analysed-window render);
+//                 Enter analyses exactly that window → pins a way-to-trade card.
+//   Esc steps back out (visual→chart→board).
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { createRoot } from 'react-dom/client';
 import {
-  ReactFlow, Background, Controls, MiniMap, Handle, Position,
+  ReactFlow, ReactFlowProvider, Background, Controls, MiniMap, Handle, Position,
   useNodesState, useEdgesState, addEdge, useReactFlow,
 } from '@xyflow/react';
 import { createChart } from 'lightweight-charts';
@@ -14,6 +20,9 @@ const html = htm.bind(React.createElement);
 const ymd = (d) => d.toISOString().slice(0, 10);
 const yearsAgo = (n) => { const d = new Date(); d.setFullYear(d.getFullYear() - n); return d; };
 const usd = (v) => '$' + Math.round(v).toLocaleString();
+
+// Registry so the board-level keydown handler can drive a focused chart's cursor.
+const chartReg = new Map(); // nodeId -> { len, barData, applyCursor, clearCursor, applyRange, clearRange }
 
 const baseChartOpts = {
   layout: { background: { color: 'transparent' }, textColor: '#7f8c9b', fontFamily: "'Fira Code',monospace", fontSize: 10, attributionLogo: false },
@@ -35,7 +44,25 @@ function rebasePct(rows, valueKey, fromStr) {
   return out;
 }
 
-// ── Price chart node — with an "analyze" trigger that fires the backtest ──
+// Shared: fire the backtest for a symbol+window, pin/refresh a way-to-trade card.
+async function runAnalysis(rf, srcId, symbol, from, to) {
+  const src = rf.getNode(srcId);
+  const cardId = srcId + '-wtt';
+  const pos = { x: (src?.position.x || 0) + 620, y: (src?.position.y || 0) };
+  rf.setNodes((ns) => ns.filter((n) => n.id !== cardId).concat(
+    { id: cardId, type: 'waytotrade', position: pos, data: { loading: true, symbol, from, to } }));
+  rf.setEdges((es) => es.filter((x) => x.id !== 'e-' + cardId).concat(
+    { id: 'e-' + cardId, source: srcId, target: cardId, animated: true, label: 'analyze',
+      style: { stroke: '#ff9a1a', strokeWidth: 1.8, filter: 'drop-shadow(0 0 4px rgba(255,154,26,.7))' } }));
+  try {
+    const r = await fetch(`/api/backtest/optimal-entry/${encodeURIComponent(symbol)}?from=${from}&to=${to}&horizon=10`);
+    const res = await r.json();
+    rf.setNodes((ns) => ns.map((n) => (n.id === cardId ? { ...n, data: { ...res, loading: false } } : n)));
+  } catch (err) {
+    rf.setNodes((ns) => ns.map((n) => (n.id === cardId ? { ...n, data: { error: String(err) } } : n)));
+  }
+}
+
 function ChartNode({ id, data }) {
   const ref = useRef(null);
   const rf = useReactFlow();
@@ -43,47 +70,45 @@ function ChartNode({ id, data }) {
     if (!ref.current) return;
     const chart = createChart(ref.current, { ...baseChartOpts, width: 520, height: 300 });
     const s = chart.addCandlestickSeries({ upColor: '#0c8', downColor: '#e55', wickUpColor: '#0c8', wickDownColor: '#e55', borderVisible: false });
+    let barData = [];
     fetch(`/api/chart/eod/${encodeURIComponent(data.symbol)}?from=${ymd(yearsAgo(1))}&to=${ymd(new Date())}`)
       .then((r) => (r.ok ? r.json() : [])).then((rows) => {
-        if (Array.isArray(rows) && rows.length) {
-          s.setData(rows.map((b) => ({ time: b.date, open: b.open, high: b.high, low: b.low, close: b.close })));
-          chart.timeScale().fitContent();
-        }
+        if (!Array.isArray(rows) || !rows.length) return;
+        barData = rows.map((b) => ({ time: b.date, open: b.open, high: b.high, low: b.low, close: b.close }));
+        s.setData(barData);
+        chart.timeScale().fitContent();
+        chartReg.set(id, {
+          len: barData.length, barData,
+          applyCursor(i) { const b = barData[i]; if (b) chart.setCrosshairPosition(b.close, b.time, s); },
+          clearCursor() { try { chart.clearCrosshairPosition(); } catch (e) {} },
+          applyRange(a, b) {
+            const lo = Math.min(a, b), hi = Math.max(a, b);
+            s.setData(barData.map((bar, idx) => {
+              const inR = idx >= lo && idx <= hi;
+              const c = inR ? (bar.close >= bar.open ? '#0c8' : '#e55') : '#2b3340';
+              return { ...bar, color: c, borderColor: c, wickColor: c };
+            }));
+          },
+          clearRange() { s.setData(barData.map((b) => ({ ...b }))); },
+        });
       }).catch(() => {});
-    return () => { try { chart.remove(); } catch (e) {} };
-  }, [data.symbol]);
+    return () => { chartReg.delete(id); try { chart.remove(); } catch (e) {} };
+  }, [data.symbol, id]);
 
-  // fire the deterministic backtest over the visible (1Y) window, pin a card
-  const analyze = useCallback(async (e) => {
+  const analyzeAll = useCallback((e) => {
     e.stopPropagation();
-    const from = ymd(yearsAgo(1)), to = ymd(new Date());
-    const src = rf.getNode(id);
-    const cardId = id + '-wtt';
-    const pos = { x: (src?.position.x || 0) + 600, y: (src?.position.y || 0) };
-    rf.setNodes((ns) => ns.filter((n) => n.id !== cardId).concat(
-      { id: cardId, type: 'waytotrade', position: pos, data: { loading: true, symbol: data.symbol } }));
-    rf.setEdges((es) => es.filter((x) => x.id !== 'e-' + cardId).concat(
-      { id: 'e-' + cardId, source: id, target: cardId, animated: true, label: 'analyze',
-        style: { stroke: '#ff9a1a', strokeWidth: 1.8, filter: 'drop-shadow(0 0 4px rgba(255,154,26,.7))' } }));
-    try {
-      const r = await fetch(`/api/backtest/optimal-entry/${encodeURIComponent(data.symbol)}?from=${from}&to=${to}&horizon=10`);
-      const res = await r.json();
-      rf.setNodes((ns) => ns.map((n) => (n.id === cardId ? { ...n, data: { ...res, loading: false } } : n)));
-    } catch (err) {
-      rf.setNodes((ns) => ns.map((n) => (n.id === cardId ? { ...n, data: { error: String(err) } } : n)));
-    }
+    runAnalysis(rf, id, data.symbol, ymd(yearsAgo(1)), ymd(new Date()));
   }, [id, data.symbol, rf]);
 
   return html`<div class="node chart">
     <div class="node-hdr"><span>${data.symbol} · 1Y</span>
-      <span class="analyze-btn" title="backtest optimal entry over this window" onClick=${analyze}>⌖ analyze</span></div>
+      <span class="analyze-btn" title="backtest the whole window" onClick=${analyzeAll}>⌖ analyze</span></div>
     <div ref=${ref} class="chart-box"></div>
     <${Handle} type="target" position=${Position.Left} />
     <${Handle} type="source" position=${Position.Right} />
   </div>`;
 }
 
-// ── The live "way-to-trade" card — real backtest result ──
 function WayToTradeNode({ data }) {
   let body;
   if (data.error) body = html`<div class="wtt-row err">error: ${data.error}</div>`;
@@ -94,10 +119,10 @@ function WayToTradeNode({ data }) {
     const opt = data.optimal || {};
     body = html`<div>
       <div class="wtt-big">${usd(end)} <span class=${ret >= 0 ? 'up' : 'dn'}>${(ret >= 0 ? '+' : '') + ret.toFixed(1)}%</span></div>
-      <div class="wtt-sub">$10k policy walk over the window</div>
+      <div class="wtt-sub">$10k walk · ${data.from} → ${data.to}</div>
       <div class="wtt-stat"><span>optimal entry</span><span class="b">${opt.date} @ $${(opt.entryPrice || 0).toFixed(2)}</span></div>
-      <div class="wtt-stat"><span>vs buy &amp; hold</span><span>${usd((data.buyHoldEquity || 0))}</span></div>
-      <div class="wtt-stat"><span>hindsight ceiling</span><span>${usd((data.hindsightEquity || 0))} (${Math.round(end / (data.hindsightEquity || end) * 100)}%)</span></div>
+      <div class="wtt-stat"><span>vs buy &amp; hold</span><span>${usd(data.buyHoldEquity || 0)}</span></div>
+      <div class="wtt-stat"><span>hindsight</span><span>${usd(data.hindsightEquity || 0)} (${Math.round(end / (data.hindsightEquity || end) * 100)}%)</span></div>
       <div class="wtt-stat"><span>decisions</span><span>${(data.policy?.trace || []).length}</span></div>
     </div>`;
   }
@@ -161,7 +186,7 @@ const initialNodes = [
         { label: '10Y Treasury (DGS10)', color: '#2db8ff', kind: 'economic', id: 'US.DGS10' },
         { label: 'Unemployment (UNRATE)', color: '#ff9a1a', kind: 'economic', id: 'US.UNRATE' },
         { label: 'AAPL', color: '#00cc66', kind: 'price', id: 'AAPL' } ] } },
-  { id: 'n1', type: 'note', position: { x: 1500, y: 96 }, data: { text: '⌖ analyze on a chart fires the $10k backtest → pins a live way-to-trade card. The watchlist drives the chart; a screen feeds the watchlist.' } },
+  { id: 'n1', type: 'note', position: { x: 1500, y: 96 }, data: { text: 'vim: h/j/k/l select · Enter focus a chart · h/l move the candle cursor (H/L ±5, 10l ±10) · v visual-select a window · Enter analyses it.' } },
 ];
 const initialEdges = [
   { id: 'e-wl-c1', source: 'wl', target: 'c1', label: 'drives', animated: true,
@@ -169,25 +194,129 @@ const initialEdges = [
 ];
 
 function Board() {
+  const rf = useReactFlow();
   const [nodes, , onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
   const onConnect = useCallback((p) => setEdges((es) => addEdge({ ...p, animated: true, style: { stroke: '#2db8ff', strokeWidth: 1.8 } }, es)), [setEdges]);
+
   const [moving, setMoving] = useState(false);
   const hideT = useRef(null);
   const onMoveStart = useCallback(() => { clearTimeout(hideT.current); setMoving(true); }, []);
   const onMoveEnd = useCallback(() => { hideT.current = setTimeout(() => setMoving(false), 900); }, []);
-  return html`<${ReactFlow}
-      nodes=${nodes} edges=${edges}
-      onNodesChange=${onNodesChange} onEdgesChange=${onEdgesChange} onConnect=${onConnect}
-      nodeTypes=${nodeTypes}
-      fitView snapToGrid snapGrid=${[16, 16]} minZoom=${0.2} maxZoom=${4}
-      onMoveStart=${onMoveStart} onMoveEnd=${onMoveEnd}
-      proOptions=${{ hideAttribution: true }}
-      defaultEdgeOptions=${{ animated: true, style: { stroke: '#2db8ff', strokeWidth: 1.6 } }}>
-    <${Background} color="#1b232d" gap=${26} />
-    <${Controls} showInteractive=${false} />
-    ${moving ? html`<${MiniMap} pannable zoomable nodeColor=${() => '#2db8ff'} maskColor="rgba(6,7,10,.7)" />` : null}
+
+  // ── vim state machine ──
+  const st = useRef({ mode: 'board', selId: null, focusId: null, cursor: 0, anchor: -1, count: '' });
+  const [hud, setHud] = useState({ mode: 'board', info: 'h/j/k/l to select' });
+  const barInfo = (reg, i) => { const b = reg.barData[i]; return b ? `${b.time} @ $${b.close}` : ''; };
+
+  const moveSel = useCallback((dir) => {
+    const ns = rf.getNodes(); if (!ns.length) return;
+    const cur = ns.find((n) => n.id === st.current.selId);
+    let pick;
+    if (!cur) pick = ns[0];
+    else {
+      let best = null, bestd = Infinity;
+      for (const n of ns) {
+        if (n.id === cur.id) continue;
+        const dx = n.position.x - cur.position.x, dy = n.position.y - cur.position.y;
+        let ok = false, primary = 0, secondary = 0;
+        if (dir === 'right') { ok = dx > 1; primary = dx; secondary = Math.abs(dy); }
+        else if (dir === 'left') { ok = dx < -1; primary = -dx; secondary = Math.abs(dy); }
+        else if (dir === 'down') { ok = dy > 1; primary = dy; secondary = Math.abs(dx); }
+        else { ok = dy < -1; primary = -dy; secondary = Math.abs(dx); }
+        if (!ok) continue;
+        const d = primary + secondary * 2;
+        if (d < bestd) { bestd = d; best = n; }
+      }
+      pick = best || cur;
+    }
+    st.current.selId = pick.id;
+    rf.setNodes((all) => all.map((n) => ({ ...n, selected: n.id === pick.id })));
+    setHud({ mode: 'board', info: 'selected ' + (pick.data.symbol || pick.type) + ' · Enter to focus' });
+  }, [rf]);
+
+  const focusSelected = useCallback(() => {
+    const s = st.current; const n = rf.getNode(s.selId); if (!n) return;
+    if (n.type === 'chart' && chartReg.has(s.selId)) {
+      const reg = chartReg.get(s.selId);
+      s.mode = 'chart'; s.focusId = s.selId; s.cursor = reg.len - 1;
+      reg.applyCursor(s.cursor);
+      rf.fitView({ nodes: [{ id: s.selId }], duration: 300, padding: 0.3 });
+      setHud({ mode: 'chart', info: barInfo(reg, s.cursor) + ' · v to select' });
+    }
+  }, [rf]);
+
+  const analyzeRange = useCallback(() => {
+    const s = st.current; const reg = chartReg.get(s.focusId); if (!reg) return;
+    const lo = Math.min(s.anchor, s.cursor), hi = Math.max(s.anchor, s.cursor);
+    const from = reg.barData[lo].time, to = reg.barData[hi].time;
+    const n = rf.getNode(s.focusId);
+    runAnalysis(rf, s.focusId, n.data.symbol, from, to);
+    reg.clearRange(); s.mode = 'chart';
+    setHud({ mode: 'chart', info: `analysed ${from} → ${to}` });
+  }, [rf]);
+
+  useEffect(() => {
+    function onKey(e) {
+      const s = st.current, k = e.key;
+      if ((s.mode === 'chart' || s.mode === 'visual') && /^[0-9]$/.test(k)) {
+        if (!(k === '0' && s.count === '')) { s.count += k; setHud({ mode: s.mode, info: 'count ' + s.count }); e.preventDefault(); return; }
+      }
+      const step = (key) => { const n = parseInt(s.count || '0', 10) || 0; s.count = ''; return n > 0 ? n : ((key === 'H' || key === 'L') ? 5 : 1); };
+      switch (k) {
+        case 'h': case 'H': case 'l': case 'L': {
+          const dir = (k === 'h' || k === 'H') ? -1 : 1;
+          if (s.mode === 'board') { moveSel(dir > 0 ? 'right' : 'left'); e.preventDefault(); return; }
+          const reg = chartReg.get(s.focusId); if (!reg) return;
+          s.cursor = Math.max(0, Math.min(reg.len - 1, s.cursor + dir * step(k)));
+          if (s.mode === 'visual') reg.applyRange(s.anchor, s.cursor);
+          reg.applyCursor(s.cursor);
+          setHud({ mode: s.mode, info: barInfo(reg, s.cursor) });
+          e.preventDefault(); return;
+        }
+        case 'j': case 'k':
+          if (s.mode === 'board') { moveSel(k === 'j' ? 'down' : 'up'); e.preventDefault(); }
+          return;
+        case 'Enter':
+          if (s.mode === 'board') { focusSelected(); e.preventDefault(); }
+          else if (s.mode === 'visual') { analyzeRange(); e.preventDefault(); }
+          return;
+        case 'v':
+          if (s.mode === 'chart') {
+            s.mode = 'visual'; s.anchor = s.cursor;
+            const reg = chartReg.get(s.focusId); if (reg) reg.applyRange(s.anchor, s.cursor);
+            setHud({ mode: 'visual', info: 'select a window · Enter to analyse' });
+            e.preventDefault();
+          }
+          return;
+        case 'Escape': {
+          const reg = chartReg.get(s.focusId);
+          if (s.mode === 'visual') { if (reg) reg.clearRange(); s.mode = 'chart'; setHud({ mode: 'chart', info: 'v to select' }); }
+          else if (s.mode === 'chart') { if (reg) reg.clearCursor(); s.mode = 'board'; s.focusId = null; setHud({ mode: 'board', info: 'h/j/k/l to select' }); }
+          e.preventDefault(); return;
+        }
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [moveSel, focusSelected, analyzeRange]);
+
+  const modeColor = { board: '#cdd7e1', chart: '#2db8ff', visual: '#ff9a1a' }[hud.mode];
+  return html`<${React.Fragment}>
+    <div class="vimhud"><span class="vmode" style=${{ color: modeColor }}>${hud.mode.toUpperCase()}</span> ${hud.info}</div>
+    <${ReactFlow}
+        nodes=${nodes} edges=${edges}
+        onNodesChange=${onNodesChange} onEdgesChange=${onEdgesChange} onConnect=${onConnect}
+        nodeTypes=${nodeTypes}
+        fitView snapToGrid snapGrid=${[16, 16]} minZoom=${0.2} maxZoom=${4}
+        onMoveStart=${onMoveStart} onMoveEnd=${onMoveEnd}
+        proOptions=${{ hideAttribution: true }}
+        defaultEdgeOptions=${{ animated: true, style: { stroke: '#2db8ff', strokeWidth: 1.6 } }}>
+      <${Background} color="#1b232d" gap=${26} />
+      <${Controls} showInteractive=${false} />
+      ${moving ? html`<${MiniMap} pannable zoomable nodeColor=${() => '#2db8ff'} maskColor="rgba(6,7,10,.7)" />` : null}
+    <//>
   <//>`;
 }
 
-createRoot(document.getElementById('root')).render(html`<${Board} />`);
+createRoot(document.getElementById('root')).render(html`<${ReactFlowProvider}><${Board} /><//>`);


### PR DESCRIPTION
Closes #158. Keyboard-native navigation for the ideas board (M3).

**board → chart → visual** state machine:
- **board**: `h/j/k/l` move the selection between nodes (directional); `Enter` focuses the selected chart.
- **chart**: a candle cursor — `h/l` ±1, `H/L` ±5, `{count}l`/`{count}h` ±count (e.g. `10l`). A mode HUD (top-right) shows position.
- **visual**: `v` anchors; `h/l` extends a candle range (in-range candles lit, the rest dimmed to the analysed-window look); `Enter` analyses *exactly that window* via `/api/backtest/optimal-entry` and pins a way-to-trade card; `Esc` steps back out.

Verified end-to-end via simulated keystrokes (incl. the `10h` count motion → select → analyse → card), no JS errors.

**Follow-up (not in this PR):** focusing a chart `fitView`-zooms to it, pushing the pinned card off-screen — either don't auto-zoom or frame chart+card together.