### PR TITLE
Ideas info panel: pre-market data (#127)

### DIFF
--- a/internal/model/premarket.go
+++ b/internal/model/premarket.go
@@ -1,0 +1,76 @@
+package model
+
+import "time"
+
+// PreMarket is the pre-market session snapshot derived from intraday bars.
+// Found is false when no bar falls inside the pre-market window.
+type PreMarket struct {
+	Found         bool    `json:"found"`
+	Price         float64 `json:"price"`
+	ChangePercent float64 `json:"changePercent"`
+	Time          string  `json:"time"` // RFC3339, UTC
+}
+
+// Pre-market window for US equities, in minutes since ET midnight:
+// 04:00 (inclusive) through 09:30 (exclusive). 09:30 is the regular-session
+// opening auction and is deliberately excluded.
+const (
+	preMarketStartMin = 4 * 60    // 04:00 ET
+	preMarketEndMin   = 9*60 + 30 // 09:30 ET
+	preMarketLayout   = "2006-01-02 15:04:05"
+)
+
+// ExtractPreMarket scans intraday 5-minute bars and returns the last bar that
+// falls within the pre-market window [04:00, 09:30) ET, together with its
+// percentage change versus the previous regular-session close.
+//
+// Bars carry FMP-style "2006-01-02 15:04:05" timestamps expressed in ET
+// wall-clock with no offset. loc is the location those wall-clock strings are
+// interpreted in (America/New_York in production); it governs the ET→UTC
+// conversion of the returned Time. The window selection itself reads only the
+// hour/minute of each bar, so it is independent of loc.
+//
+// The function is pure: no network, no clock, no globals. When no bar lands in
+// the window (or all timestamps are unparseable) it returns PreMarket{Found:false}.
+func ExtractPreMarket(bars []OHLCV, prevClose float64, loc *time.Location) PreMarket {
+	if loc == nil {
+		loc = time.UTC
+	}
+
+	var best time.Time
+	var bestPrice float64
+	found := false
+
+	for _, b := range bars {
+		t, err := time.ParseInLocation(preMarketLayout, b.Date, loc)
+		if err != nil {
+			continue
+		}
+		tod := t.Hour()*60 + t.Minute()
+		if tod < preMarketStartMin || tod >= preMarketEndMin {
+			continue
+		}
+		// Keep the chronologically latest pre-market bar.
+		if !found || t.After(best) {
+			best = t
+			bestPrice = b.Close
+			found = true
+		}
+	}
+
+	if !found {
+		return PreMarket{Found: false}
+	}
+
+	pct := 0.0
+	if prevClose > 0 {
+		pct = (bestPrice - prevClose) / prevClose * 100
+	}
+
+	return PreMarket{
+		Found:         true,
+		Price:         bestPrice,
+		ChangePercent: pct,
+		Time:          best.UTC().Format(time.RFC3339),
+	}
+}

--- a/internal/model/premarket_test.go
+++ b/internal/model/premarket_test.go
@@ -1,0 +1,72 @@
+package model
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func bar(date string, close float64) OHLCV {
+	return OHLCV{Date: date, Open: close, High: close, Low: close, Close: close, Volume: 0}
+}
+
+func TestExtractPreMarket_PicksLastPreMarketBar(t *testing.T) {
+	// Bars span pre-market and regular hours of one ET trading day. The window
+	// is [04:00, 09:30). The latest in-window bar is 09:25 (103). The 09:30
+	// opening-auction bar and the 09:35 regular bar must be ignored, as must
+	// the 03:55 bar that falls before the window opens.
+	bars := []OHLCV{
+		bar("2024-03-01 03:55:00", 99),  // before window — excluded
+		bar("2024-03-01 04:00:00", 100), // window opens (inclusive)
+		bar("2024-03-01 09:00:00", 102),
+		bar("2024-03-01 09:25:00", 103), // last pre-market bar
+		bar("2024-03-01 09:30:00", 110), // opening auction — excluded
+		bar("2024-03-01 09:35:00", 105), // regular session — excluded
+	}
+
+	pm := ExtractPreMarket(bars, 100.0, time.UTC)
+
+	if !pm.Found {
+		t.Fatalf("expected Found=true, got false")
+	}
+	if pm.Price != 103 {
+		t.Errorf("expected last pre-market price 103, got %v", pm.Price)
+	}
+	// (103 - 100) / 100 * 100 = 3%
+	if math.Abs(pm.ChangePercent-3.0) > 1e-9 {
+		t.Errorf("expected change %% 3.0, got %v", pm.ChangePercent)
+	}
+}
+
+func TestExtractPreMarket_NoPreMarketBars(t *testing.T) {
+	// Only regular-session bars — nothing in the pre-market window.
+	bars := []OHLCV{
+		bar("2024-03-01 09:30:00", 110),
+		bar("2024-03-01 12:00:00", 112),
+		bar("2024-03-01 15:55:00", 111),
+	}
+
+	pm := ExtractPreMarket(bars, 100.0, time.UTC)
+
+	if pm.Found {
+		t.Errorf("expected Found=false for regular-session-only bars, got %+v", pm)
+	}
+}
+
+func TestExtractPreMarket_NegativeChangeAndZeroPrevClose(t *testing.T) {
+	bars := []OHLCV{bar("2024-03-01 08:00:00", 98)}
+
+	pm := ExtractPreMarket(bars, 100.0, time.UTC)
+	if !pm.Found || pm.Price != 98 {
+		t.Fatalf("expected found price 98, got %+v", pm)
+	}
+	if math.Abs(pm.ChangePercent-(-2.0)) > 1e-9 {
+		t.Errorf("expected -2.0%%, got %v", pm.ChangePercent)
+	}
+
+	// prevClose <= 0 must not divide by zero; percent should be 0.
+	pmZero := ExtractPreMarket(bars, 0, time.UTC)
+	if !pmZero.Found || pmZero.ChangePercent != 0 {
+		t.Errorf("expected found with 0%% change for zero prevClose, got %+v", pmZero)
+	}
+}

--- a/internal/news/news.go
+++ b/internal/news/news.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	_ "time/tzdata" // embed the IANA tz database so America/New_York always resolves
 )
 
 // SearchResult represents a security from the FMP search API.
@@ -526,6 +527,36 @@ func (c *Client) GetIntradayChart(ctx context.Context, symbol, interval, from, t
 	}
 
 	return items, nil
+}
+
+// etLocation resolves America/New_York. The embedded tzdata import guarantees
+// the zone is available even on minimal containers without a system tz database.
+func etLocation() *time.Location {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		return time.UTC
+	}
+	return loc
+}
+
+// GetPreMarket fetches today's 5-minute intraday bars and extracts the
+// pre-market session quote (last bar in 04:00–09:30 ET) along with its percent
+// change versus the previous regular-session close.
+//
+// FMP's /stable/quote does not carry pre-market data, so we derive it from
+// /stable/historical-chart/5min. The "today" date is computed in ET so the
+// from/to window aligns with the pre-market session and only one trading day's
+// bars are returned. prevClose is the previous regular-session close (from the
+// realtime quote). Returns PreMarket{Found:false} when no pre-market bars exist.
+func (c *Client) GetPreMarket(ctx context.Context, symbol string, prevClose float64) (model.PreMarket, error) {
+	loc := etLocation()
+	today := time.Now().In(loc).Format("2006-01-02")
+
+	bars, err := c.GetIntradayChart(ctx, symbol, "5min", today, today)
+	if err != nil {
+		return model.PreMarket{}, err
+	}
+	return model.ExtractPreMarket(bars, prevClose, loc), nil
 }
 
 // GetSICList fetches the full Standard Industrial Classification list.

--- a/internal/server/ideas_info_panels.go
+++ b/internal/server/ideas_info_panels.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"stocktopus/internal/model"
 	"stocktopus/internal/news"
 )
 
@@ -15,17 +16,20 @@ import (
 // live quote, news pulse, and which of the company's metrics are pinned on this
 // sketch (for the metric-chip strip).
 type CompanyInfoPanel struct {
-	Symbol            string   `json:"symbol"`
-	CompanyName       string   `json:"companyName"`
-	Price             float64  `json:"price"`
-	PreviousClose     float64  `json:"previousClose"`
-	ChangePercentage  float64  `json:"changePercentage"`
-	DayHigh           float64  `json:"dayHigh"`
-	DayLow            float64  `json:"dayLow"`
-	Volume            float64  `json:"volume"`
-	Open              float64  `json:"open"`
-	NewsCount24h      int      `json:"newsCount24h"`
-	PinnedMetrics     []string `json:"pinnedMetrics"`
+	Symbol           string   `json:"symbol"`
+	CompanyName      string   `json:"companyName"`
+	Price            float64  `json:"price"`
+	PreviousClose    float64  `json:"previousClose"`
+	ChangePercentage float64  `json:"changePercentage"`
+	DayHigh          float64  `json:"dayHigh"`
+	DayLow           float64  `json:"dayLow"`
+	Volume           float64  `json:"volume"`
+	Open             float64  `json:"open"`
+	HasPreMarket     bool     `json:"hasPreMarket"`
+	PreMarketPrice   float64  `json:"preMarketPrice"`
+	PreMarketChange  float64  `json:"preMarketChange"`
+	NewsCount24h     int      `json:"newsCount24h"`
+	PinnedMetrics    []string `json:"pinnedMetrics"`
 }
 
 // handleSketchInfoPanels: GET /api/sketches/{id}/info-panels
@@ -98,6 +102,7 @@ func (s *Server) handleSketchInfoPanels(w http.ResponseWriter, r *http.Request) 
 	type enrichment struct {
 		companyName  string
 		newsCount24h int
+		preMarket    model.PreMarket
 	}
 	enrichments := make(map[string]enrichment, len(symbols))
 	var mu sync.Mutex
@@ -117,6 +122,12 @@ func (s *Server) handleSketchInfoPanels(w http.ResponseWriter, r *http.Request) 
 			}
 			if q, ok := quotes[sym]; ok {
 				en.companyName = q.Name
+				// Derive pre-market price/% from intraday 5-min bars; FMP's
+				// /stable/quote carries no pre-market data. Best-effort: a
+				// failure (or no pre-market session) just leaves it absent.
+				if pm, perr := s.news.GetPreMarket(ctx, sym, q.PreviousClose); perr == nil {
+					en.preMarket = pm
+				}
 			}
 			mu.Lock()
 			enrichments[sym] = en
@@ -139,6 +150,9 @@ func (s *Server) handleSketchInfoPanels(w http.ResponseWriter, r *http.Request) 
 			DayLow:           q.DayLow,
 			Volume:           q.Volume,
 			Open:             q.Open,
+			HasPreMarket:     en.preMarket.Found,
+			PreMarketPrice:   en.preMarket.Price,
+			PreMarketChange:  en.preMarket.ChangePercent,
 			NewsCount24h:     en.newsCount24h,
 			PinnedMetrics:    g.metrics,
 		})

--- a/internal/server/static/ideas.js
+++ b/internal/server/static/ideas.js
@@ -311,6 +311,17 @@
         infoPanelsEl.innerHTML = lastInfoPanels.map(function (p) {
             var pctClass = p.changePercentage >= 0 ? 'price-up' : 'price-down';
             var pctStr = (p.changePercentage >= 0 ? '+' : '') + (p.changePercentage || 0).toFixed(2) + '%';
+            var preRow = '';
+            if (p.hasPreMarket) {
+                var preClass = p.preMarketChange >= 0 ? 'price-up' : 'price-down';
+                var preChg = (p.preMarketChange >= 0 ? '+' : '') + (p.preMarketChange || 0).toFixed(2) + '%';
+                preRow = '<div class="ideas-info-quote ideas-info-premkt">'
+                    + '<span class="ideas-info-price">' + fmtPrice(p.preMarketPrice) + '</span>'
+                    + '<span class="ideas-info-tag">:pre:</span>'
+                    + '<span class="ideas-info-pct ' + preClass + '">' + preChg + '</span>'
+                    + '<span class="ideas-info-tag">:premkt:</span>'
+                    + '</div>';
+            }
             var newsBadge = p.newsCount24h > 0
                 ? '<span class="ideas-info-news-badge" title="news items last 24h">' + p.newsCount24h + ' news</span>'
                 : '';
@@ -348,6 +359,7 @@
                 +      '<span class="ideas-info-pct ' + pctClass + '">' + pctStr + '</span>'
                 +      '<span class="ideas-info-tag">:1d:</span>'
                 +    '</div>'
+                +    preRow
                 +    '<div class="ideas-info-stats">'
                 +      '<span><label>Open</label>' + fmtPrice(p.open) + '</span>'
                 +      '<span><label>Day H</label>' + fmtPrice(p.dayHigh) + '</span>'

--- a/internal/server/static/style.css
+++ b/internal/server/static/style.css
@@ -4698,6 +4698,18 @@ details.screener-group > summary.vim-selected {
     margin-left: -4px;
 }
 
+/* Pre-market quote row: same layout as the live row but dimmed and smaller,
+   since it qualifies the regular session rather than replacing it. */
+.ideas-info-quote.ideas-info-premkt {
+    opacity: 0.8;
+    margin-top: 2px;
+}
+.ideas-info-quote.ideas-info-premkt .ideas-info-price {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-secondary, #aaa);
+}
+
 .ideas-info-stats {
     display: grid;
     grid-template-columns: repeat(4, 1fr);


### PR DESCRIPTION
Closes #127.

## What
The ideas company info panel showed only day change vs previous close. This adds **pre-market price + pre-market % change** for US equities.

FMP's `/stable/quote` does not return pre-market data, so we derive it from `/stable/historical-chart/5min/{symbol}` and capture the pre-market session window **04:00–09:30 ET**.

## Testable core (pure function)
`model.ExtractPreMarket(bars []OHLCV, prevClose float64, loc *time.Location) PreMarket` in `internal/model/premarket.go`:
- Scans intraday 5-min bars, returns the **last bar in `[04:00, 09:30)` ET** (09:30 opening auction excluded).
- Computes `% change` vs previous regular-session close (guards prevClose <= 0).
- Returns `Found:false` when no bar lands in the window.
- Pure: no network, no clock, no globals. Window selection reads wall-clock hour/minute; returned `Time` is normalised to UTC.

## Wiring
- `news.GetPreMarket` — computes "today" in ET, fetches 5-min bars via the existing `GetIntradayChart`, runs the pure extractor. Embeds `time/tzdata` so `America/New_York` always resolves.
- `CompanyInfoPanel` gains `hasPreMarket` / `preMarketPrice` / `preMarketChange`; fetched best-effort in the existing per-symbol fan-out (a failure or no session just leaves it absent).
- `ideas.js` renders a dimmed `:pre:` quote row when pre-market data is present; CSS added.

## Tests (real, hermetic — pass with `make test`)
`internal/model/premarket_test.go`:
- `TestExtractPreMarket_PicksLastPreMarketBar` — bars spanning 03:55→09:35; asserts it picks the 09:25 bar (last in window), value 103, change +3.00%, and that the 09:30 auction bar and 09:35 regular bar are excluded.
- `TestExtractPreMarket_NoPreMarketBars` — regular-session-only bars → `Found:false`.
- `TestExtractPreMarket_NegativeChangeAndZeroPrevClose` — negative % case, and prevClose=0 yields 0% without dividing by zero.

Tests use `time.UTC` (no `LoadLocation`) so they're hermetic regardless of system tzdata.

## Verification
`make test` and `go build ./...` both green. `make smoke` not run (needs `STOCK_API_KEY` / live FMP); the live 5-min integration is wired to compile and follow the existing FMP-call pattern.