### PR TITLE
Migrate /news page to declarative vim-nav (#119)

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"stocktopus/internal/hub"
@@ -75,5 +76,46 @@ func TestWatchlistPage(t *testing.T) {
 	body := w.Body.String()
 	if len(body) == 0 {
 		t.Error("expected non-empty response body")
+	}
+}
+
+// TestNewsPageDeclarativeNav verifies the /news page has been migrated from the
+// bespoke vimHandlers.news path to the declarative vim-nav engine (issue #119).
+//
+// The category tab strip is server-rendered in news.html, so its declarative
+// contract (data-vim-row on the strip, data-vim-item on each tab) is asserted
+// against the page HTML. The news cards are rendered client-side by
+// renderNewsCard in terminal.js, so the card contract
+// (data-vim-action="open-reader") is asserted against the served static JS.
+func TestNewsPageDeclarativeNav(t *testing.T) {
+	_, mux := testServer(t)
+
+	// Category tab strip — declarative region + per-tab items in the template.
+	req := httptest.NewRequest("GET", "/news", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /news: expected 200, got %d", w.Code)
+	}
+	page := w.Body.String()
+	if !strings.Contains(page, `data-vim-row`) {
+		t.Error("/news category strip missing data-vim-row (declarative region)")
+	}
+	if !strings.Contains(page, `data-vim-item`) {
+		t.Error("/news category tabs missing data-vim-item")
+	}
+
+	// News cards are client-rendered, so assert the card contract against the
+	// served terminal.js (renderNewsCard must emit the canonical open-reader
+	// pattern used by the sibling pages, not the legacy data-vim-action="click").
+	req = httptest.NewRequest("GET", "/static/terminal.js", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /static/terminal.js: expected 200, got %d", w.Code)
+	}
+	js := w.Body.String()
+	if !strings.Contains(js, `data-vim-action="open-reader"`) {
+		t.Error(`renderNewsCard missing data-vim-action="open-reader" (cards not migrated to declarative vim-nav)`)
 	}
 }

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -1155,8 +1155,8 @@ window.onerror = function (msg, src, line, col, err) {
         });
 
         // Card open: delegated so it survives re-renders. VimNav fires the
-        // selected card's data-vim-action="click" → card.click() bubbles here,
-        // marking it read and opening the reader. Mouse clicks land here too.
+        // selected card's data-vim-action="open-reader" → _openReader (which
+        // marks it read). Mouse clicks land here, marking read + opening too.
         var container = document.getElementById('news-cards');
         if (container && !container.dataset.cardClickWired) {
             container.dataset.cardClickWired = '1';
@@ -1380,7 +1380,7 @@ window.onerror = function (msg, src, line, col, err) {
         var symbolBadge = item.symbol ? '<span class="news-symbol">' + escapeHtml(item.symbol) + '</span>' : '';
         var unreadClass = unread ? ' news-unread' : '';
 
-        return '<div class="news-card' + unreadClass + '" data-url="' + escapeHtml(item.url) + '" data-vim-region data-vim-action="click">'
+        return '<div class="news-card' + unreadClass + '" data-url="' + escapeHtml(item.url) + '" data-vim-row data-vim-action="open-reader" data-vim-url="' + escapeHtml(item.url) + '" data-vim-title="' + escapeHtml(item.title) + '">'
             + '<div class="news-card-title"><a href="' + escapeHtml(item.url) + '" onclick="event.preventDefault();if(window._openReader)window._openReader(this.href,this.textContent)">' + escapeHtml(item.title) + '</a></div>'
             + '<div class="news-card-meta">'
             +   symbolBadge
@@ -3407,7 +3407,7 @@ window.onerror = function (msg, src, line, col, err) {
                     return;
                 }
                 // /news: open the article reader on the highlighted card —
-                // same effect as Enter (the card's data-vim-action="click"),
+                // same effect as Enter (the card's data-vim-action="open-reader"),
                 // mapped to 'p' for the 'p = preview' muscle-memory convention.
                 if (currentView === 'news') {
                     var nsel = window.VimNav && window.VimNav.getSelected();


### PR DESCRIPTION
Closes #119.

## What
Migrates the top-level **/news** page news cards onto the canonical declarative vim-nav contract that the sibling pages already use (info.js, fund.js, etf.js, crypto.js, forex.js, index_page.js).

`renderNewsCard` in `terminal.js` now emits:
```
<div class="news-card" data-url="…" data-vim-row data-vim-action="open-reader" data-vim-url="…" data-vim-title="…">
```
replacing the legacy `data-vim-region` + `data-vim-action="click"` markup.

The category tab strip already carries `data-vim-row` + per-tab `data-vim-item` and the bespoke `vimHandlers.news` path was already retired (landed in #152/#153). With the card change, **/news now runs entirely through the common VimNav engine**: h/l switch categories, j/k walk cards, Enter opens the reader, gg/G jump. The container click handler, title `<a>` onclick and `data-url` read-state are kept (identical to info.js).

## Test
Adds `TestNewsPageDeclarativeNav` in `internal/server/server_test.go` (httptest, mirrors the existing `New(...)` arity):
- `GET /news` → asserts the category strip carries `data-vim-row` and tabs carry `data-vim-item` (server-rendered in news.html).
- `GET /static/terminal.js` → asserts `renderNewsCard` emits `data-vim-action="open-reader"`. Cards are **client-rendered**, so the card contract is asserted against the served JS rather than the page HTML. Verified RED on master (terminal.js had zero `open-reader` occurrences) and GREEN after the change.

## Gates
`make test`, `go build ./...`, and `node --check internal/server/static/terminal.js` all pass.