### PR TITLE
Migrate /watchlist page to declarative vim-nav (#118)

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"stocktopus/internal/hub"
@@ -75,5 +76,46 @@ func TestWatchlistPage(t *testing.T) {
 	body := w.Body.String()
 	if len(body) == 0 {
 		t.Error("expected non-empty response body")
+	}
+}
+
+// TestWatchlistDeclarativeVimNav gates the migration of the /watchlist page
+// onto the shared declarative vim-nav engine (issue #118). The watchlists
+// tab strip must carry data-vim-row + data-vim-role="tabs" so directional
+// keys flow through VimNav, and the JS that builds the tabs/rows must emit
+// the per-item / per-row markup the engine reads.
+func TestWatchlistDeclarativeVimNav(t *testing.T) {
+	_, mux := testServer(t)
+
+	// 1) The watchlists strip is static template markup — assert it directly.
+	req := httptest.NewRequest("GET", "/watchlist", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /watchlist: expected 200, got %d", w.Code)
+	}
+	page := w.Body.String()
+	if !strings.Contains(page, `id="watchlist-tabs" data-vim-row`) {
+		t.Error("watchlists strip is missing data-vim-row — h/l won't flow through VimNav")
+	}
+	if !strings.Contains(page, `data-vim-role="tabs"`) {
+		t.Error("watchlists strip is missing data-vim-role=\"tabs\"")
+	}
+
+	// 2) Tabs and symbol rows are rendered client-side; gate the JS that
+	//    builds them. The substrings are unique to the watchlist builders
+	//    (a bare data-vim-item already exists for company-panel sparks).
+	req2 := httptest.NewRequest("GET", "/static/terminal.js", nil)
+	w2 := httptest.NewRecorder()
+	mux.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("GET /static/terminal.js: expected 200, got %d", w2.Code)
+	}
+	js := w2.Body.String()
+	if !strings.Contains(js, `data-vim-item style="--wl-color:`) {
+		t.Error("watchlist tab builder no longer emits data-vim-item")
+	}
+	if !strings.Contains(js, `data-vim-row data-vim-action="navigate" data-vim-href="/security/`) {
+		t.Error("watchlist symbol-row builder no longer emits data-vim-row navigation markup")
 	}
 }

--- a/internal/server/static/terminal.js
+++ b/internal/server/static/terminal.js
@@ -418,7 +418,7 @@ window.onerror = function (msg, src, line, col, err) {
         // for (e.g. an FMP plan that doesn't cover this exchange). Keeps the
         // row visible so the user can still `d` it from the watchlist.
         var safe = escapeHtml(symbol);
-        var html = '<tr id="quote-' + safe + '" class="quote-row-ghost">'
+        var html = '<tr id="quote-' + safe + '" class="quote-row-ghost" data-vim-row data-vim-action="navigate" data-vim-href="/security/' + encodeURIComponent(symbol) + '">'
             + '<td><span class="sym-link" data-symbol="' + safe + '">' + safe + '</span></td>'
             + '<td id="quote-' + safe + '-price" class="quote-na">—</td>'
             + '<td id="quote-' + safe + '-change" class="quote-na">—</td>'
@@ -478,7 +478,7 @@ window.onerror = function (msg, src, line, col, err) {
                     // precisely without touching the 1W / 6M / sparkline
                     // cells. Those static cells get populated by
                     // hydrateWatchlistHistorical() once the row is in the DOM.
-                    var html = '<tr id="quote-' + sym + '">'
+                    var html = '<tr id="quote-' + sym + '" data-vim-row data-vim-action="navigate" data-vim-href="/security/' + encodeURIComponent(sym) + '">'
                         + '<td><span class="sym-link" data-symbol="' + sym + '">' + sym + '</span></td>'
                         + '<td id="quote-' + sym + '-price" class="' + chgClass + '">' + (q.price ? q.price.toFixed(2) : '') + '</td>'
                         + '<td id="quote-' + sym + '-change" class="' + chgClass + '">' + chg + '</td>'
@@ -773,7 +773,7 @@ window.onerror = function (msg, src, line, col, err) {
         listEl.innerHTML = watchlistData.map(function (wl) {
             var active = wl.id === activeWatchlistId ? ' wl-tab-active active' : '';
             var count = wl.symbols ? wl.symbols.length : 0;
-            return '<li class="watchlist-list-item wl-tab' + active + '" data-id="' + wl.id + '" style="--wl-color:' + wl.color + '">'
+            return '<li class="watchlist-list-item wl-tab' + active + '" data-id="' + wl.id + '" data-vim-item style="--wl-color:' + wl.color + '">'
                 + '<span class="watchlist-list-name">' + escapeHtml(wl.name) + '</span>'
                 + '<span class="watchlist-list-meta">' + count + ' securities</span>'
                 + '</li>';
@@ -2627,14 +2627,11 @@ window.onerror = function (msg, src, line, col, err) {
                 }
             },
             graph: function () {
-                var items = this.getItems();
-                if (vimSelectedIndex < 0 || vimSelectedIndex >= items.length) return;
-                var sym = items[vimSelectedIndex].querySelector('[data-symbol]');
-                if (sym) {
-                    setSecurity(sym.dataset.symbol);
-                    onViewLeave(currentView);
-                    navigate('graph', sym.dataset.symbol);
-                }
+                var sym = this._selectedSymbol();
+                if (!sym) return;
+                setSecurity(sym);
+                onViewLeave(currentView);
+                navigate('graph', sym);
             },
             // ── Vim row ops (idea #12) ──
             //
@@ -2644,10 +2641,12 @@ window.onerror = function (msg, src, line, col, err) {
             //   y → yank to another list via picker (does not delete source);
             //       on confirm the dest list re-renders so the new color sticks
             _selectedSymbol: function () {
-                var items = this.getItems();
-                if (vimSelectedIndex < 0 || vimSelectedIndex >= items.length) return null;
-                var el = items[vimSelectedIndex].querySelector('[data-symbol]');
-                return el ? el.dataset.symbol : null;
+                // Selection is owned by the declarative VimNav engine now; the
+                // selected element is the symbol <tr> (its own data-vim-row).
+                var sel = window.VimNav && window.VimNav.getSelected();
+                if (!sel || !sel.el) return null;
+                var link = sel.el.querySelector ? sel.el.querySelector('[data-symbol]') : null;
+                return link ? link.dataset.symbol : null;
             },
             deleteSelected: function () {
                 var sym = this._selectedSymbol();
@@ -3202,11 +3201,12 @@ window.onerror = function (msg, src, line, col, err) {
             var readerOpen = false;
             var readerEl = document.getElementById('article-reader');
             if (readerEl && !readerEl.classList.contains('hidden')) readerOpen = true;
-            // Ideas and watchlist use custom two-column pane models.
-            // ideas / watchlist still use bespoke two-pane handlers (migrating
-            // post-2.0). Everything else — including news, now declarative —
-            // goes through the common VimNav engine.
-            if (!readerOpen && currentView !== 'ideas' && currentView !== 'watchlist' && window.VimNav.handleKey(e.key, e)) return;
+            // Ideas still uses a custom two-column pane model. Everything
+            // else — including news and watchlist, now declarative — goes
+            // through the common VimNav engine. The watchlist's per-view
+            // handler keeps only the legacy row-ops (d/y/p cut/yank/paste,
+            // c=chart, p=preview), which fall through below.
+            if (!readerOpen && currentView !== 'ideas' && window.VimNav.handleKey(e.key, e)) return;
         }
 
         switch (e.key) {

--- a/internal/server/templates/watchlist.html
+++ b/internal/server/templates/watchlist.html
@@ -5,7 +5,7 @@
         <div class="watchlist-sidebar-header st-pane-header">
             <span>Watchlists</span>
         </div>
-        <ul class="watchlist-list st-nav-list" id="watchlist-tabs"></ul>
+        <ul class="watchlist-list st-nav-list" id="watchlist-tabs" data-vim-row data-vim-role="tabs"></ul>
     </aside>
     <section class="watchlist-main st-pane st-pane--content pane-focused" id="watchlist-main">
         <div class="watchlist-main-header">


### PR DESCRIPTION
Closes #118 (parent #104).

## What
Migrates the `/watchlist` page off the bespoke `vimHandlers.watchlist`
directional code and onto the shared declarative vim-nav engine
(`vim-nav.js`), the same engine the security/news/etf/etc pages use.

## How
- **Watchlists strip** (`#watchlist-tabs`): static template now carries
  `data-vim-row data-vim-role="tabs"`; `renderWatchlistTabs()` tags each
  tab `<li>` with `data-vim-item`. h/l move between watchlists, Enter
  activates the highlighted one (`selectWatchlist` via the existing tab
  onclick — highlight-then-Enter, consistent with the info tab strip).
- **Symbol rows**: each `<tr>` (both the live row and the ghost row for
  unreachable symbols) gets `data-vim-row data-vim-action="navigate"
  data-vim-href="/security/SYM"`, mirroring the `info.js`/`etf.js`
  peer-row pattern. Only the real rows carry the attribute, so j/k never
  walks the nested lightweight-charts sparkline `<tr>`s (the phantom-row
  concern from the old `getItems()` direct-children filter is handled
  structurally — phantoms have no `data-vim-row`).
- **Dispatcher gate**: the keydown dispatcher no longer excludes
  `watchlist`, so directional h/j/k/l + Enter (plus w/b/1-9/gg/G) flow
  through `VimNav`.

## d/y/p preserved
`VimNav.handleKey` only claims directional/Enter/word/numeric keys; every
other key falls through to the per-view handler. `deleteSelected` (d=cut),
`yankSelected` (y=copy via picker), `pasteSelected` (P=paste), `c`=chart
and `p`=preview are untouched — they just read the selected symbol from
`VimNav.getSelected()` now instead of the retired `vimSelectedIndex`.
Live per-cell quote updates (`handleQuoteHTML`) swap cells, not rows, so
the `<tr>` identity persists and VimNav keeps the selection across ticks.

## Behavior notes (intended, non-blocking)
- Enter on a row now full-loads `/security/SYM` (server 301s
  crypto/forex/index to the right view) instead of the old SPA
  `navigate('info')` — the consequence of moving Enter onto the
  declarative engine, and consistent with every sibling listing page.
- After a `d`/`p`, the full-row re-render in `fetchWatchlistQuotes` drops
  the VimNav highlight (the old integer index survived it). The row-op
  itself still works; only the highlight resets.

## Test
`TestWatchlistDeclarativeVimNav` in `internal/server/server_test.go`:
GETs `/watchlist` and asserts the strip carries `data-vim-row` +
`data-vim-role="tabs"`, then GETs `/static/terminal.js` and asserts the
tab builder emits `data-vim-item` and the row builder emits the
`data-vim-row ... data-vim-href="/security/` markup (substrings unique to
the watchlist builders). Verified red on master (all four asserts fail)
and green after the change. `make test` and `go build ./...` pass;
`node --check` on terminal.js passes.